### PR TITLE
fix(ci): drop D1 migration step + add Paraglide compile to deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,11 @@ name: Deploy to Cloudflare Workers
 #   - Manual run with environment    → deploy to the chosen env
 #
 # Both paths run the same CI gates (check / lint / build) first, then
-# apply pending D1 migrations for that env, then deploy the Worker,
-# then probe the public URL as a smoke test.
+# deploy the Worker, then probe the public URL as a smoke test.
+#
+# Note: D1 migrations are applied out-of-band from a developer machine
+# (see the deploy step's NOTE for the exact command). This avoids
+# requiring D1 — Edit scope on the org-wide CLOUDFLARE_API_TOKEN.
 
 on:
   push:
@@ -116,14 +119,32 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Compile Paraglide messages
+        run: pnpm exec paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
+
       - run: pnpm build
 
-      - name: Apply D1 migrations (${{ needs.resolve-env.outputs.environment }})
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply khaopad-db --remote --env ${{ needs.resolve-env.outputs.environment }}
+      # NOTE: We deliberately do NOT run `d1 migrations apply` here.
+      # The conventional org-wide `CLOUDFLARE_API_TOKEN` for a Cloudflare
+      # account is created from the "Edit Cloudflare Workers" template,
+      # which only grants `Workers Scripts — Edit`. D1's REST API needs
+      # the separate `D1 — Edit` permission, so a migration step here
+      # returns:
+      #
+      #   The given account is not valid or is not authorized to access
+      #   this service [code: 7403]
+      #
+      # …even though the deploy step against the same account works fine.
+      # Apply migrations out-of-band from a developer machine instead:
+      #
+      #   CLOUDFLARE_ACCOUNT_ID=<account-id> \
+      #     pnpm exec wrangler d1 migrations apply khaopad-db --remote \
+      #       --env ${{ needs.resolve-env.outputs.environment }}
+      #
+      # If you want migrations in CI, create a repo-level
+      # CLOUDFLARE_API_TOKEN that adds D1 — Edit (it overrides the
+      # org-wide token for this repo only) and re-add a step here.
 
       - name: Deploy Worker (${{ needs.resolve-env.outputs.environment }})
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary

Two CI bugs that bite every fresh fork of khaopad. Both surfaced when bootstrapping `codustry/drvakuum-website` from this template — would have hit `codustry/bactrack-website` too if it weren't for the workaround in its deploy.yml.

### 1. D1 migration step fails with 7403

Symptom on a fresh fork after wiring `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` correctly:

\`\`\`
✘ ERROR  A request to the Cloudflare API
  /accounts/<id>/d1/database/<id>/query failed.

  The given account is not valid or is not authorized to access
  this service [code: 7403]
\`\`\`

Even though the deploy step against the same account works fine.

**Root cause:** the conventional org-wide `CLOUDFLARE_API_TOKEN` is created from the "Edit Cloudflare Workers" template, which only grants `Workers Scripts — Edit`. D1's REST API needs the separate `D1 — Edit` permission. The 7403 error message doesn't mention permissions, which makes this hard to diagnose.

**Fix:** drop the D1 step entirely, document the out-of-band command inline. Same pattern `codustry/bactrack-website` settled on (their deploy.yml has the same comment block I'm proposing here).

If a fork wants migrations in CI, they can create a repo-level `CLOUDFLARE_API_TOKEN` with `D1 — Edit` added (it overrides the org-wide one for that repo only) and re-add a migration step.

### 2. Deploy job missing Paraglide compile

The `deploy` job runs `pnpm build` without first compiling Paraglide messages. `src/lib/paraglide` is gitignored, and each GitHub Actions job gets a fresh runner — so the gate job's compile output doesn't carry over. On any non-trivial fork the build fails on missing imports from `\$lib/paraglide/messages`.

**Fix:** add the same compile step the gate job already has.

## Test plan

- [x] Verified the same workflow shape (D1 step removed, paraglide compile added to deploy job) on `codustry/drvakuum-website` — first deploy went green: gate ✅ resolve-env ✅ deploy ✅ smoke-test ✅
- [x] Worker live at https://drvakuum-website.codustry.workers.dev
- [x] Migrations applied locally with the documented command

🤖 Generated with [Claude Code](https://claude.com/claude-code)