### PR TITLE
fix(settings): treat undefined/null as delete in D1ContentProvider.updateSettings

### DIFF
--- a/src/lib/server/content/providers/d1.ts
+++ b/src/lib/server/content/providers/d1.ts
@@ -564,6 +564,18 @@ export class D1ContentProvider implements ContentProvider {
     const now = new Date().toISOString();
 
     for (const [key, value] of Object.entries(data)) {
+      // A `value` of `undefined` means "field omitted by the caller" — most
+      // commonly an optional form field left blank. We treat that as a
+      // delete so the row goes away (caller can re-create later) and the
+      // NOT NULL `value` column never sees a null bind. `null` is treated
+      // the same way for symmetry.
+      if (value === undefined || value === null) {
+        await this.db
+          .delete(schema.siteSettings)
+          .where(eq(schema.siteSettings.key, key));
+        continue;
+      }
+
       const serialized =
         typeof value === "string" ? value : JSON.stringify(value);
       const existing = await this.db


### PR DESCRIPTION
Fixes `/cms/settings` crash when an optional form field is blank.

Reported on the live demo: changing site name to "Khao Pad (ข้าวผัด)" returned `D1_ERROR: NOT NULL constraint failed: site_settings.value`.

Cause: `updateSettings` upserts every key in the patch payload. `JSON.stringify(undefined)` returns the JS value `undefined`, not the string "undefined" — Drizzle then binds NULL and the NOT NULL constraint fails. The bad row was `cdnBaseUrl` (left blank in the form), batched alongside `siteName`, so the error surface looked like "site name failed" but it was actually the empty CDN field.

Fix: treat `undefined`/`null` as a delete. The row goes away cleanly, the caller can recreate it later with a real value, and the NOT NULL column never sees a null bind.