### PR TITLE
fix(auth): pass request headers + harden getSession against bad cookies

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -231,10 +231,17 @@ const authHook: Handle = async ({ event, resolve }) => {
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
   });
 
-  // Resolve session from request cookies
-  const session = await auth.api.getSession({
-    headers: event.request.headers,
-  });
+  // Resolve session from request cookies. Wrap defensively: getSession
+  // can throw if the cookie is malformed or if a session-refresh write
+  // fails, and we don't want every page to 500 over auth lookup.
+  let session: Awaited<ReturnType<typeof auth.api.getSession>> = null;
+  try {
+    session = await auth.api.getSession({
+      headers: event.request.headers,
+    });
+  } catch {
+    session = null;
+  }
 
   if (session) {
     event.locals.user = session.user as unknown as App.Locals["user"];

--- a/src/routes/(cms)/cms/signup/+page.server.ts
+++ b/src/routes/(cms)/cms/signup/+page.server.ts
@@ -45,10 +45,13 @@ export const actions: Actions = {
     });
 
     // Better Auth creates the user + credential row in one batched call.
+    // Pass `headers` so the auto-sign-in path has request context for the
+    // session cookie write.
     let result;
     try {
       result = await auth.api.signUpEmail({
         body: { name, email, password },
+        headers: request.headers,
         asResponse: false,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

Two small auth-resilience improvements found while debugging the `/cms/signup` flow on `khaopad-example`:

### 1. Pass `request.headers` to `auth.api.signUpEmail`

Better Auth's signup endpoint sets a session cookie on auto-sign-in. When called from a SvelteKit form action without `headers`, it crashes with a generic "Internal Error" inside `setSessionCookie` because there's no request context to write the cookie against.

```ts
result = await auth.api.signUpEmail({
  body: { name, email, password },
+ headers: request.headers,
  asResponse: false,
});
```

### 2. Defensive try/catch around `auth.api.getSession` in `hooks.server.ts`

`getSession` runs on **every** request (the `authHook` resolves the user from cookies). If the cookie is malformed — or if any session-refresh DB write transiently fails — without a guard the entire site goes 500 until the cookie is cleared. Wrap it.

```ts
+ let session: Awaited<ReturnType<typeof auth.api.getSession>> = null;
+ try {
+   session = await auth.api.getSession({ headers: event.request.headers });
+ } catch {
+   session = null;
+ }
```

## Verified live

Both changes already in `khaopad-example@main`. End-to-end signup form POST returns `302 → /cms/login?bootstrapped=1` and creates a `super_admin` user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)