### PR TITLE
fix(auth): wrap D1 to coerce Date → ISO at bind time

### DIFF
--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -3,31 +3,74 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { drizzle } from "drizzle-orm/d1";
 import * as schema from "../content/schema";
 
+/**
+ * D1 + Better Auth date binding workaround.
+ *
+ * Better Auth's adapter factory passes JS Date objects directly to the
+ * Drizzle driver for any field declared as `type: "date"` (e.g.
+ * `createdAt`, `updatedAt`, `expiresAt`). Cloudflare D1's binding layer
+ * only accepts string / number / boolean / null / Uint8Array — it rejects
+ * Date with `D1_TYPE_ERROR: Type 'object' not supported`.
+ *
+ * `databaseHooks` won't help here because the transform layer runs AFTER
+ * hooks and converts ISO strings back to Date objects (see
+ * @better-auth/core/db/adapter/factory.mjs `transformInput`).
+ *
+ * The fix: proxy the D1 database so `prepare(sql).bind(...args)` swaps
+ * any Date in `args` for its ISO string form before Cloudflare sees it.
+ * Same effect for `D1PreparedStatement.bind`.
+ */
+function wrapD1ForDates(d1: D1Database): D1Database {
+  const coerce = (v: unknown): unknown => (v instanceof Date ? v.toISOString() : v);
+
+  return new Proxy(d1, {
+    get(target, prop, receiver) {
+      const original = Reflect.get(target, prop, receiver);
+      if (prop !== "prepare" || typeof original !== "function") return original;
+      return (sql: string) => {
+        const stmt = original.call(target, sql);
+        return new Proxy(stmt, {
+          get(stmtTarget, stmtProp) {
+            const inner = Reflect.get(stmtTarget, stmtProp);
+            if (stmtProp !== "bind" || typeof inner !== "function") return inner;
+            return (...args: unknown[]) => inner.call(stmtTarget, ...args.map(coerce));
+          },
+        });
+      };
+    },
+  });
+}
+
 export function createAuth(
   d1: D1Database,
   env: { BETTER_AUTH_SECRET: string; BETTER_AUTH_URL: string },
 ) {
-  const db = drizzle(d1, { schema });
+  const db = drizzle(wrapD1ForDates(d1), { schema });
 
   return betterAuth({
-    database: drizzleAdapter(db, { provider: "sqlite" }),
+    database: drizzleAdapter(db, {
+      provider: "sqlite",
+      // Better Auth's adapter looks for singular model names ("user",
+      // "session", "account", "verification"). Our Drizzle schema uses
+      // plural names. Pass the schema explicitly and map the names.
+      schema: {
+        user: schema.users,
+        session: schema.sessions,
+        account: schema.accounts,
+        verification: schema.verifications,
+      },
+    }),
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
     basePath: "/api/auth",
-    emailAndPassword: {
-      enabled: true,
-    },
+    emailAndPassword: { enabled: true },
     session: {
       expiresIn: 60 * 60 * 24 * 7, // 7 days
       updateAge: 60 * 60 * 24, // refresh daily
     },
     user: {
       additionalFields: {
-        role: {
-          type: "string",
-          defaultValue: "author",
-          input: false,
-        },
+        role: { type: "string", defaultValue: "author", input: false },
       },
     },
   });


### PR DESCRIPTION
## Summary

Signup at `/cms/signup` was returning **`FAILED_TO_CREATE_USER`** because Cloudflare D1's binding layer rejects JS `Date` objects with:

```
D1_TYPE_ERROR: Type 'object' not supported for value 'Mon Apr 27 2026 ...'
```

## Why this happens

Better Auth's adapter factory (`@better-auth/core/db/adapter/factory.mjs`'s `transformInput`) passes `Date` instances directly to the database driver for any field declared as `type: "date"` (`createdAt`, `updatedAt`, `expiresAt`, …) — relying on the driver to handle the type. The Drizzle adapter sets `supportsDates: true` (the default), so the factory leaves the Date untouched.

D1's binding layer only accepts string / number / boolean / null / Uint8Array. It rejects everything else.

The natural fix — `databaseHooks.user.create.before` returning ISO strings — does not work either: the factory's `transformInput` runs **after** hooks and on line 30 of factory.mjs it converts ISO strings *back* to `Date` objects when the field type is `"date"`. Hooks become no-ops.

## Fix

Proxy the D1 driver inside `createAuth` so `prepare(sql).bind(...args)` walks `args` and replaces any `Date` with its `.toISOString()` form before Cloudflare's binding code sees it. The proxy is local to the auth init — app code that uses the original D1 binding directly is unaffected.

## Verified live on the example fork

```
$ curl -X POST https://khaopad-example.codustry.workers.dev/api/auth/sign-up/email \\
  -H 'Content-Type: application/json' \\
  -d '{"name":"Test","email":"test@example.com","password":"testpass1234"}'
HTTP 200
{"token":"...","user":{"id":"...","name":"Test","email":"test@example.com",...}}
```

Real `/cms/signup` form submission also works end-to-end.

## Why this lives in `createAuth` and not at the schema layer

Two cleaner-looking alternatives were considered and rejected:

- **Change schema columns to `integer({ mode: 'timestamp' })`.** Requires a destructive D1 migration and the rest of the app (which reads/writes ISO strings) would need updating.
- **`databaseHooks` to coerce inputs.** Doesn't work — see "Why this happens" above. Verified empirically.

The driver-level proxy is the smallest possible surface area and isolates the workaround from the rest of the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)