### PR TITLE
feat(m6): staging + production deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,108 @@
 name: Deploy to Cloudflare Workers
 
+# Deploy pipeline:
+#   - Every push to main             → deploy to staging
+#   - Every version tag  `v*.*.*`    → deploy to production
+#   - Manual run with environment    → deploy to the chosen env
+#
+# Both paths run the same CI gates (check / lint / build) first, then
+# apply pending D1 migrations for that env, then deploy the Worker,
+# then probe the public URL as a smoke test.
+
 on:
   push:
     branches: [main]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options: [staging, production]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  # ──────────────────────────────────────
+  # Gate: same checks as ci.yml. If these fail, nothing deploys.
+  # ──────────────────────────────────────
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Compile Paraglide messages
+        run: pnpm exec paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
+
+      - name: Type-check
+        run: pnpm run check
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build
+
+  # ──────────────────────────────────────
+  # Resolve which environment this run targets.
+  # main push      → staging
+  # v*.*.* tag     → production
+  # manual dispatch → input
+  # ──────────────────────────────────────
+  resolve-env:
+    runs-on: ubuntu-latest
+    needs: gate
+    outputs:
+      environment: ${{ steps.pick.outputs.environment }}
+      public_url: ${{ steps.pick.outputs.public_url }}
+    steps:
+      - id: pick
+        env:
+          STAGING_URL: ${{ vars.STAGING_PUBLIC_URL }}
+          PRODUCTION_URL: ${{ vars.PRODUCTION_PUBLIC_URL }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ENV="${{ github.event.inputs.environment }}"
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            ENV="production"
+          else
+            ENV="staging"
+          fi
+          if [[ "$ENV" == "production" ]]; then
+            URL="${PRODUCTION_URL:-}"
+          else
+            URL="${STAGING_URL:-}"
+          fi
+          echo "environment=$ENV" >> "$GITHUB_OUTPUT"
+          echo "public_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "→ deploying to: $ENV (url: ${URL:-<unset>})"
+
+  # ──────────────────────────────────────
+  # Deploy: migrate D1, then deploy the Worker.
+  # GitHub Environment protections (required reviewers, wait timers) attach
+  # to `environment:` below — configure them under repo Settings → Environments.
+  # ──────────────────────────────────────
   deploy:
     runs-on: ubuntu-latest
+    needs: [gate, resolve-env]
+    environment:
+      name: ${{ needs.resolve-env.outputs.environment }}
+      url: ${{ needs.resolve-env.outputs.public_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -22,15 +118,50 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      - name: Run D1 migrations
+      - name: Apply D1 migrations (${{ needs.resolve-env.outputs.environment }})
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply khaopad-db --remote
+          command: d1 migrations apply khaopad-db --remote --env ${{ needs.resolve-env.outputs.environment }}
 
-      - name: Deploy Worker
+      - name: Deploy Worker (${{ needs.resolve-env.outputs.environment }})
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --env ${{ needs.resolve-env.outputs.environment }}
+
+  # ──────────────────────────────────────
+  # Smoke test: hit the public URL and make sure it responds.
+  # Skipped (with a warning) if the environment URL var isn't set yet.
+  # ──────────────────────────────────────
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: [resolve-env, deploy]
+    steps:
+      - name: Probe public URL
+        env:
+          URL: ${{ needs.resolve-env.outputs.public_url }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${URL}" ]]; then
+            echo "::warning::Public URL not set for ${{ needs.resolve-env.outputs.environment }}; skipping smoke test."
+            echo "Set STAGING_PUBLIC_URL / PRODUCTION_PUBLIC_URL under repo Settings → Variables to enable."
+            exit 0
+          fi
+          echo "Probing $URL ..."
+          # Retry for up to ~60s — Worker propagation is fast but not instant.
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+            echo "  attempt $i → HTTP $code"
+            # 2xx/3xx is healthy. 503 is the Khao Pad "config required" screen —
+            # still counts as the Worker running, just pointed at unconfigured bindings.
+            if [[ "$code" =~ ^(2|3)..$ ]] || [[ "$code" == "503" ]]; then
+              echo "✔ Worker responded ($code)"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Smoke test failed — $URL never returned a healthy status."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ BETTER_AUTH_SECRET=dev-local-only-not-a-real-secret
 - [x] **M3** — Better Auth integration + CMS admin panel (article CRUD, first-admin signup, role-based permissions)
 - [x] **M4** — Media library (R2 upload/delete, cover images, migration guide)
 - [x] **M5** — Categories & tags (CMS taxonomy UI, article pickers, public blog filtering, CI workflow)
-- [ ] **M6** — GitHub Actions deploy pipeline (staging + production)
+- [x] **M6** — Deploy pipeline (staging on `main`, production on `v*.*.*` tag, D1 migrations + smoke test)
 - [ ] **M7** — Markdown editor UX (syntax highlight, image picker, preview)
 
 See [docs/MILESTONES.md](docs/MILESTONES.md) for a detailed breakdown of what shipped in each milestone.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,21 +56,52 @@ BETTER_AUTH_SECRET=dev-local-only-not-a-real-secret
 
 **`pnpm dev` (plain Vite).** No Cloudflare runtime at all. `platform.env` is undefined, so the 503 screen renders. Useful for working on purely client-side Svelte code without needing Wrangler, and for verifying the 503 page itself still looks right.
 
-## CI deploy
+## CI deploy pipeline
 
-`.github/workflows/deploy.yml` fires on push to `main`:
+`.github/workflows/deploy.yml` runs four sequential jobs: **gate → resolve-env → deploy → smoke-test**.
 
-```yaml
-- pnpm install --frozen-lockfile
-- pnpm build
-- wrangler d1 migrations apply khaopad-db --remote # only pending migrations
-- wrangler deploy
+| Trigger                      | Target env   | Notes                                      |
+| ---------------------------- | ------------ | ------------------------------------------ |
+| Push to `main`               | `staging`    | Automatic after every merge                |
+| Tag `v*.*.*` (e.g. `v1.2.0`) | `production` | Cut a release tag to promote               |
+| `workflow_dispatch` (manual) | your choice  | Select `staging` or `production` in the UI |
+
+**Jobs:**
+
+1. **gate** — install, Paraglide compile, `svelte-check`, `eslint`, `prettier`, `vite build`. If any fail, nothing deploys. Same checks as `ci.yml` so PRs and deploys never disagree.
+2. **resolve-env** — emits `environment` (`staging` / `production`) and `public_url` (from repo Variables) as step outputs.
+3. **deploy** — attaches to a GitHub Environment (same name), applies pending D1 migrations via `wrangler d1 migrations apply --env <target>`, then `wrangler deploy --env <target>`. Add required-reviewer protection on the `production` environment in repo Settings → Environments to gate prod behind an approval.
+4. **smoke-test** — curls the public URL up to 6× with 10s backoff. `2xx`, `3xx`, and `503` all count as "Worker responded" (503 = Khao Pad's config-guard page, which still means the Worker itself is live). `000`/`5xx-other` fails the run.
+
+### Pre-reqs
+
+**Secrets** (repo or org → Settings → Secrets):
+
+- `CLOUDFLARE_API_TOKEN` — scopes: Workers Scripts Edit, D1 Edit, KV Edit, R2 Edit, Zone DNS Read
+- `CLOUDFLARE_ACCOUNT_ID`
+
+**Variables** (repo → Settings → Variables → Actions) — optional but recommended:
+
+- `STAGING_PUBLIC_URL` (e.g. `https://staging-www.example.com`)
+- `PRODUCTION_PUBLIC_URL` (e.g. `https://www.example.com`)
+
+Without these, smoke-test emits a warning and exits 0 (so the pipeline still goes green on fresh forks before DNS is wired).
+
+### Promotion flow
+
+```
+PR merged into main
+     ↓
+gate passes  →  deploy to staging  →  smoke-test staging
+     ↓
+manual QA on staging-*.example.com
+     ↓
+tag release:  git tag v1.2.0 && git push origin v1.2.0
+     ↓
+gate passes  →  (optional reviewer approval)  →  deploy to production  →  smoke-test prod
 ```
 
-Pre-reqs:
-
-- GitHub Actions secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (at org or repo level).
-- Token scopes: Workers Scripts Edit, D1 Edit, KV Edit, R2 Edit, Zone DNS Read.
+Need to roll back? Re-run the last good tag's deploy run in the Actions UI, or push a new tag pointing at the previous commit. D1 migrations are forward-only — down-migrations aren't generated, so plan schema changes to be additive where possible.
 
 ## First-deploy checklist
 
@@ -89,7 +120,27 @@ After first deploy: visit `cms.your-domain.com` → see the "No admin exists yet
 
 ## Environments (prod/staging/dev)
 
-Not wired yet, but when we add them: Cloudflare Workers has `[env.staging]` blocks in `wrangler.toml`. Each env gets its own bindings and `[vars]` and deploys via `wrangler deploy --env staging`. CI adds a matching workflow job. Keep D1/R2/KV **per environment** — don't share DBs across envs or you'll blow away prod when testing destructive migrations.
+Cloudflare Workers supports `[env.staging]` / `[env.production]` blocks in `wrangler.toml`, and Khao Pad now ships with both. Each env gets its own D1 database, R2 bucket, and KV namespace — **never share state across envs** or a destructive migration run against staging will wipe prod.
+
+### Provisioning a new env
+
+Everything under `[env.staging]` / `[env.production]` defaults to placeholder IDs (`STAGING_DB_ID`, `PRODUCTION_DB_ID`, etc). To fill them in:
+
+```bash
+# 1. Create the resources for that env
+wrangler d1 create khaopad-db-staging
+wrangler r2 bucket create khaopad-media-staging
+wrangler kv namespace create khaopad-staging-cache
+
+# 2. Paste the returned IDs into the matching [env.staging.*] blocks
+# 3. Apply migrations once to seed the schema
+wrangler d1 migrations apply khaopad-db --remote --env staging
+
+# 4. Push secrets for that env
+wrangler secret put BETTER_AUTH_SECRET --env staging
+```
+
+Repeat with `--env production` for prod. The top-level config in `wrangler.toml` (with `LOCAL_DB_ID` / `LOCAL_KV_ID`) is only used by `pnpm dev` and `pnpm wrangler:dev` locally — CI always deploys through a named env.
 
 ---
 

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -34,7 +34,7 @@ Tracks what shipped in each milestone and what is pending. Updated every time a 
 - `coverMediaId` picker in the article form with preview.
 - `docs/MIGRATING.md` — guide for folding an existing SvelteKit project into Khao Pad.
 
-### M5 — Categories & tags (this milestone)
+### M5 — Categories & tags
 
 - CMS `/categories` and `/tags` pages: list/create/edit/delete with inline editor and EN/TH localizations.
 - `canManageTaxonomy` permission gate (editor+ can write, anyone authenticated can read).
@@ -44,15 +44,22 @@ Tracks what shipped in each milestone and what is pending. Updated every time a 
 - GitHub Actions `ci.yml` runs `svelte-check`, `eslint`, `prettier`, and `vite build` on every PR.
 - `updateTag` added to `ContentProvider` (and stubbed in GitHub provider) so categories and tags now share a symmetric surface.
 
+### M6 — Deploy pipeline (this milestone)
+
+- `wrangler.toml` now defines `[env.staging]` and `[env.production]` with per-env D1 / R2 / KV bindings so state is never shared across envs.
+- `.github/workflows/deploy.yml` rewritten as a four-stage pipeline: **gate → resolve-env → deploy → smoke-test**.
+  - Push to `main` → auto-deploy to **staging**.
+  - Push tag `v*.*.*` → deploy to **production**.
+  - `workflow_dispatch` input → deploy to the chosen env manually.
+- The `gate` job runs the same checks as `ci.yml` (svelte-check + lint + build) so PRs and deploys can't disagree.
+- `deploy` attaches to a GitHub Environment of the same name — add required-reviewer protection on `production` under Settings → Environments to gate prod behind an approval.
+- D1 migrations apply with `--env <target>` so each env's schema is bumped independently.
+- `smoke-test` curls the public URL (from repo Variables `STAGING_PUBLIC_URL` / `PRODUCTION_PUBLIC_URL`) up to 6× with 10 s backoff; treats 2xx/3xx/503 as healthy.
+- `docs/DEPLOYMENT.md` now documents the full promotion flow, required secrets/variables, and per-env provisioning steps.
+
 ## Pending
 
-### M6 — Deploy pipeline
-
-- GitHub Actions `deploy.yml` for staging and production environments.
-- Wrangler secrets + environment promotion flow.
-- Smoke tests against the deployed worker.
-
-### M7 — Editor UX
+### M7 — Editor UX (next)
 
 - Markdown editor with syntax highlighting and live preview.
 - Inline image picker (pull from media library).

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -49,3 +49,76 @@ BETTER_AUTH_URL = "https://cms.example.com"
 # GITHUB_OWNER = "your-org"
 # GITHUB_REPO = "your-repo"
 # GITHUB_BRANCH = "main"
+
+# ──────────────────────────────────────
+# Environments
+# ──────────────────────────────────────
+# Each environment gets its OWN D1 database, R2 bucket, and KV namespace —
+# never share state across envs (a destructive migration on staging should
+# never touch production). `pnpm setup` creates the default set; re-run it
+# with `--env staging` to provision a parallel stack.
+#
+# Deploy:
+#   wrangler deploy --env staging
+#   wrangler deploy --env production
+#
+# The top-level config above is what `pnpm dev` and `pnpm wrangler:dev` use
+# locally. CI deploys go through one of the named envs below.
+
+[env.staging]
+name = "khaopad-staging"
+# routes = [
+#   { pattern = "staging-www.example.com/*", zone_name = "example.com" },
+#   { pattern = "staging-cms.example.com/*", zone_name = "example.com" },
+# ]
+
+[env.staging.vars]
+CONTENT_MODE = "d1"
+SUPPORTED_LOCALES = "en,th"
+DEFAULT_LOCALE = "en"
+PUBLIC_SITE_URL = "https://staging-www.example.com"
+CMS_SITE_URL = "https://staging-cms.example.com"
+BETTER_AUTH_URL = "https://staging-cms.example.com"
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "khaopad-db-staging"
+database_id = "STAGING_DB_ID"
+migrations_dir = "drizzle"
+
+[[env.staging.r2_buckets]]
+binding = "MEDIA_BUCKET"
+bucket_name = "khaopad-media-staging"
+
+[[env.staging.kv_namespaces]]
+binding = "CONTENT_CACHE"
+id = "STAGING_KV_ID"
+
+[env.production]
+name = "khaopad"
+# routes = [
+#   { pattern = "www.example.com/*", zone_name = "example.com" },
+#   { pattern = "cms.example.com/*", zone_name = "example.com" },
+# ]
+
+[env.production.vars]
+CONTENT_MODE = "d1"
+SUPPORTED_LOCALES = "en,th"
+DEFAULT_LOCALE = "en"
+PUBLIC_SITE_URL = "https://www.example.com"
+CMS_SITE_URL = "https://cms.example.com"
+BETTER_AUTH_URL = "https://cms.example.com"
+
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "khaopad-db"
+database_id = "PRODUCTION_DB_ID"
+migrations_dir = "drizzle"
+
+[[env.production.r2_buckets]]
+binding = "MEDIA_BUCKET"
+bucket_name = "khaopad-media"
+
+[[env.production.kv_namespaces]]
+binding = "CONTENT_CACHE"
+id = "PRODUCTION_KV_ID"


### PR DESCRIPTION
## Summary

- **Per-env config** in `wrangler.toml`: new `[env.staging]` and `[env.production]` blocks with their own D1 / R2 / KV bindings and `[vars]`. State is never shared across envs — a destructive migration on staging can't touch production.
- **Four-stage pipeline** in `.github/workflows/deploy.yml`: **gate → resolve-env → deploy → smoke-test**.
  - Push to `main` → auto-deploy to **staging**
  - Tag `v*.*.*` → deploy to **production**
  - `workflow_dispatch` → manual env choice
- **Gate reuses CI checks** (svelte-check + lint + build) so PRs and deploys never diverge.
- **GitHub Environment binding** on the deploy job — flip required-reviewer protection on `production` under repo Settings → Environments to gate prod behind an approval without touching this workflow.
- **Smoke test** curls `STAGING_PUBLIC_URL` / `PRODUCTION_PUBLIC_URL` (repo Variables) up to 6× with 10 s backoff; 2xx/3xx/503 count as healthy (503 = Khao Pad's config-guard page, which still means the Worker itself is live).
- **Docs**: `docs/DEPLOYMENT.md` now documents the pipeline, secrets, variables, promotion flow, and per-env provisioning. `MILESTONES.md` + README roadmap mark M6 shipped.

## Test plan

- [x] `wrangler deploy --dry-run --env staging` validates config
- [x] `wrangler deploy --dry-run --env production` validates config
- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds
- [ ] After merge, watch the Actions run → staging gate → staging deploy → staging smoke-test
- [ ] Configure repo variables `STAGING_PUBLIC_URL` + `PRODUCTION_PUBLIC_URL` (smoke test is a warning-only no-op until set)
- [ ] Replace placeholder IDs (`STAGING_DB_ID`, `PRODUCTION_DB_ID`, etc.) with real values when provisioning each env per the guide in `docs/DEPLOYMENT.md`
- [ ] Cut first release tag `v0.1.0` to dry-run the production path

🤖 Generated with [Claude Code](https://claude.com/claude-code)