### PR TITLE
feat(cms): shadcn-style reskin of admin shell + login + signup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,8 +50,15 @@ export default defineConfig(
     rules: {},
   },
   {
-    // CMS routes use root-relative paths; `(www)` uses `localePath()` for locale-prefixed URLs.
-    files: ["src/routes/(cms)/**/*.svelte", "src/routes/(www)/**/*.svelte"],
+    // CMS routes use root-relative paths; `(www)` uses `localePath()` for
+    // locale-prefixed URLs; shared CMS shell components and UI primitives
+    // accept absolute hrefs as props or render hardcoded admin links.
+    files: [
+      "src/routes/(cms)/**/*.svelte",
+      "src/routes/(www)/**/*.svelte",
+      "src/lib/components/cms/**/*.svelte",
+      "src/lib/components/ui/**/*.svelte",
+    ],
     rules: {
       "svelte/no-navigation-without-resolve": "off",
     },

--- a/src/app.css
+++ b/src/app.css
@@ -1,45 +1,99 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* ─── Design tokens ────────────────────────────────────
+ * Same shape as shadcn-svelte: HSL-equivalent oklch
+ * tokens for both color modes plus a dedicated "sidebar"
+ * sub-palette so the admin shell can be themed
+ * independently from the public site if desired.
+ *
+ * Pattern adopted from codustry/workflow.
+ */
 @theme {
+  --font-sans:
+    "IBM Plex Sans Thai", "Inter", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-mono:
+    "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas,
+    monospace;
+
   --color-background: oklch(1 0 0);
   --color-foreground: oklch(0.145 0 0);
   --color-card: oklch(1 0 0);
   --color-card-foreground: oklch(0.145 0 0);
   --color-popover: oklch(1 0 0);
   --color-popover-foreground: oklch(0.145 0 0);
-  --color-primary: oklch(0.205 0.064 285.82);
+  --color-primary: oklch(0.205 0.017 285.82);
   --color-primary-foreground: oklch(0.985 0 0);
   --color-secondary: oklch(0.97 0 0);
-  --color-secondary-foreground: oklch(0.205 0.064 285.82);
+  --color-secondary-foreground: oklch(0.205 0.017 285.82);
   --color-muted: oklch(0.97 0 0);
   --color-muted-foreground: oklch(0.556 0 0);
   --color-accent: oklch(0.97 0 0);
-  --color-accent-foreground: oklch(0.205 0.064 285.82);
+  --color-accent-foreground: oklch(0.205 0.017 285.82);
   --color-destructive: oklch(0.577 0.245 27.33);
-  --color-destructive-foreground: oklch(0.577 0.245 27.33);
+  --color-destructive-foreground: oklch(0.985 0 0);
   --color-border: oklch(0.922 0 0);
   --color-input: oklch(0.922 0 0);
-  --color-ring: oklch(0.708 0.165 254.62);
-  --color-sidebar-background: oklch(0.985 0 0);
-  --color-sidebar-foreground: oklch(0.145 0 0);
-  --color-sidebar-primary: oklch(0.205 0.064 285.82);
+  --color-ring: oklch(0.708 0.117 285.82);
+
+  --color-sidebar-background: oklch(0.985 0.004 285.82);
+  --color-sidebar-foreground: oklch(0.205 0.017 285.82);
+  --color-sidebar-primary: oklch(0.205 0.017 285.82);
   --color-sidebar-primary-foreground: oklch(0.985 0 0);
-  --color-sidebar-accent: oklch(0.97 0 0);
-  --color-sidebar-accent-foreground: oklch(0.205 0.064 285.82);
+  --color-sidebar-accent: oklch(0.96 0.004 285.82);
+  --color-sidebar-accent-foreground: oklch(0.205 0.017 285.82);
   --color-sidebar-border: oklch(0.922 0 0);
-  --color-sidebar-ring: oklch(0.708 0.165 254.62);
-  --radius-sm: 0.25rem;
-  --radius-md: 0.375rem;
-  --radius-lg: 0.5rem;
-  --radius-xl: 0.75rem;
+  --color-sidebar-ring: oklch(0.708 0.117 285.82);
+
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.625rem;
+  --radius-xl: 0.875rem;
 }
 
+/* Dark mode: same tokens, inverted lightness. Toggled by adding
+ * `class="dark"` on <html> — left for a future PR; the structure is
+ * here so the reskin doesn't have to repaint when dark mode lands.
+ */
 @layer base {
+  .dark {
+    --color-background: oklch(0.145 0 0);
+    --color-foreground: oklch(0.985 0 0);
+    --color-card: oklch(0.145 0 0);
+    --color-card-foreground: oklch(0.985 0 0);
+    --color-popover: oklch(0.145 0 0);
+    --color-popover-foreground: oklch(0.985 0 0);
+    --color-primary: oklch(0.985 0 0);
+    --color-primary-foreground: oklch(0.205 0.017 285.82);
+    --color-secondary: oklch(0.269 0 0);
+    --color-secondary-foreground: oklch(0.985 0 0);
+    --color-muted: oklch(0.269 0 0);
+    --color-muted-foreground: oklch(0.708 0 0);
+    --color-accent: oklch(0.269 0 0);
+    --color-accent-foreground: oklch(0.985 0 0);
+    --color-destructive: oklch(0.396 0.141 25.72);
+    --color-destructive-foreground: oklch(0.985 0 0);
+    --color-border: oklch(0.269 0 0);
+    --color-input: oklch(0.269 0 0);
+    --color-ring: oklch(0.439 0.016 285.82);
+    --color-sidebar-background: oklch(0.205 0.017 285.82);
+    --color-sidebar-foreground: oklch(0.985 0 0);
+    --color-sidebar-primary: oklch(0.439 0.016 285.82);
+    --color-sidebar-primary-foreground: oklch(0.985 0 0);
+    --color-sidebar-accent: oklch(0.269 0 0);
+    --color-sidebar-accent-foreground: oklch(0.985 0 0);
+    --color-sidebar-border: oklch(0.269 0 0);
+    --color-sidebar-ring: oklch(0.439 0.016 285.82);
+  }
+
   * {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+    font-feature-settings:
+      "rlig" 1,
+      "calt" 1;
   }
 }

--- a/src/lib/components/cms/CmsLocaleToggle.svelte
+++ b/src/lib/components/cms/CmsLocaleToggle.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Languages } from 'lucide-svelte';
+	import { getLocale, setLocale } from '$lib/paraglide/runtime';
+
+	const current = $derived(getLocale());
+	const next = $derived(current === 'en' ? 'th' : 'en');
+
+	function switchLocale() {
+		// Cookie strategy: writes the locale cookie and reloads. The Paraglide
+		// strategy array `["url", "cookie", "baseLocale"]` falls through to
+		// the cookie on /cms/* (no /en or /th prefix to match), so the URL
+		// stays clean.
+		setLocale(next);
+	}
+</script>
+
+<button
+	type="button"
+	onclick={switchLocale}
+	class="inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+	aria-label={`Switch to ${next === 'th' ? 'Thai' : 'English'}`}
+	title={`Switch to ${next === 'th' ? 'Thai' : 'English'}`}
+>
+	<Languages class="h-3.5 w-3.5" aria-hidden="true" />
+	{next.toUpperCase()}
+</button>

--- a/src/lib/components/cms/Sidebar.svelte
+++ b/src/lib/components/cms/Sidebar.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { ChevronLeft, LogOut } from 'lucide-svelte';
+	import { Avatar, Separator } from '$lib/components/ui';
+	import { cn } from '$lib/utils';
+	import { navGroups, type NavItem } from './sidebar-nav';
+
+	type User = { name: string; role: string };
+
+	let { user, onLogout }: { user: User; onLogout?: () => void } = $props();
+
+	// Sidebar collapse state — persist across reloads via localStorage,
+	// hydrated on mount to avoid SSR/CSR mismatch.
+	let collapsed = $state(false);
+
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		try {
+			collapsed = localStorage.getItem('khaopad:cms:sidebar:collapsed') === '1';
+		} catch {
+			// Private mode etc — fall back to expanded.
+		}
+	});
+
+	function toggleCollapsed() {
+		collapsed = !collapsed;
+		try {
+			localStorage.setItem('khaopad:cms:sidebar:collapsed', collapsed ? '1' : '0');
+		} catch {
+			// ignore
+		}
+	}
+
+	const currentPath = $derived(page.url.pathname);
+
+	function isActive(href: string) {
+		// Exact match wins; otherwise treat as section root (e.g. /cms/articles
+		// stays active on /cms/articles/new and /cms/articles/[id]).
+		return currentPath === href || currentPath.startsWith(href + '/');
+	}
+
+	function visibleItems(items: readonly NavItem[]): NavItem[] {
+		return items.filter(
+			(it) => !it.roles || (it.roles as readonly string[]).includes(user.role),
+		);
+	}
+
+	const widthClass = $derived(collapsed ? 'w-[64px]' : 'w-64');
+</script>
+
+<aside
+	class={cn(
+		'flex h-full flex-col border-r border-sidebar-border bg-sidebar-background',
+		'transition-[width] duration-200 ease-out',
+		widthClass,
+	)}
+	aria-label="Admin navigation"
+>
+	<!-- Brand row -->
+	<div class="flex h-14 shrink-0 items-center gap-3 border-b border-sidebar-border px-3">
+		<a
+			href="/cms/dashboard"
+			class="flex min-w-0 items-center gap-2.5 text-sidebar-foreground"
+			title="Khao Pad"
+		>
+			<span
+				class="grid h-8 w-8 shrink-0 place-items-center rounded-md bg-primary font-bold text-primary-foreground"
+				aria-hidden="true"
+			>
+				ข
+			</span>
+			{#if !collapsed}
+				<span class="truncate text-sm font-semibold tracking-tight">Khao Pad</span>
+			{/if}
+		</a>
+		{#if !collapsed}
+			<button
+				type="button"
+				onclick={toggleCollapsed}
+				class="ml-auto grid h-7 w-7 place-items-center rounded-md text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+				aria-label="Collapse sidebar"
+			>
+				<ChevronLeft class="h-4 w-4" />
+			</button>
+		{/if}
+	</div>
+
+	<!-- Navigation groups -->
+	<nav class="flex-1 overflow-y-auto p-2">
+		{#each navGroups as group, i (group.id)}
+			{@const items = visibleItems(group.items)}
+			{#if items.length > 0}
+				{#if i > 0}
+					<div class="my-2 px-2">
+						<Separator />
+					</div>
+				{/if}
+				{#if !collapsed}
+					<div
+						class="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-sidebar-foreground/50"
+					>
+						{group.title()}
+					</div>
+				{/if}
+				<ul class="space-y-0.5">
+					{#each items as item (item.href)}
+						{@const Icon = item.icon}
+						{@const active = isActive(item.href)}
+						<li>
+							<a
+								href={item.href}
+								title={collapsed ? item.label() : undefined}
+								class={cn(
+									'flex items-center gap-3 rounded-md px-2 py-1.5 text-sm transition-colors',
+									active
+										? 'bg-sidebar-accent font-medium text-sidebar-accent-foreground'
+										: 'text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+									collapsed && 'justify-center',
+								)}
+								aria-current={active ? 'page' : undefined}
+							>
+								<Icon class="h-4 w-4 shrink-0" aria-hidden="true" />
+								{#if !collapsed}
+									<span class="truncate">{item.label()}</span>
+								{/if}
+							</a>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		{/each}
+	</nav>
+
+	<!-- User chip + collapse-to-icon -->
+	<div class="border-t border-sidebar-border p-2">
+		{#if collapsed}
+			<div class="flex flex-col items-center gap-1.5">
+				<Avatar name={user.name} size="sm" />
+				<button
+					type="button"
+					onclick={toggleCollapsed}
+					class="grid h-7 w-7 place-items-center rounded-md text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+					aria-label="Expand sidebar"
+				>
+					<ChevronLeft class="h-4 w-4 rotate-180" />
+				</button>
+				{#if onLogout}
+					<button
+						type="button"
+						onclick={onLogout}
+						class="grid h-7 w-7 place-items-center rounded-md text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+						aria-label="Sign out"
+					>
+						<LogOut class="h-4 w-4" />
+					</button>
+				{/if}
+			</div>
+		{:else}
+			<div class="flex items-center gap-2.5 rounded-md p-2">
+				<Avatar name={user.name} size="md" />
+				<div class="min-w-0 flex-1">
+					<div class="truncate text-sm font-medium text-sidebar-foreground">{user.name}</div>
+					<div class="truncate text-xs capitalize text-sidebar-foreground/60">
+						{user.role.replace('_', ' ')}
+					</div>
+				</div>
+				{#if onLogout}
+					<button
+						type="button"
+						onclick={onLogout}
+						class="grid h-7 w-7 place-items-center rounded-md text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+						aria-label="Sign out"
+						title="Sign out"
+					>
+						<LogOut class="h-4 w-4" />
+					</button>
+				{/if}
+			</div>
+		{/if}
+	</div>
+</aside>

--- a/src/lib/components/cms/sidebar-nav.ts
+++ b/src/lib/components/cms/sidebar-nav.ts
@@ -1,0 +1,66 @@
+import type { ComponentType } from "svelte";
+import {
+  LayoutDashboard,
+  FileText,
+  Image as ImageIcon,
+  Folder,
+  Tag,
+  Users,
+  Settings,
+} from "lucide-svelte";
+import * as m from "$lib/paraglide/messages";
+
+export type NavItem = {
+  href: string;
+  /** Localized label (called at render time) */
+  label: () => string;
+  icon: ComponentType;
+  /** Roles that can see this item. Empty = visible to everyone signed in. */
+  roles?: ReadonlyArray<"super_admin" | "admin" | "editor" | "author">;
+};
+
+export type NavGroup = {
+  /** Stable key used for localStorage open/close state */
+  id: string;
+  /** Localized group title (shown above items, hidden in collapsed mode) */
+  title: () => string;
+  items: ReadonlyArray<NavItem>;
+};
+
+export const navGroups: ReadonlyArray<NavGroup> = [
+  {
+    id: "main",
+    title: m.cms_app_name,
+    items: [
+      { href: "/cms/dashboard", label: m.cms_dashboard, icon: LayoutDashboard },
+      { href: "/cms/articles", label: m.cms_articles, icon: FileText },
+      { href: "/cms/media", label: m.cms_media, icon: ImageIcon },
+    ],
+  },
+  {
+    id: "taxonomy",
+    title: m.cms_categories,
+    items: [
+      { href: "/cms/categories", label: m.cms_categories, icon: Folder },
+      { href: "/cms/tags", label: m.cms_tags, icon: Tag },
+    ],
+  },
+  {
+    id: "admin",
+    title: m.cms_settings,
+    items: [
+      {
+        href: "/cms/users",
+        label: m.cms_users,
+        icon: Users,
+        roles: ["super_admin", "admin"],
+      },
+      {
+        href: "/cms/settings",
+        label: m.cms_settings,
+        icon: Settings,
+        roles: ["super_admin", "admin"],
+      },
+    ],
+  },
+];

--- a/src/lib/components/ui/avatar/avatar.svelte
+++ b/src/lib/components/ui/avatar/avatar.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		name: string;
+		src?: string | null;
+		size?: 'sm' | 'md' | 'lg';
+		class?: string;
+	};
+
+	let { name, src = null, size = 'md', class: className = '' }: Props = $props();
+
+	const initials = $derived(
+		name
+			.trim()
+			.split(/\s+/)
+			.slice(0, 2)
+			.map((n) => n[0]?.toUpperCase() ?? '')
+			.join('') || '?',
+	);
+
+	const sizeClass = $derived(
+		size === 'sm'
+			? 'h-7 w-7 text-[10px]'
+			: size === 'lg'
+				? 'h-10 w-10 text-sm'
+				: 'h-8 w-8 text-xs',
+	);
+
+	let imgFailed = $state(false);
+</script>
+
+<span
+	class={cn(
+		'inline-flex items-center justify-center overflow-hidden rounded-full bg-muted font-medium text-muted-foreground select-none',
+		sizeClass,
+		className,
+	)}
+	aria-label={name}
+>
+	{#if src && !imgFailed}
+		<img
+			{src}
+			alt={name}
+			class="h-full w-full object-cover"
+			onerror={() => (imgFailed = true)}
+		/>
+	{:else}
+		<span>{initials}</span>
+	{/if}
+</span>

--- a/src/lib/components/ui/avatar/index.ts
+++ b/src/lib/components/ui/avatar/index.ts
@@ -1,0 +1,1 @@
+export { default as Avatar } from "./avatar.svelte";

--- a/src/lib/components/ui/badge/badge.svelte
+++ b/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	export const badgeVariants = tv({
+		base: 'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+		variants: {
+			variant: {
+				default:
+					'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+				secondary:
+					'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+				destructive:
+					'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+				outline: 'text-foreground',
+			},
+		},
+		defaultVariants: { variant: 'default' },
+	});
+
+	export type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type Props = {
+		class?: string;
+		variant?: BadgeVariant;
+		children?: Snippet;
+	} & Omit<HTMLAttributes<HTMLSpanElement>, 'class' | 'children'>;
+
+	let { class: className = '', variant, children, ...rest }: Props = $props();
+</script>
+
+<span class={cn(badgeVariants({ variant }), className)} {...rest}>
+	{@render children?.()}
+</span>

--- a/src/lib/components/ui/badge/index.ts
+++ b/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,2 @@
+export { default as Badge, badgeVariants } from "./badge.svelte";
+export type { BadgeVariant } from "./badge.svelte";

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -1,0 +1,71 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	export const buttonVariants = tv({
+		base: "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+		variants: {
+			variant: {
+				default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+				destructive:
+					'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+				outline:
+					'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+				secondary:
+					'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+				ghost: 'hover:bg-accent hover:text-accent-foreground',
+				link: 'text-primary underline-offset-4 hover:underline',
+			},
+			size: {
+				default: 'h-9 px-4 py-2',
+				sm: 'h-8 rounded-md px-3 text-xs',
+				lg: 'h-10 rounded-md px-6',
+				icon: 'h-9 w-9',
+			},
+		},
+		defaultVariants: { variant: 'default', size: 'default' },
+	});
+
+	export type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
+	export type ButtonSize = VariantProps<typeof buttonVariants>['size'];
+</script>
+
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLButtonAttributes, HTMLAnchorAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props =
+		| ({
+				href: string;
+				variant?: ButtonVariant;
+				size?: ButtonSize;
+				class?: string;
+				children?: Snippet;
+		  } & Omit<HTMLAnchorAttributes, 'class' | 'children'>)
+		| ({
+				href?: undefined;
+				variant?: ButtonVariant;
+				size?: ButtonSize;
+				class?: string;
+				children?: Snippet;
+		  } & Omit<HTMLButtonAttributes, 'class' | 'children'>);
+
+	let { class: className = '', variant, size, href, children, ...rest }: Props = $props();
+</script>
+
+{#if href}
+	<a
+		{href}
+		class={cn(buttonVariants({ variant, size }), className)}
+		{...rest as HTMLAnchorAttributes}
+	>
+		{@render children?.()}
+	</a>
+{:else}
+	<button
+		class={cn(buttonVariants({ variant, size }), className)}
+		{...rest as HTMLButtonAttributes}
+	>
+		{@render children?.()}
+	</button>
+{/if}

--- a/src/lib/components/ui/button/index.ts
+++ b/src/lib/components/ui/button/index.ts
@@ -1,0 +1,2 @@
+export { default as Button, buttonVariants } from "./button.svelte";
+export type { ButtonVariant, ButtonSize } from "./button.svelte";

--- a/src/lib/components/ui/card/card-content.svelte
+++ b/src/lib/components/ui/card/card-content.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLAttributes<HTMLDivElement>,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<div class={cn('p-6 pt-0', className)} {...rest}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-description.svelte
+++ b/src/lib/components/ui/card/card-description.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLAttributes<HTMLParagraphElement>,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<p class={cn('text-sm text-muted-foreground', className)} {...rest}>
+	{@render children?.()}
+</p>

--- a/src/lib/components/ui/card/card-footer.svelte
+++ b/src/lib/components/ui/card/card-footer.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLAttributes<HTMLDivElement>,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<div class={cn('flex items-center p-6 pt-0', className)} {...rest}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-header.svelte
+++ b/src/lib/components/ui/card/card-header.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLAttributes<HTMLDivElement>,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<div class={cn('flex flex-col space-y-1.5 p-6', className)} {...rest}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-title.svelte
+++ b/src/lib/components/ui/card/card-title.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLAttributes<HTMLHeadingElement>,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<h3
+	class={cn('text-lg font-semibold leading-none tracking-tight', className)}
+	{...rest}
+>
+	{@render children?.()}
+</h3>

--- a/src/lib/components/ui/card/card.svelte
+++ b/src/lib/components/ui/card/card.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLAttributes<HTMLDivElement>,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<div
+	class={cn(
+		'rounded-lg border border-border bg-card text-card-foreground shadow-sm',
+		className,
+	)}
+	{...rest}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/index.ts
+++ b/src/lib/components/ui/card/index.ts
@@ -1,0 +1,6 @@
+export { default as Card } from "./card.svelte";
+export { default as CardHeader } from "./card-header.svelte";
+export { default as CardTitle } from "./card-title.svelte";
+export { default as CardDescription } from "./card-description.svelte";
+export { default as CardContent } from "./card-content.svelte";
+export { default as CardFooter } from "./card-footer.svelte";

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -1,0 +1,7 @@
+export * from "./avatar";
+export * from "./badge";
+export * from "./button";
+export * from "./card";
+export * from "./input";
+export * from "./label";
+export * from "./separator";

--- a/src/lib/components/ui/input/index.ts
+++ b/src/lib/components/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from "./input.svelte";

--- a/src/lib/components/ui/input/input.svelte
+++ b/src/lib/components/ui/input/input.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	type Props = {
+		value?: string | number | null;
+		class?: string;
+	} & Omit<HTMLInputAttributes, 'class' | 'value'>;
+
+	let { value = $bindable(''), class: className = '', ...rest }: Props = $props();
+</script>
+
+<input
+	bind:value
+	class={cn(
+		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+		'file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground',
+		'placeholder:text-muted-foreground',
+		'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+		'disabled:cursor-not-allowed disabled:opacity-50',
+		className,
+	)}
+	{...rest}
+/>

--- a/src/lib/components/ui/label/index.ts
+++ b/src/lib/components/ui/label/index.ts
@@ -1,0 +1,1 @@
+export { default as Label } from "./label.svelte";

--- a/src/lib/components/ui/label/label.svelte
+++ b/src/lib/components/ui/label/label.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { HTMLLabelAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	type Props = { class?: string; children?: Snippet } & Omit<
+		HTMLLabelAttributes,
+		'class' | 'children'
+	>;
+
+	let { class: className = '', children, ...rest }: Props = $props();
+</script>
+
+<label
+	class={cn(
+		'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+		className,
+	)}
+	{...rest}
+>
+	{@render children?.()}
+</label>

--- a/src/lib/components/ui/separator/index.ts
+++ b/src/lib/components/ui/separator/index.ts
@@ -1,0 +1,1 @@
+export { default as Separator } from "./separator.svelte";

--- a/src/lib/components/ui/separator/separator.svelte
+++ b/src/lib/components/ui/separator/separator.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		class?: string;
+		orientation?: 'horizontal' | 'vertical';
+		decorative?: boolean;
+	};
+
+	let {
+		class: className = '',
+		orientation = 'horizontal',
+		decorative = true,
+	}: Props = $props();
+</script>
+
+<div
+	role={decorative ? 'none' : 'separator'}
+	aria-orientation={decorative ? undefined : orientation}
+	class={cn(
+		'shrink-0 bg-border',
+		orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
+		className,
+	)}
+></div>

--- a/src/routes/(cms)/cms/+layout.svelte
+++ b/src/routes/(cms)/cms/+layout.svelte
@@ -1,52 +1,99 @@
 <script lang="ts">
 	import '../../../app.css';
-	import * as m from '$lib/paraglide/messages';
-	let { children, data } = $props();
+	import { goto } from '$app/navigation';
+	import { Menu, X } from 'lucide-svelte';
+	import Sidebar from '$lib/components/cms/Sidebar.svelte';
+	import CmsLocaleToggle from '$lib/components/cms/CmsLocaleToggle.svelte';
+	import type { Snippet } from 'svelte';
+	import type { LayoutData } from './$types';
+
+	let {
+		children,
+		data,
+	}: {
+		children: Snippet;
+		data: LayoutData;
+	} = $props();
+
+	let mobileOpen = $state(false);
+
+	async function logout() {
+		try {
+			await fetch('/api/auth/sign-out', { method: 'POST' });
+		} catch {
+			// network failure: still try to leave
+		}
+		goto('/cms/login', { invalidateAll: true });
+	}
+
+	// Re-derived per page so the sidebar sees route changes for active state.
+	// data.user is null on the public-ish auth pages (login/signup).
 </script>
 
+<svelte:head>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Thai:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+		rel="stylesheet"
+	/>
+</svelte:head>
+
 {#if !data.user}
+	<!-- Auth pages (login / signup) render full-bleed without the shell. -->
 	{@render children()}
 {:else}
-	<div class="min-h-screen flex">
-		<!-- Sidebar -->
-		<aside class="w-64 border-r border-border bg-sidebar-background p-4 flex flex-col">
-			<div class="mb-8">
-				<h1 class="text-lg font-bold">{m.cms_app_name()}</h1>
-			</div>
-			<nav class="flex-1 space-y-1">
-				<a href="/cms/dashboard" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-					{m.cms_dashboard()}
-				</a>
-				<a href="/cms/articles" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-					{m.cms_articles()}
-				</a>
-				<a href="/cms/media" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-					{m.cms_media()}
-				</a>
-				<a href="/cms/categories" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-					{m.cms_categories()}
-				</a>
-				<a href="/cms/tags" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-					{m.cms_tags()}
-				</a>
-				{#if data.user.role === 'super_admin' || data.user.role === 'admin'}
-					<a href="/cms/users" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-						{m.cms_users()}
-					</a>
-					<a href="/cms/settings" class="block px-3 py-2 rounded-md hover:bg-sidebar-accent text-sm">
-						{m.cms_settings()}
-					</a>
-				{/if}
-			</nav>
-			<div class="text-xs text-muted-foreground pt-4 border-t border-border">
-				<p>{data.user.name}</p>
-				<p class="capitalize">{data.user.role.replace('_', ' ')}</p>
-			</div>
-		</aside>
+	<div class="flex min-h-screen bg-background">
+		<!-- Desktop sidebar (lg+) -->
+		<div class="hidden shrink-0 lg:block">
+			<Sidebar user={data.user} onLogout={logout} />
+		</div>
 
-		<!-- Main content -->
-		<main class="flex-1 p-8">
-			{@render children()}
-		</main>
+		<!-- Mobile drawer -->
+		{#if mobileOpen}
+			<div
+				class="fixed inset-0 z-40 bg-black/50 lg:hidden"
+				onclick={() => (mobileOpen = false)}
+				role="presentation"
+			></div>
+			<div
+				class="fixed inset-y-0 left-0 z-50 lg:hidden"
+				role="dialog"
+				aria-modal="true"
+				aria-label="Navigation"
+			>
+				<Sidebar user={data.user} onLogout={logout} />
+			</div>
+		{/if}
+
+		<!-- Main column -->
+		<div class="flex min-w-0 flex-1 flex-col">
+			<!-- Topbar -->
+			<header
+				class="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur-sm sm:px-6"
+			>
+				<button
+					type="button"
+					onclick={() => (mobileOpen = !mobileOpen)}
+					class="grid h-8 w-8 place-items-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground lg:hidden"
+					aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+				>
+					{#if mobileOpen}
+						<X class="h-4 w-4" />
+					{:else}
+						<Menu class="h-4 w-4" />
+					{/if}
+				</button>
+
+				<div class="flex-1"></div>
+
+				<CmsLocaleToggle />
+			</header>
+
+			<!-- Page content -->
+			<main class="flex-1 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+				{@render children()}
+			</main>
+		</div>
 	</div>
 {/if}

--- a/src/routes/(cms)/cms/login/+page.svelte
+++ b/src/routes/(cms)/cms/login/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages';
 	import { submitEmailLogin } from './login-submit';
+	import { Button, Input, Label, Card, CardContent } from '$lib/components/ui';
+	import { ArrowRight, Sparkles } from 'lucide-svelte';
+
 	let { data }: { data: { bootstrapNeeded?: boolean } } = $props();
 
 	let email = $state('');
@@ -33,56 +36,116 @@
 	<title>{m.cms_sign_in()} — {m.cms_app_name()}</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center">
-	<div class="w-full max-w-sm">
-		<div class="text-center mb-8">
-			<h1 class="text-2xl font-bold">{m.cms_app_name()}</h1>
-			<p class="text-muted-foreground text-sm mt-2">{m.cms_sign_in_description()}</p>
+<div class="grid min-h-screen lg:grid-cols-2">
+	<!-- Left: brand panel (desktop only) -->
+	<aside
+		class="relative hidden flex-col justify-between overflow-hidden border-r border-border bg-sidebar-background p-10 text-sidebar-foreground lg:flex"
+	>
+		<!-- soft accent shapes -->
+		<div
+			aria-hidden="true"
+			class="pointer-events-none absolute -left-24 -top-24 h-72 w-72 rounded-full bg-primary/5 blur-3xl"
+		></div>
+		<div
+			aria-hidden="true"
+			class="pointer-events-none absolute -bottom-24 -right-24 h-80 w-80 rounded-full bg-primary/10 blur-3xl"
+		></div>
+
+		<a href="/" class="relative flex items-center gap-2.5">
+			<span
+				class="grid h-9 w-9 place-items-center rounded-md bg-primary font-bold text-primary-foreground"
+			>
+				ข
+			</span>
+			<span class="text-base font-semibold tracking-tight">Khao Pad</span>
+		</a>
+
+		<div class="relative max-w-md space-y-5">
+			<div class="inline-flex items-center gap-2 rounded-full border border-border bg-background/60 px-3 py-1 text-xs font-medium backdrop-blur">
+				<Sparkles class="h-3.5 w-3.5 text-primary" />
+				<span class="text-muted-foreground">{m.cms_app_name()}</span>
+			</div>
+			<h2 class="text-2xl font-semibold tracking-tight sm:text-3xl">
+				{m.cms_sign_in_description()}
+			</h2>
+			<p class="text-sm leading-relaxed text-muted-foreground">
+				ข้าวผัด — same dish, your sauce. A modular CMS for Cloudflare, multilingual since the first byte.
+			</p>
 		</div>
 
-		{#if data.bootstrapNeeded}
-			<div class="mb-4 border border-border rounded-md bg-muted/50 p-3 text-sm">
-				No admin exists yet. <a href="/cms/signup" class="underline font-medium">{m.cms_sign_up()}</a>
-			</div>
-		{/if}
+		<p class="relative text-xs text-muted-foreground">
+			© {new Date().getFullYear()} Khao Pad. MIT licensed.
+		</p>
+	</aside>
 
-		<form onsubmit={handleLogin} class="space-y-4">
-			{#if error}
-				<div class="bg-destructive/10 text-destructive text-sm p-3 rounded-md">
-					{error}
-				</div>
+	<!-- Right: form -->
+	<section class="flex flex-col justify-center px-6 py-12 sm:px-12">
+		<div class="mx-auto w-full max-w-sm">
+			<!-- mobile brand -->
+			<div class="mb-8 flex items-center gap-2.5 lg:hidden">
+				<span
+					class="grid h-9 w-9 place-items-center rounded-md bg-primary font-bold text-primary-foreground"
+				>
+					ข
+				</span>
+				<span class="text-base font-semibold tracking-tight">Khao Pad</span>
+			</div>
+
+			<div class="mb-6">
+				<h1 class="text-2xl font-semibold tracking-tight">{m.cms_sign_in()}</h1>
+				<p class="mt-1.5 text-sm text-muted-foreground">{m.cms_sign_in_description()}</p>
+			</div>
+
+			{#if data.bootstrapNeeded}
+				<Card class="mb-5 border-dashed bg-muted/30">
+					<CardContent class="p-4">
+						<p class="text-sm">
+							No admin exists yet.
+							<a href="/cms/signup" class="font-medium text-primary underline-offset-4 hover:underline"
+								>{m.cms_sign_up()}</a
+							>
+						</p>
+					</CardContent>
+				</Card>
 			{/if}
 
-			<div>
-				<label for="email" class="block text-sm font-medium mb-1">{m.cms_email()}</label>
-				<input
-					id="email"
-					type="email"
-					bind:value={email}
-					required
-					class="w-full px-3 py-2 border border-input rounded-md bg-background text-sm"
-					placeholder="admin@example.com"
-				/>
-			</div>
+			<form onsubmit={handleLogin} class="space-y-4">
+				{#if error}
+					<div
+						class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+					>
+						{error}
+					</div>
+				{/if}
 
-			<div>
-				<label for="password" class="block text-sm font-medium mb-1">{m.cms_password()}</label>
-				<input
-					id="password"
-					type="password"
-					bind:value={password}
-					required
-					class="w-full px-3 py-2 border border-input rounded-md bg-background text-sm"
-				/>
-			</div>
+				<div class="space-y-1.5">
+					<Label for="email">{m.cms_email()}</Label>
+					<Input
+						id="email"
+						type="email"
+						bind:value={email}
+						required
+						autocomplete="email"
+						placeholder="admin@example.com"
+					/>
+				</div>
 
-			<button
-				type="submit"
-				disabled={loading}
-				class="w-full px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm hover:opacity-90 disabled:opacity-50"
-			>
-				{loading ? m.cms_signing_in() : m.cms_sign_in()}
-			</button>
-		</form>
-	</div>
+				<div class="space-y-1.5">
+					<Label for="password">{m.cms_password()}</Label>
+					<Input
+						id="password"
+						type="password"
+						bind:value={password}
+						required
+						autocomplete="current-password"
+					/>
+				</div>
+
+				<Button type="submit" disabled={loading} class="w-full">
+					{loading ? m.cms_signing_in() : m.cms_sign_in()}
+					<ArrowRight class="h-4 w-4" />
+				</Button>
+			</form>
+		</div>
+	</section>
 </div>

--- a/src/routes/(cms)/cms/signup/+page.svelte
+++ b/src/routes/(cms)/cms/signup/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import * as m from '$lib/paraglide/messages';
+	import { Button, Input, Label } from '$lib/components/ui';
+	import { ArrowRight, Crown } from 'lucide-svelte';
 
 	let { form }: { form: { ok?: boolean; error?: string } | null } = $props();
 	let loading = $state(false);
@@ -10,71 +12,118 @@
 	<title>{m.cms_sign_up()} — {m.cms_app_name()}</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center">
-	<div class="w-full max-w-sm">
-		<div class="text-center mb-8">
-			<h1 class="text-2xl font-bold">{m.cms_app_name()}</h1>
-			<p class="text-muted-foreground text-sm mt-2">{m.cms_sign_up_description()}</p>
+<div class="grid min-h-screen lg:grid-cols-2">
+	<!-- Left: brand panel -->
+	<aside
+		class="relative hidden flex-col justify-between overflow-hidden border-r border-border bg-sidebar-background p-10 text-sidebar-foreground lg:flex"
+	>
+		<div
+			aria-hidden="true"
+			class="pointer-events-none absolute -left-24 -top-24 h-72 w-72 rounded-full bg-primary/5 blur-3xl"
+		></div>
+		<div
+			aria-hidden="true"
+			class="pointer-events-none absolute -bottom-24 -right-24 h-80 w-80 rounded-full bg-primary/10 blur-3xl"
+		></div>
+
+		<a href="/" class="relative flex items-center gap-2.5">
+			<span
+				class="grid h-9 w-9 place-items-center rounded-md bg-primary font-bold text-primary-foreground"
+			>
+				ข
+			</span>
+			<span class="text-base font-semibold tracking-tight">Khao Pad</span>
+		</a>
+
+		<div class="relative max-w-md space-y-5">
+			<div class="inline-flex items-center gap-2 rounded-full border border-border bg-background/60 px-3 py-1 text-xs font-medium backdrop-blur">
+				<Crown class="h-3.5 w-3.5 text-primary" />
+				<span class="text-muted-foreground">First admin</span>
+			</div>
+			<h2 class="text-2xl font-semibold tracking-tight sm:text-3xl">
+				{m.cms_sign_up_description()}
+			</h2>
+			<p class="text-sm leading-relaxed text-muted-foreground">
+				{m.cms_sign_up_only_once()}
+			</p>
 		</div>
 
-		<form
-			method="POST"
-			class="space-y-4"
-			use:enhance={() => {
-				loading = true;
-				return async ({ update }) => {
-					await update();
-					loading = false;
-				};
-			}}
-		>
-			{#if form?.error}
-				<div class="bg-destructive/10 text-destructive text-sm p-3 rounded-md">
-					{form.error}
-				</div>
-			{/if}
+		<p class="relative text-xs text-muted-foreground">
+			© {new Date().getFullYear()} Khao Pad. MIT licensed.
+		</p>
+	</aside>
 
-			<div>
-				<label for="name" class="block text-sm font-medium mb-1">{m.cms_name()}</label>
-				<input
-					id="name"
-					name="name"
-					required
-					class="w-full px-3 py-2 border border-input rounded-md bg-background text-sm"
-				/>
+	<!-- Right: form -->
+	<section class="flex flex-col justify-center px-6 py-12 sm:px-12">
+		<div class="mx-auto w-full max-w-sm">
+			<div class="mb-8 flex items-center gap-2.5 lg:hidden">
+				<span
+					class="grid h-9 w-9 place-items-center rounded-md bg-primary font-bold text-primary-foreground"
+				>
+					ข
+				</span>
+				<span class="text-base font-semibold tracking-tight">Khao Pad</span>
 			</div>
 
-			<div>
-				<label for="email" class="block text-sm font-medium mb-1">{m.cms_email()}</label>
-				<input
-					id="email"
-					name="email"
-					type="email"
-					required
-					class="w-full px-3 py-2 border border-input rounded-md bg-background text-sm"
-					placeholder="admin@example.com"
-				/>
+			<div class="mb-6">
+				<h1 class="text-2xl font-semibold tracking-tight">{m.cms_sign_up()}</h1>
+				<p class="mt-1.5 text-sm text-muted-foreground">{m.cms_sign_up_description()}</p>
 			</div>
 
-			<div>
-				<label for="password" class="block text-sm font-medium mb-1">{m.cms_password()}</label>
-				<input
-					id="password"
-					name="password"
-					type="password"
-					required
-					minlength={8}
-					class="w-full px-3 py-2 border border-input rounded-md bg-background text-sm"
-				/>
-			</div>
-
-			<button
-				type="submit"
-				disabled={loading}
-				class="w-full px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm hover:opacity-90 disabled:opacity-50"
+			<form
+				method="POST"
+				class="space-y-4"
+				use:enhance={() => {
+					loading = true;
+					return async ({ update }) => {
+						await update();
+						loading = false;
+					};
+				}}
 			>
-				{loading ? m.cms_signing_up() : m.cms_sign_up()}
-			</button>
-		</form>
-	</div>
+				{#if form?.error}
+					<div
+						class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive"
+					>
+						{form.error}
+					</div>
+				{/if}
+
+				<div class="space-y-1.5">
+					<Label for="name">{m.cms_name()}</Label>
+					<Input id="name" name="name" required autocomplete="name" />
+				</div>
+
+				<div class="space-y-1.5">
+					<Label for="email">{m.cms_email()}</Label>
+					<Input
+						id="email"
+						name="email"
+						type="email"
+						required
+						autocomplete="email"
+						placeholder="admin@example.com"
+					/>
+				</div>
+
+				<div class="space-y-1.5">
+					<Label for="password">{m.cms_password()}</Label>
+					<Input
+						id="password"
+						name="password"
+						type="password"
+						required
+						minlength={8}
+						autocomplete="new-password"
+					/>
+					<p class="text-xs text-muted-foreground">Minimum 8 characters.</p>
+				</div>
+
+				<Button type="submit" disabled={loading} class="w-full">
+					{loading ? m.cms_signing_up() : m.cms_sign_up()}
+					<ArrowRight class="h-4 w-4" />
+				</Button>
+			</form>
+		</div>
+	</section>
 </div>


### PR DESCRIPTION
## Summary

Modernizes the CMS surface with the same design pattern as `codustry/workflow`'s dashboard. The bare layout that shipped in M3 is replaced with a proper application shell. **Stacked on top of #11** — that PR's commit will appear in this diff if viewed before #11 lands; the actual change unique to this PR is the shadcn reskin.

| Surface | Before | After |
|---|---|---|
| Layout shell | Plain 256px aside + bare nav | Collapsible Sidebar + sticky topbar + mobile sheet drawer |
| Login | Basic centered form | Two-column auth pattern (brand panel + form) |
| Signup | Basic centered form | Same two-column pattern |
| Theme | Simple oklch tokens | Workflow-style oklch palette + IBM Plex Sans Thai + dark-mode-ready |
| Components | None | Button, Input, Label, Card, Separator, Badge, Avatar in `$lib/components/ui/` |

## Highlights

**Hand-rolled `Sidebar`** (workflow's pattern, not shadcn's `Sidebar` primitive — more control over our nav shape):
- Persists collapsed state to `localStorage` (`khaopad:cms:sidebar:collapsed`)
- Lucide icons throughout (`LayoutDashboard`, `FileText`, `Image`, `Folder`, `Tag`, `Users`, `Settings`)
- Active-route highlighting that survives nested paths — `/cms/articles/[id]` keeps the Articles item active
- Role-gated items: Users + Settings hidden from `author`/`editor`
- Icon-only mode when collapsed, full labels when expanded, tooltips on hover

**Cookie-based locale toggle** (`CmsLocaleToggle`):
- Lives in the topbar, calls `setLocale(next)` from Paraglide runtime
- Strategy `["url","cookie","baseLocale"]` already does this — `/cms/*` has no `/en` or `/th` prefix to match, so it falls through to cookie automatically. Confirmed via [Paraglide docs](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/strategy).

**Logout** wired to `POST /api/auth/sign-out` then redirects to `/cms/login`.

**Avatar** with initials fallback when image fails to load — pattern lifted from workflow.

**Login + signup** redesign:
- Two-column layout on `lg+`: brand panel on the left (soft blurred primary-color shapes, IBM Plex tagline), form on the right
- Single-column stack on mobile
- Inputs/buttons use the new shadcn primitives so theme tokens flow

## Theme

`src/app.css` migrated to oklch tokens matching shadcn-svelte and workflow conventions. Added `.dark` block — the structure is in place so dark-mode toggle in a future PR doesn't require repainting. Larger base radii (0.5rem md). IBM Plex Sans Thai loaded via Google Fonts for clean Thai/Latin rendering.

## Out of scope (intentional)

- **CRUD pages** (articles list/edit, media, categories, tags) keep their existing markup. They use the same theme tokens, so the visual baseline lifts automatically. Per-page polish lands in follow-ups so this PR stays reviewable.
- **DropdownMenu / Sheet primitives** — used a hand-rolled overlay for the mobile drawer instead of pulling in another bits-ui surface.
- **Dark mode toggle UI** — palette ready, switch in a future PR.

## Verification

- [x] `pnpm check` — 0 errors (16 pre-existing warnings)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds (~127 kB server entry)
- [ ] Manual: visit `/cms/login` — desktop two-column layout renders; mobile collapses to single-column
- [ ] Manual: log in and verify sidebar collapses/expands and persists across reload
- [ ] Manual: switch language with the topbar EN/TH toggle — URL stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)