### PR TITLE
fix(media): drop stale surface gate that 404'd every upload/delete

### DIFF
--- a/src/routes/api/media/+server.ts
+++ b/src/routes/api/media/+server.ts
@@ -13,14 +13,13 @@ const ALLOWED_PREFIXES = ["image/", "video/", "audio/", "application/pdf"];
  * resulting MediaRecord.
  */
 export const POST: RequestHandler = async ({ request, locals }) => {
-  // Auth: author+ may upload.
+  // Auth: author+ may upload. (No surface gate — `/api/*` is shared between
+  // surfaces under path-prefix routing; the auth check above is the real gate.
+  // Pre-v1.1 this also checked `locals.subdomain === "cms"` because the CMS
+  // ran on its own host; with path-prefix routing every `/api/*` request
+  // classifies as the `www` surface, so that check 404'd every upload.)
   if (!locals.user) throw error(401, "Not authenticated");
   if (!hasRole(locals.user, "author")) throw error(403, "Forbidden");
-
-  // We only allow uploads on the CMS subdomain — the www surface is read-only.
-  if (locals.subdomain !== "cms") {
-    throw error(404, "Not found");
-  }
 
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.includes("multipart/form-data")) {

--- a/src/routes/api/media/[id]/+server.ts
+++ b/src/routes/api/media/[id]/+server.ts
@@ -32,7 +32,8 @@ export const GET: RequestHandler = async ({ locals, params, setHeaders }) => {
 export const DELETE: RequestHandler = async ({ locals, params }) => {
   if (!locals.user) throw error(401, "Not authenticated");
   if (!hasRole(locals.user, "admin")) throw error(403, "Forbidden");
-  if (locals.subdomain !== "cms") throw error(404, "Not found");
+  // No surface gate: `/api/*` classifies as `www` under path-prefix routing
+  // (see POST /api/media). The role check above is the real gate.
 
   const record = await locals.media.get(params.id);
   if (!record) throw error(404, "Not found");


### PR DESCRIPTION
## Summary
- `POST /api/media` and `DELETE /api/media/[id]` checked `locals.subdomain !== \"cms\"` and threw 404 — a leftover from the pre-v1.1 subdomain layout.
- Under path-prefix routing (v1.1+), `surfaceHook` classifies surface from `event.url.pathname` via `isCmsPath()`, which only matches `/cms` or `/cms/*`. Every `/api/*` request classifies as `www`, so the gate 404'd every upload and delete from the CMS UI.
- Fix: remove the surface check from both endpoints. The `hasRole()` auth check is the real gate; branching on path-prefix at an `/api/media` endpoint adds nothing.

## Test plan
- [x] `pnpm build` succeeds.
- [ ] After deploy: from `/cms/media`, drag-upload an image and confirm a 201 + library refresh.
- [ ] From `/cms/media`, delete a media row and confirm a 204 + row removed.
- [ ] Confirm `GET /api/media/[id]` (public stream) is unchanged — no role gate, no surface gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)