### PR TITLE
fix: switch articles_fts to external-content FTS5 (closes #48)

### DIFF
--- a/drizzle/0011_fts5_external_content.sql
+++ b/drizzle/0011_fts5_external_content.sql
@@ -1,0 +1,73 @@
+-- Fix #48: switch articles_fts from a contentless FTS5 table to an
+-- external-content table (content='article_localizations',
+-- content_rowid='rowid').
+--
+-- The contentless pattern from migration 0002 requires the
+-- ('delete', old.rowid, …all column values…) tuple to **exactly
+-- match** what's stored in the index. Any drift — different
+-- normalization, trailing newline, prior failed REPLACE — makes the
+-- delete-trigger fail with SQLITE_ERROR. UPDATE inherits that fault.
+-- After-effect on the CMS: editors couldn't update or delete an
+-- article_localizations row once any drift had occurred.
+--
+-- The external-content pattern lets the trigger reference rowid
+-- alone:
+--   INSERT INTO articles_fts(articles_fts, rowid) VALUES('delete', old.rowid);
+-- — no column values to match against, so drift becomes a non-issue.
+-- And `rebuild` can recover from any inconsistency without dropping
+-- the table.
+--
+-- Migration steps:
+--   1. Drop the old triggers (must happen before dropping the table).
+--   2. Drop the old virtual table.
+--   3. Recreate as external-content.
+--   4. Rebuild the index from article_localizations in one shot.
+--   5. Recreate triggers using the simpler delete pattern.
+
+DROP TRIGGER IF EXISTS articles_fts_ai;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS articles_fts_ad;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS articles_fts_au;
+--> statement-breakpoint
+DROP TABLE IF EXISTS articles_fts;
+--> statement-breakpoint
+
+CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
+  title,
+  excerpt,
+  body,
+  locale UNINDEXED,
+  article_id UNINDEXED,
+  content = 'article_localizations',
+  content_rowid = 'rowid',
+  tokenize = 'unicode61 remove_diacritics 2'
+);
+--> statement-breakpoint
+
+-- Build the index from current state. With external-content, this
+-- reads from article_localizations directly (the `content =` link
+-- above tells FTS5 where to look).
+INSERT INTO articles_fts(articles_fts) VALUES('rebuild');
+--> statement-breakpoint
+
+-- Triggers — simpler than before because external-content tables
+-- only need rowid for delete (the source-of-truth values come from
+-- the linked table itself).
+
+CREATE TRIGGER IF NOT EXISTS articles_fts_ai AFTER INSERT ON article_localizations BEGIN
+  INSERT INTO articles_fts(rowid, title, excerpt, body, locale, article_id)
+  VALUES (new.rowid, new.title, COALESCE(new.excerpt, ''), new.body, new.locale, new.article_id);
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS articles_fts_ad AFTER DELETE ON article_localizations BEGIN
+  INSERT INTO articles_fts(articles_fts, rowid) VALUES('delete', old.rowid);
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER IF NOT EXISTS articles_fts_au AFTER UPDATE ON article_localizations BEGIN
+  INSERT INTO articles_fts(articles_fts, rowid) VALUES('delete', old.rowid);
+  INSERT INTO articles_fts(rowid, title, excerpt, body, locale, article_id)
+  VALUES (new.rowid, new.title, COALESCE(new.excerpt, ''), new.body, new.locale, new.article_id);
+END;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777709468165,
       "tag": "0010_windy_carmella_unuscione",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1778060000000,
+      "tag": "0011_fts5_external_content",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #48. Migrates \`articles_fts\` from a **contentless** to an **external-content** FTS5 virtual table. The contentless pattern from migration 0002 required \`('delete', old.rowid, …all column values…)\` tuples to match exactly — any drift broke UPDATE and DELETE on \`article_localizations\` with \`SQLITE_ERROR\`.

## What changed

Migration 0011 (\`drizzle/0011_fts5_external_content.sql\`):

1. Drop the three existing triggers + the old virtual table.
2. Recreate as external-content with \`content = 'article_localizations', content_rowid = 'rowid'\`.
3. \`INSERT INTO articles_fts(articles_fts) VALUES('rebuild')\` to populate from the linked table.
4. New triggers use the simpler delete pattern that needs only rowid:
   \`\`\`sql
   INSERT INTO articles_fts(articles_fts, rowid) VALUES('delete', old.rowid);
   \`\`\`

## Why external-content is the right fix

- **Drift becomes impossible.** Delete only references rowid; nothing to match against.
- **Recovery in one statement.** \`articles_fts(articles_fts) VALUES('rebuild')\` rebuilds the index from the source table without a DROP/CREATE.
- **Same query surface.** \`SELECT … FROM articles_fts WHERE articles_fts MATCH ?\` keeps working — the application code doesn't change.

## Live verification

Migration applied to khaopad-example-db. Reproduced the original bug pattern:

\`\`\`sql
INSERT INTO article_localizations (...) VALUES (...);   -- ok before fix
UPDATE article_localizations SET ... WHERE id='...';    -- threw SQLITE_ERROR before
DELETE FROM article_localizations WHERE id='...';        -- threw SQLITE_ERROR before
\`\`\`

After the fix: all three succeed. \`SELECT … FROM articles_fts WHERE articles_fts MATCH 'khao'\` still returns ranked snippets.

## Migration notes

- Migration 0011 already applied to live khaopad-example-db.
- Downstream installs need to apply 0011 via \`pnpm run db:migrate:remote\` (or equivalent).
- The migration is **idempotent** within itself (uses \`DROP IF EXISTS\` / \`CREATE IF NOT EXISTS\`) so re-running is safe.
- No data loss — the \`rebuild\` in step 3 reads from \`article_localizations\` (source of truth, untouched).

## Test plan

- [x] Migration applies cleanly on live D1
- [x] INSERT / UPDATE / DELETE all succeed on \`article_localizations\` after fix
- [x] \`articles_fts MATCH\` still returns ranked + snippet results
- [x] \`pnpm run build\` succeeds
- [ ] After deploy: edit an existing article via the CMS → save succeeds
- [ ] After deploy: delete an article via the CMS → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)