### PR TITLE
fix(cms): pin desktop sidebar to viewport so long pages scroll alone

### DIFF
--- a/src/routes/(cms)/cms/+layout.svelte
+++ b/src/routes/(cms)/cms/+layout.svelte
@@ -44,8 +44,17 @@
 	{@render children()}
 {:else}
 	<div class="flex min-h-screen bg-background">
-		<!-- Desktop sidebar (lg+) -->
-		<div class="hidden shrink-0 lg:block">
+		<!--
+			Desktop sidebar (lg+).
+
+			Sticky to the viewport so long pages (settings, audit log,
+			navigation manager, history timeline, etc.) scroll their
+			content while the nav stays visible. `h-screen` clamps to
+			the viewport; `lg:sticky lg:top-0` keeps it pinned. The
+			inner <aside> is already `h-full` so it fills exactly that
+			height.
+		-->
+		<div class="hidden shrink-0 lg:block lg:sticky lg:top-0 lg:h-screen">
 			<Sidebar user={data.user} onLogout={logout} />
 		</div>
 


### PR DESCRIPTION
## Summary

The CMS desktop sidebar wrapper had no sticky positioning, so on any page taller than the viewport (settings, audit log, navigation manager, history timeline, etc.) the sidebar grew with the document and scrolled out of reach.

The inner \`<aside>\` is already \`h-full\` so giving the wrapper \`lg:sticky lg:top-0 lg:h-screen\` clamps it to the viewport without touching the component itself.

One-line fix; one shared layout; repairs every \`/cms/*\` page in one shot.

## Test plan

- [x] \`pnpm build\` succeeds
- [ ] After deploy: visit \`/cms/settings\` (long page) — sidebar stays pinned while form scrolls
- [ ] Same on \`/cms/audit\` (paginated log) — sidebar visible at all times
- [ ] Mobile drawer (\`< lg\`) unaffected — already \`fixed inset-y-0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)