### PR TITLE
feat(m2): D1 migration, seed + setup scripts, template docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
+package-lock.json
+yarn.lock
 .svelte-kit
 src/lib/paraglide
 build

--- a/README.md
+++ b/README.md
@@ -62,42 +62,58 @@ Khao Pad fills the gap: **start lightweight, scale when needed, stay on Cloudfla
 - [Cloudflare R2](https://developers.cloudflare.com/r2/) — Object storage
 - [Cloudflare KV](https://developers.cloudflare.com/kv/) — Key-value cache
 
-## Getting Started
+## Using Khao Pad in your project
+
+Khao Pad is a **template**, not a hosted service. Fork or clone this repo, provision your own Cloudflare resources, and deploy to your own account. Every project gets its own isolated D1 database, R2 bucket, and KV namespace — nothing is shared between installations.
 
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) 22+ (for local tooling parity with CI)
 - [pnpm](https://pnpm.io/) 9+
 - Cloudflare account
-- Wrangler CLI (`pnpm add -g wrangler`)
+- Wrangler CLI (`pnpm add -g wrangler`) and `wrangler login`
 
 ### Setup
 
 ```bash
-# Clone
-git clone https://github.com/codustry/khaopad.git
-cd khaopad
+# 1. Fork on GitHub (or clone directly)
+git clone https://github.com/your-org/your-project.git
+cd your-project
 
-# Install dependencies
+# 2. Install dependencies
 pnpm install
 
-# Copy environment variables
-cp .env.example .env
-# Edit .env with your secrets
+# 3. Provision Cloudflare resources (D1 + R2 + KV) in one command
+pnpm setup
+# Prints the database_id and KV id you need. Paste them into wrangler.toml
+# (replace LOCAL_DB_ID and LOCAL_KV_ID).
 
-# Create Cloudflare resources
-wrangler d1 create khaopad-db
-wrangler r2 bucket create khaopad-media
-wrangler kv namespace create CONTENT_CACHE
+# 4. Set your Better Auth secret (any long random string)
+wrangler secret put BETTER_AUTH_SECRET
 
-# Update wrangler.toml with the IDs from above
+# 5. Apply migrations and seed sample data into local D1
+pnpm db:migrate
+pnpm db:seed
 
-# Run database migrations
-pnpm run db:migrate
-
-# Start dev server
+# 6. Start the dev server (Wrangler, uses local D1/R2/KV simulators)
+pnpm wrangler:dev
+# or plain Vite without bindings (shows a friendly 503 "Configuration required")
 pnpm dev
 ```
+
+### How D1, R2, and KV connect to Khao Pad
+
+Cloudflare bindings are **not auto-generated** — they must be provisioned once per project, then bound to your Worker by ID in `wrangler.toml`:
+
+| Binding         | Resource     | Created by                         | Referenced in `wrangler.toml` |
+| --------------- | ------------ | ---------------------------------- | ----------------------------- |
+| `DB`            | D1 database  | `wrangler d1 create <name>`        | `database_id`                 |
+| `MEDIA_BUCKET`  | R2 bucket    | `wrangler r2 bucket create <name>` | `bucket_name`                 |
+| `CONTENT_CACHE` | KV namespace | `wrangler kv namespace create`     | `id`                          |
+
+`pnpm setup` runs all three for you and prints the IDs to paste in. Your code never hardcodes account IDs or credentials — Cloudflare injects the bindings into `platform.env` at runtime.
+
+For **local dev** with `pnpm wrangler:dev`, Wrangler spins up local simulators for D1/R2/KV automatically — the production IDs only matter when you deploy with `pnpm deploy`.
 
 ### Local Development
 

--- a/README.md
+++ b/README.md
@@ -166,16 +166,113 @@ Both modes share the same `ContentProvider` interface — your CMS code doesn't 
 
 ## Deployment
 
-Deploys automatically to Cloudflare Workers on push to `main` via GitHub Actions.
+Deploys automatically to Cloudflare Workers on push to `main` via GitHub Actions (`.github/workflows/deploy.yml`). The workflow runs `pnpm install --frozen-lockfile`, `pnpm build`, applies pending D1 migrations to the remote database, then deploys the Worker.
 
-Required GitHub Secrets (sourced from the **codustry organization** secrets — already configured, inherited automatically by all repos):
+### Config reference
 
-- `CLOUDFLARE_API_TOKEN`
-- `CLOUDFLARE_ACCOUNT_ID`
+Khao Pad reads everything through Cloudflare's binding/env model. There are four layers — know which goes where:
 
-Required Cloudflare Secrets (set via `wrangler secret put`):
+| Layer                  | Where it lives                           | Scope        | Example                       |
+| ---------------------- | ---------------------------------------- | ------------ | ----------------------------- |
+| Bindings               | `wrangler.toml` `[[d1_databases]]` etc.  | Per project  | `DB`, `MEDIA_BUCKET`          |
+| Plain vars             | `wrangler.toml` `[vars]`                 | Per project  | `CONTENT_MODE`, locales, URLs |
+| Cloudflare secrets     | `wrangler secret put`                    | Per project  | `BETTER_AUTH_SECRET`          |
+| GitHub Actions secrets | GitHub repo/org → Settings → Secrets     | CI only      | `CLOUDFLARE_API_TOKEN`        |
 
-- `BETTER_AUTH_SECRET`
+Secrets are **never** committed to `wrangler.toml`. Plain vars can be, and are safe to read in both server and client code (treat them like public config).
+
+### 1. GitHub Actions secrets (for CI deploy)
+
+Configured at the GitHub **org or repo** level. At Codustry they're already set on the organization and inherited by every repo:
+
+| Secret                   | Purpose                                                    |
+| ------------------------ | ---------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`   | Lets the CI runner call the Cloudflare API (deploy, D1).   |
+| `CLOUDFLARE_ACCOUNT_ID`  | Tells `wrangler` which account to deploy into.             |
+
+Token permissions required: **Workers Scripts — Edit**, **Account D1 — Edit**, **Account Workers KV Storage — Edit**, **Workers R2 Storage — Edit**, **Zone DNS — Read** (for routes). Create at `dash.cloudflare.com/profile/api-tokens` → "Edit Cloudflare Workers" template, then narrow to your account.
+
+### 2. Cloudflare secrets (Worker runtime, encrypted)
+
+Set once per environment via `wrangler secret put <NAME>`:
+
+| Secret                | Purpose                                                             | How to generate                        |
+| --------------------- | ------------------------------------------------------------------- | -------------------------------------- |
+| `BETTER_AUTH_SECRET`  | Signs/encrypts Better Auth session cookies. Must be long + random.  | `openssl rand -base64 32`              |
+| `GITHUB_TOKEN` *(optional, Mode B)* | PAT used by the GitHub content provider to read/write markdown files in the content repo. | Fine-grained PAT with Contents: Read & Write on the content repo. |
+
+> **Never** put these in `[vars]` — they leak to the dashboard and CI logs.
+
+### 3. Cloudflare bindings (wrangler.toml)
+
+Provisioned once per project via `pnpm setup`, then referenced by ID:
+
+```toml
+[[d1_databases]]
+binding = "DB"                 # exposed as platform.env.DB
+database_name = "khaopad-db"
+database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # from `wrangler d1 create`
+migrations_dir = "drizzle"
+
+[[r2_buckets]]
+binding = "MEDIA_BUCKET"       # exposed as platform.env.MEDIA_BUCKET
+bucket_name = "khaopad-media"
+
+[[kv_namespaces]]
+binding = "CONTENT_CACHE"      # exposed as platform.env.CONTENT_CACHE
+id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"               # from `wrangler kv namespace create`
+```
+
+### 4. Plain environment variables (wrangler.toml `[vars]`)
+
+Non-secret config that ships with the Worker:
+
+| Var                 | Required | Default                     | Purpose                                                   |
+| ------------------- | :------: | --------------------------- | --------------------------------------------------------- |
+| `CONTENT_MODE`      | yes      | `d1`                        | `d1` (active) or `github` (planned).                      |
+| `SUPPORTED_LOCALES` | yes      | `en,th`                     | Comma-separated. Must match `project.inlang/settings.json`. |
+| `DEFAULT_LOCALE`    | yes      | `en`                        | Fallback locale. Must be in `SUPPORTED_LOCALES`.          |
+| `PUBLIC_SITE_URL`   | yes      | `https://www.example.com`   | Canonical origin for `www` subdomain.                     |
+| `CMS_SITE_URL`      | yes      | `https://cms.example.com`   | Canonical origin for `cms` subdomain.                     |
+| `BETTER_AUTH_URL`   | yes      | = `CMS_SITE_URL`            | Base URL Better Auth uses in callbacks/cookies.           |
+| `GITHUB_OWNER`      | Mode B   | —                           | Org/user owning the content repo.                         |
+| `GITHUB_REPO`       | Mode B   | —                           | Repo name holding markdown content.                       |
+| `GITHUB_BRANCH`     | Mode B   | `main`                      | Branch the provider reads/writes.                         |
+
+### 5. Routes & DNS (production only)
+
+Uncomment the `routes` block in `wrangler.toml` after your domain is on Cloudflare:
+
+```toml
+routes = [
+  { pattern = "www.example.com/*", zone_name = "example.com" },
+  { pattern = "cms.example.com/*", zone_name = "example.com" },
+]
+```
+
+Both subdomains must exist as proxied (orange-cloud) DNS records — `CNAME` to your Worker is fine since Cloudflare terminates TLS and routes by the pattern above. The `subdomainHook` in `hooks.server.ts` reads the `Host` header to dispatch between the `(www)` and `(cms)` route groups.
+
+### 6. Local dev
+
+- `pnpm wrangler:dev` (recommended) — Wrangler spins up local simulators for D1/R2/KV. Reads `wrangler.toml` `[vars]`; secrets come from `.dev.vars` (gitignored). The production `database_id`/KV `id` are ignored locally — a local SQLite file is used instead.
+- `pnpm dev` — plain Vite, no Cloudflare runtime. Renders the 503 "Configuration required" screen so missing bindings are obvious.
+
+Create `.dev.vars` (gitignored) for local-only secrets:
+
+```
+BETTER_AUTH_SECRET=dev-local-only-not-a-real-secret
+```
+
+### Deployment checklist
+
+- [ ] `pnpm setup` ran and `wrangler.toml` has real `database_id` + KV `id`
+- [ ] `BETTER_AUTH_SECRET` set in Cloudflare (`wrangler secret put BETTER_AUTH_SECRET`)
+- [ ] `PUBLIC_SITE_URL`, `CMS_SITE_URL`, `BETTER_AUTH_URL` updated to real domains in `[vars]`
+- [ ] `routes` block uncommented with real domain + zone
+- [ ] Both subdomains point to the Worker in Cloudflare DNS
+- [ ] GitHub org/repo has `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
+- [ ] `pnpm build` passes locally
+- [ ] Migrations applied remote (`pnpm db:migrate:remote`) or CI will do it on first push
 
 ## Scripts
 

--- a/drizzle/0000_nice_thor.sql
+++ b/drizzle/0000_nice_thor.sql
@@ -1,0 +1,149 @@
+CREATE TABLE `accounts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`account_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`access_token` text,
+	`refresh_token` text,
+	`access_token_expires_at` text,
+	`refresh_token_expires_at` text,
+	`scope` text,
+	`id_token` text,
+	`password` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `article_localizations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`article_id` text NOT NULL,
+	`locale` text NOT NULL,
+	`title` text NOT NULL,
+	`excerpt` text,
+	`body` text NOT NULL,
+	`seo_title` text,
+	`seo_description` text,
+	FOREIGN KEY (`article_id`) REFERENCES `articles`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `article_tags` (
+	`article_id` text NOT NULL,
+	`tag_id` text NOT NULL,
+	PRIMARY KEY(`article_id`, `tag_id`),
+	FOREIGN KEY (`article_id`) REFERENCES `articles`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`tag_id`) REFERENCES `tags`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `articles` (
+	`id` text PRIMARY KEY NOT NULL,
+	`slug` text NOT NULL,
+	`cover_media_id` text,
+	`category_id` text,
+	`author_id` text NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`published_at` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`cover_media_id`) REFERENCES `media`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`category_id`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`author_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `articles_slug_unique` ON `articles` (`slug`);--> statement-breakpoint
+CREATE TABLE `audit_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text,
+	`action` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`entity_id` text NOT NULL,
+	`metadata` text,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `categories` (
+	`id` text PRIMARY KEY NOT NULL,
+	`slug` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `categories_slug_unique` ON `categories` (`slug`);--> statement-breakpoint
+CREATE TABLE `category_localizations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`category_id` text NOT NULL,
+	`locale` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	FOREIGN KEY (`category_id`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `media` (
+	`id` text PRIMARY KEY NOT NULL,
+	`filename` text NOT NULL,
+	`r2_key` text NOT NULL,
+	`mime_type` text NOT NULL,
+	`size` integer NOT NULL,
+	`width` integer,
+	`height` integer,
+	`alt_text` text,
+	`uploaded_by` text,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`uploaded_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `media_r2_key_unique` ON `media` (`r2_key`);--> statement-breakpoint
+CREATE TABLE `sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`token` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`ip_address` text,
+	`user_agent` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `sessions_token_unique` ON `sessions` (`token`);--> statement-breakpoint
+CREATE TABLE `site_settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `tag_localizations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tag_id` text NOT NULL,
+	`locale` text NOT NULL,
+	`name` text NOT NULL,
+	FOREIGN KEY (`tag_id`) REFERENCES `tags`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `tags` (
+	`id` text PRIMARY KEY NOT NULL,
+	`slug` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `tags_slug_unique` ON `tags` (`slug`);--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`email_verified` integer DEFAULT false NOT NULL,
+	`image` text,
+	`role` text DEFAULT 'author' NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);--> statement-breakpoint
+CREATE TABLE `verifications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1005 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8a83d89a-0e94-410f-b16f-00c61040a2b5",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "article_localizations": {
+      "name": "article_localizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_localizations_article_id_articles_id_fk": {
+          "name": "article_localizations_article_id_articles_id_fk",
+          "tableFrom": "article_localizations",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "article_tags": {
+      "name": "article_tags",
+      "columns": {
+        "article_id": {
+          "name": "article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_tags_article_id_articles_id_fk": {
+          "name": "article_tags_article_id_articles_id_fk",
+          "tableFrom": "article_tags",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "article_tags_tag_id_tags_id_fk": {
+          "name": "article_tags_tag_id_tags_id_fk",
+          "tableFrom": "article_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "article_tags_article_id_tag_id_pk": {
+          "columns": [
+            "article_id",
+            "tag_id"
+          ],
+          "name": "article_tags_article_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_slug_unique": {
+          "name": "articles_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "articles_cover_media_id_media_id_fk": {
+          "name": "articles_cover_media_id_media_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "articles_category_id_categories_id_fk": {
+          "name": "articles_category_id_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category_localizations": {
+      "name": "category_localizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_localizations_category_id_categories_id_fk": {
+          "name": "category_localizations_category_id_categories_id_fk",
+          "tableFrom": "category_localizations",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_r2_key_unique": {
+          "name": "media_r2_key_unique",
+          "columns": [
+            "r2_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_uploaded_by_users_id_fk": {
+          "name": "media_uploaded_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_localizations": {
+      "name": "tag_localizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tag_localizations_tag_id_tags_id_fk": {
+          "name": "tag_localizations_tag_id_tags_id_fk",
+          "tableFrom": "tag_localizations",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1776422775409,
+      "tag": "0000_nice_thor",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:migrate": "wrangler d1 migrations apply khaopad-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply khaopad-db --remote",
     "db:seed": "tsx scripts/seed.ts",
+    "setup": "tsx scripts/setup.ts",
     "wrangler:dev": "wrangler dev",
     "deploy": "pnpm build && wrangler deploy"
   },

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,64 @@
+/**
+ * Seed script — inserts a sample admin user and one published article into local
+ * D1 via `wrangler d1 execute`.
+ *
+ * Usage:
+ *   pnpm db:seed               # seed local D1 (default)
+ *   pnpm db:seed -- --remote   # seed production D1
+ *
+ * This is a *minimal* seed for development and demos — it does NOT set up a
+ * Better Auth password (the `accounts` row for a password credential is
+ * skipped). Use the CMS sign-up flow, or add a password via `better-auth` APIs
+ * once auth is wired up end-to-end.
+ */
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const remote = process.argv.includes("--remote");
+const target = remote ? "--remote" : "--local";
+const dbName = process.env.D1_DB_NAME ?? "khaopad-db";
+
+const now = new Date().toISOString();
+
+// Deterministic IDs so re-seeding is idempotent-ish (INSERT OR IGNORE).
+const userId = "seed_user_admin";
+const articleId = "seed_article_hello";
+
+const sql = `
+-- Khao Pad seed data (safe to re-run: uses INSERT OR IGNORE).
+
+INSERT OR IGNORE INTO users (id, name, email, email_verified, role, created_at, updated_at)
+VALUES ('${userId}', 'Seed Admin', 'admin@khaopad.local', 1, 'super_admin', '${now}', '${now}');
+
+INSERT OR IGNORE INTO articles (id, slug, author_id, status, published_at, created_at, updated_at)
+VALUES ('${articleId}', 'hello-khao-pad', '${userId}', 'published', '${now}', '${now}', '${now}');
+
+INSERT OR IGNORE INTO article_localizations (id, article_id, locale, title, excerpt, body)
+VALUES
+  ('${articleId}_en', '${articleId}', 'en', 'Hello from Khao Pad',
+   'Your first article, served from Cloudflare D1.',
+   '# Hello from Khao Pad\\n\\nWelcome to your new CMS. Edit me in the admin panel.'),
+  ('${articleId}_th', '${articleId}', 'th', 'สวัสดีจาก Khao Pad',
+   'บทความแรกของคุณ จาก Cloudflare D1',
+   '# สวัสดีจาก Khao Pad\\n\\nยินดีต้อนรับสู่ CMS ใหม่ของคุณ แก้ไขได้ในหน้าแอดมิน');
+`.trim();
+
+const outDir = join(process.cwd(), "drizzle");
+mkdirSync(outDir, { recursive: true });
+const outFile = join(outDir, "seed.sql");
+writeFileSync(outFile, sql + "\n");
+
+console.log(`[seed] wrote ${outFile}`);
+console.log(`[seed] applying to ${remote ? "REMOTE" : "LOCAL"} D1 (${dbName})…`);
+
+try {
+  execSync(
+    `npx wrangler d1 execute ${dbName} ${target} --file=${outFile}`,
+    { stdio: "inherit" },
+  );
+  console.log("[seed] done.");
+} catch (err) {
+  console.error("[seed] failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,0 +1,84 @@
+/**
+ * One-shot Cloudflare provisioning helper.
+ *
+ * Khao Pad is a *template*: each fork gets its own D1 database, R2 bucket, and
+ * KV namespace. Cloudflare does NOT auto-create these for you — they must be
+ * provisioned once per project and their IDs pasted into `wrangler.toml`.
+ *
+ * This script runs the three `wrangler` commands and prints the IDs you need
+ * to copy into `wrangler.toml`:
+ *
+ *   wrangler d1 create <db-name>         -> database_id
+ *   wrangler r2 bucket create <bucket>   -> (no ID — bucket name is the key)
+ *   wrangler kv namespace create <name>  -> id
+ *
+ * Usage:
+ *   pnpm setup                # uses defaults (khaopad-db, khaopad-media, CONTENT_CACHE)
+ *   pnpm setup -- --db=foo --bucket=bar --kv=BAZ
+ *
+ * Prerequisites:
+ *   - `wrangler login` (or CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID env).
+ *
+ * After it finishes: open `wrangler.toml`, replace the `LOCAL_DB_ID` and
+ * `LOCAL_KV_ID` placeholders, then run `pnpm db:migrate` and `pnpm db:seed`.
+ */
+import { execSync } from "node:child_process";
+
+type Args = { db: string; bucket: string; kv: string };
+
+function parseArgs(): Args {
+  const args: Args = {
+    db: "khaopad-db",
+    bucket: "khaopad-media",
+    kv: "CONTENT_CACHE",
+  };
+  for (const arg of process.argv.slice(2)) {
+    const [key, val] = arg.replace(/^--/, "").split("=");
+    if (key === "db" && val) args.db = val;
+    if (key === "bucket" && val) args.bucket = val;
+    if (key === "kv" && val) args.kv = val;
+  }
+  return args;
+}
+
+function run(label: string, cmd: string): string {
+  console.log(`\n──── ${label} ────`);
+  console.log(`$ ${cmd}`);
+  try {
+    const out = execSync(cmd, { encoding: "utf-8", stdio: ["ignore", "pipe", "inherit"] });
+    process.stdout.write(out);
+    return out;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`  (step failed or resource exists — continuing): ${msg.split("\n")[0]}`);
+    return "";
+  }
+}
+
+const args = parseArgs();
+
+const d1Out = run("1/3 Create D1 database", `npx wrangler d1 create ${args.db}`);
+const r2Out = run("2/3 Create R2 bucket", `npx wrangler r2 bucket create ${args.bucket}`);
+const kvOut = run("3/3 Create KV namespace", `npx wrangler kv namespace create ${args.kv}`);
+
+// Try to extract IDs for convenience.
+const dbId = d1Out.match(/database_id\s*=\s*"([^"]+)"/)?.[1];
+const kvId = kvOut.match(/id\s*=\s*"([^"]+)"/)?.[1];
+
+console.log("\n──── Summary ────");
+console.log(`D1 database:  ${args.db}${dbId ? `  (id: ${dbId})` : ""}`);
+console.log(`R2 bucket:    ${args.bucket}`);
+console.log(`KV namespace: ${args.kv}${kvId ? `  (id: ${kvId})` : ""}`);
+
+console.log(`
+Next steps:
+  1. Open wrangler.toml and paste the IDs above into the matching bindings
+     (replace LOCAL_DB_ID and LOCAL_KV_ID).
+  2. Set your Better Auth secret:
+       wrangler secret put BETTER_AUTH_SECRET
+  3. Apply migrations locally and seed:
+       pnpm db:migrate
+       pnpm db:seed
+  4. Start the dev server:
+       pnpm wrangler:dev
+`);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -44,6 +44,7 @@ SUPPORTED_LOCALES = "en,th"
 DEFAULT_LOCALE = "en"
 PUBLIC_SITE_URL = "https://www.example.com"
 CMS_SITE_URL = "https://cms.example.com"
+BETTER_AUTH_URL = "https://cms.example.com"
 # GitHub content mode vars (only needed when CONTENT_MODE = "github")
 # GITHUB_OWNER = "your-org"
 # GITHUB_REPO = "your-repo"


### PR DESCRIPTION
## Summary

Completes Milestone 2 — storage layer + developer ergonomics for the fork/clone template model.

- **First D1 migration** (`drizzle/0000_nice_thor.sql`) — 14 tables covering auth, content, localizations, media, audit.
- **`pnpm db:seed`** — seeds a super_admin user + one bilingual (EN/TH) published article via `wrangler d1 execute`. `--remote` seeds production D1.
- **`pnpm setup`** — one-shot Cloudflare provisioner: creates D1 DB, R2 bucket, KV namespace and prints the IDs to paste into `wrangler.toml`.
- **README** — rewritten around the template usage model; explains that D1/R2/KV are **not auto-generated** (must be provisioned per fork) and documents the binding table.
- **.gitignore** — repo is pnpm-only; ignore `package-lock.json` and `yarn.lock`.

## Context: why the setup script?

Khao Pad is a base template that users fork or clone to bootstrap new projects. Cloudflare resources can't be shared across installations — each project needs its own D1 database, R2 bucket, and KV namespace, bound by ID in its own `wrangler.toml`. `pnpm setup` turns three separate `wrangler` commands into one step.

## Test plan

- [ ] `pnpm install` (uses legacy peer deps for Better Auth)
- [ ] `pnpm setup` in a fresh fork creates the three CF resources and prints IDs
- [ ] Paste IDs into `wrangler.toml`, then `pnpm db:migrate` creates all 14 tables locally
- [ ] `pnpm db:seed` inserts the admin user + sample article (idempotent on re-run)
- [ ] `pnpm wrangler:dev` serves the sample article at `www.khaopad.local:8787/en/blog/hello-khao-pad`
- [ ] `pnpm dev` (no Wrangler) renders the 503 "Configuration required" screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)