### PR TITLE
fix(cms): redirect bare /cms to dashboard or login

### DIFF
--- a/src/routes/(cms)/cms/+page.server.ts
+++ b/src/routes/(cms)/cms/+page.server.ts
@@ -1,0 +1,13 @@
+import { redirect } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
+
+/**
+ * Bare `/cms` has no content of its own — it's just the prefix for the
+ * admin surface. Send authenticated users to the dashboard, everyone else
+ * to the login page. The auth state is already resolved on locals by the
+ * (cms) layout.
+ */
+export const load: PageServerLoad = async ({ locals }) => {
+  if (locals.user) throw redirect(302, "/cms/dashboard");
+  throw redirect(302, "/cms/login");
+};


### PR DESCRIPTION
Visiting `/cms` returned 404 because the route had no `+page.svelte`. Add a redirect-only `+page.server.ts`:

- Authenticated → `/cms/dashboard`
- Unauthenticated → `/cms/login`

Caught on the live demo.