### PR TITLE
docs(milestones): mark v1.2 (user management + settings) as shipped

### DIFF
--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -94,24 +94,39 @@ A consolidation release: ship the architectural change everyone needs, modernize
 **Scope tightening (PR #17)**
 
 - Removed the never-shipped GitHub-backed "Mode B" content storage entirely (`src/lib/server/content/providers/github.ts`, `CONTENT_MODE` env var, `GITHUB_*` config knobs, `.github/workflows/content-sync.yml`). Doubled the bug surface for hypothetical users; broke at media (R2 isn't versioned); confused the product pitch. The `ContentProvider` interface stays as a seam for tests.
-- Sidebar entries for `/cms/users` and `/cms/settings` removed (#16) — the routes were referenced but had no `+page.svelte`. Re-added in v1.2 below when the pages exist.
+- Sidebar entries for `/cms/users` and `/cms/settings` removed (#16) — the routes were referenced but had no `+page.svelte`. Re-added in v1.2 (#20).
 
 **Net effect:** ~500 lines deleted, 6 PRs merged (#11–#13, #14–#16, #17). README, ARCHITECTURE, CONTENT-MODEL, MIGRATING, CLAUDE.md all updated to match. Live demo at `khaopad-example.codustry.workers.dev` runs all of v1.1 end-to-end.
 
+### v1.2 — User & settings management (PR #20)
+
+Closes the two sidebar 404s left by v1.1. Pure UI work on top of infrastructure that was already in place: the `users` table from M3, the `site_settings` table from M2, and the `ContentProvider.getSettings`/`updateSettings` methods that have existed in the interface since day one.
+
+**`/cms/users`** — list view with avatar, role badge, joined date.
+
+- Inline per-row role change with a dropdown.
+- Last-super-admin demotion blocked with a clear error.
+- Plain admins can manage editors and authors but not other admins or super_admins.
+- Hard-delete with confirm; sessions and accounts cascade via existing FK rules; articles authored by the user block the delete with a surfaced "reassign first" message instead of a 500.
+- Cannot change your own role or delete yourself.
+- Every role change and deletion writes an `audit_log` row (best-effort, swallowed if the table isn't available so it never fails the action).
+- Invite-link card surfaces the existing `/cms/signup` flow as the MVP. A real token-based invite system is deferred to a later release.
+
+**`/cms/settings`** — form for `siteName`, `defaultLocale`, `supportedLocales`, `cdnBaseUrl`. Validates `defaultLocale` is in `supportedLocales`; site name required; at least one locale required. Reads from + writes to the existing `site_settings` table via `ContentProvider`.
+
+**Permission helper** — new `canManageUser(actor, target)` centralizes three rules (no self-management, super_admin protection, admin-can't-touch-admin). Both server actions and the UI use it, so the buttons that appear match the actions that succeed.
+
+**Sidebar** — `/cms/users` and `/cms/settings` re-added to the "Admin" group, role-gated to `super_admin` and `admin`.
+
+**i18n** — 38 new Paraglide keys (EN + TH) covering role labels, field labels, help text, error strings, invite-card copy.
+
 ## Pending
-
-### v1.2 — User & settings management
-
-The most-requested gaps after v1.1, both flagged by sidebar 404s on the live demo.
-
-- **`/cms/users`** — list users, change roles, soft-delete, invite-by-email link (no actual email sending — copyable URL).
-- **`/cms/settings`** — site name, default locale, SEO defaults, branding (logo upload to R2). Stored in the existing `site_settings` D1 table.
-- Re-add both items to the admin sidebar once the pages exist.
 
 ### v1.3+ — Future ideas (not committed)
 
 - OAuth providers (Google, GitHub) for multi-admin sites that don't want to manage passwords.
-- Audit trail (who edited what, when) — schema is ready (`audit_log` table), needs UI + write hooks.
+- Token-based user invitations — replace the v1.2 "share /cms/signup" placeholder with one-shot signed links + role assignment on accept.
+- Audit-log viewer page — write hooks already exist for user changes; needs UI + write hooks for article/category/tag actions.
 - Content versioning / diff view per article.
 - Scheduled publishing (set `publishedAt` in the future, public site respects it).
 - Full-text search via D1 FTS5 or KV-indexed.


### PR DESCRIPTION
Promotes the v1.2 section from Pending to Shipped after PR #20 landed. Refines the v1.3+ wishlist.