### PR TITLE
fix: 7 ESLint errors blocking CI on fresh install (closes #47)

### DIFF
--- a/src/lib/components/consent/CookieBanner.svelte
+++ b/src/lib/components/consent/CookieBanner.svelte
@@ -46,6 +46,7 @@
 				<p class="font-medium text-foreground mb-1">{m.cookie_banner_title()}</p>
 				<p>
 					{m.cookie_banner_body()}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- privacy href is operator-supplied (always /[locale]/privacy-policy from layout); not a build-time route -->
 					<a href={privacyHref} class="underline hover:text-foreground">{m.cookie_banner_learn_more()}</a>
 				</p>
 				{#if detailsOpen}

--- a/src/lib/components/seo/Seo.svelte
+++ b/src/lib/components/seo/Seo.svelte
@@ -88,9 +88,16 @@
 		<meta name="twitter:site" content={defaults.twitter} />
 	{/if}
 
-	<!-- JSON-LD: one <script> per entry for maximum tooling compatibility -->
+	<!-- JSON-LD: one <script> per entry for maximum tooling compatibility.
+		 Using {@html} is required to emit a literal <script> tag (Svelte
+		 strips them in normal markup). The payload is server-built JSON
+		 from our own typed builders ($lib/seo) — never user input — and
+		 we escape any "</script>" sequence before injection so a JSON
+		 value can't break out of the tag. -->
 	{#each jsonLd as ld, i (i)}
-		{@html `<script type="application/ld+json">${JSON.stringify(ld)}<\/script>`}
+		{@const safeJson = JSON.stringify(ld).replace(/<\/script>/gi, '<\\/script>')}
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted: server-built JSON-LD with </script> escaped -->
+		{@html '<script type="application/ld+json">' + safeJson + '<' + '/script>'}
 	{/each}
 
 	<!-- RSS auto-discovery -->

--- a/src/lib/server/webhooks/index.ts
+++ b/src/lib/server/webhooks/index.ts
@@ -79,7 +79,9 @@ async function deliverOne(
   for (let attempt = 1; attempt <= MAX_INLINE_ATTEMPTS; attempt++) {
     const t0 = Date.now();
     let responseStatus: number | null = null;
-    let responseExcerpt: string | null = null;
+    // Assigned in every code path below; no initializer to satisfy
+    // no-useless-assignment.
+    let responseExcerpt: string | null;
     let ok = false;
     try {
       const ctrl = new AbortController();

--- a/src/routes/(cms)/cms/dashboard/+page.server.ts
+++ b/src/routes/(cms)/cms/dashboard/+page.server.ts
@@ -1,6 +1,6 @@
 import { redirect, error } from "@sveltejs/kit";
 import { drizzle } from "drizzle-orm/d1";
-import { desc, eq, and, gte } from "drizzle-orm";
+import { desc, eq, gte } from "drizzle-orm";
 import * as schema from "$lib/server/content/schema";
 import { canManageUsers } from "$lib/server/auth/permissions";
 import { AnalyticsService } from "$lib/server/analytics";

--- a/src/routes/(cms)/cms/media/+page.svelte
+++ b/src/routes/(cms)/cms/media/+page.svelte
@@ -34,8 +34,11 @@
 		Boolean(data.user && ['super_admin', 'admin', 'editor'].includes(data.user.role)),
 	);
 
-	// Build a parent → children map for the folder tree.
+	// Build a parent → children map for the folder tree. Local to the
+	// derived; never read reactively (rebuilt every invocation), so a
+	// plain Map is correct — no need for SvelteMap's reactivity overhead.
 	const childrenByParent = $derived.by(() => {
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local lookup, not reactive state
 		const map = new Map<string | null, MediaFolderRecord[]>();
 		for (const f of data.folders) {
 			const parent = f.parentId ?? null;

--- a/src/routes/(www)/[locale]/[...slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/[...slug]/+page.svelte
@@ -22,6 +22,7 @@
 		<h1 class="text-4xl font-bold mb-2">{data.title}</h1>
 	</header>
 	<div class="prose prose-neutral dark:prose-invert max-w-none">
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted: server-rendered markdown from CMS -->
 		{@html data.htmlContent}
 	</div>
 </article>


### PR DESCRIPTION
## Summary

Closes #47. CI's gate job runs \`pnpm run lint\` which fails on every push due to 7 legitimately-flagged code patterns. None are real bugs — each fix scoped narrowly:

| File | Rule | Fix |
|---|---|---|
| \`CookieBanner.svelte\` | \`svelte/no-navigation-without-resolve\` | privacyHref is operator-supplied — eslint-disable with rationale |
| \`Seo.svelte\` | \`svelte/no-at-html-tags\` + \`no-useless-escape\` | concat + escape \`</script>\` so JSON values can't break out; eslint-disable |
| \`webhooks/index.ts\` | \`no-useless-assignment\` | drop dead initializer on \`responseExcerpt\` |
| \`dashboard/+page.server.ts\` | \`@typescript-eslint/no-unused-vars\` | drop unused \`and\` import |
| \`media/+page.svelte\` | \`svelte/prefer-svelte-reactivity\` | local-scope Map in \`$derived.by\`, never reactive — eslint-disable |
| \`[locale]/[...slug]/+page.svelte\` | \`svelte/no-at-html-tags\` | trusted server-rendered markdown — same eslint-disable as blog/[slug] |

After:
\`\`\`
✖ 407 problems (0 errors, 407 warnings)
\`\`\`
407 warnings are all paraglide-generated files (gitignored in spirit) — separate cleanup.

## Test plan

- [x] \`pnpm run lint\` → 0 errors
- [x] \`pnpm run build\` succeeds
- [x] \`svelte-check\` unchanged
- [ ] After merge: deploy.yml gate job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)