### PR TITLE
security: __Host- session cookie + CSP + hardening headers (follow-up to #64)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,97 @@
+# Security posture
+
+Khao Pad ships single-host: public content at `/` and admin at `/admin/*` share the same origin. That makes the primary threat model **stored-XSS in user-generated content on the public surface exfiltrating admin cookies**, not cross-origin CSRF. Every defense below serves that model.
+
+## Session cookie
+
+Configured in `src/lib/server/auth/index.ts`. In production:
+
+- **Name**: `__Host-khaopad_session`
+- **`Secure`**: `true` (HTTPS-only)
+- **`HttpOnly`**: `true` (not readable from `document.cookie`)
+- **`SameSite`**: `Lax` (sent on top-level navigations, blocked on cross-site subresources)
+- **`Path`**: `/`
+- **`Domain`**: not set → host-only (cookie only sent to the exact origin)
+- **`__Host-` prefix**: browser enforces `Secure=true`, `Path=/`, no `Domain` — a rogue subdomain (if one is ever added) cannot set a cookie with this name
+
+### Why `__Host-` over `__Secure-`
+
+Better Auth's default in production is `__Secure-better-auth.session_token`. `__Secure-` mandates `Secure=true` but permits `Domain` and `Path` variations. `__Host-` additionally forbids `Domain` and mandates `Path=/` — the browser refuses to store the cookie unless those hold.
+
+Practical effect: if someone ever spins up `blog.example.com` next to `example.com`, they *cannot* set a cookie named `__Host-khaopad_session` targeting the admin. This is belt-and-braces against a future architectural change (see [OWASP Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) and RFC 6265bis §4.1.3.2).
+
+## Content Security Policy
+
+Configured in `src/hooks.server.ts` (`securityHeadersHook`). Two policies, one per surface:
+
+### Public (`/`, not `/admin/*`)
+
+```
+default-src 'self';
+script-src 'self';                  # no inline scripts — kills the primary XSS vector
+style-src 'self' 'unsafe-inline';   # svelte hydration needs per-component style attributes
+img-src 'self' data: blob: https:;  # data: for markdown-embedded, https: for R2 + external images
+media-src 'self' data: blob: https:;
+font-src 'self' data:;
+connect-src 'self';                 # comments + newsletter fetch, no external APIs
+frame-ancestors 'none';             # clickjacking defense
+form-action 'self';
+base-uri 'self';
+object-src 'none';
+```
+
+### Admin (`/admin/*`)
+
+Same as public. Admin is authenticated, so the primary threat class differs (a hostile admin has legitimate write access; CSP doesn't help there). Kept strict as defense-in-depth in case an author account is compromised.
+
+### Notable strictness choices
+
+- **`script-src 'self'` (no `unsafe-inline` or `unsafe-eval`)**: This is the single most impactful anti-XSS control. A stored `<script>alert(document.cookie)</script>` in a comment body simply doesn't execute. If a specific external script is ever needed, add its origin explicitly — never fall back to `'unsafe-inline'`.
+- **`frame-ancestors 'none'`** (+ `X-Frame-Options: DENY`): admin cannot be framed, so clickjacking-driven state changes are blocked.
+- **`connect-src 'self'`**: no external fetch. If analytics ever ships (e.g. PostHog Cloud), extend this to include the analytics origin explicitly.
+
+## Other headers
+
+- `X-Content-Type-Options: nosniff` — blocks MIME sniffing (used for JS-served-as-HTML attacks)
+- `Referrer-Policy: strict-origin-when-cross-origin` — narrows referrer leakage on outbound clicks
+- `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()` — denies feature-policy APIs we never use
+- `X-Frame-Options: DENY` — legacy anti-framing (paired with `frame-ancestors 'none'` for browsers that respect only one)
+
+HSTS is set by Cloudflare in front of the Worker; not managed here.
+
+## What's NOT in scope
+
+- **CSRF tokens for admin forms** — SvelteKit form actions POST to the same origin; `SameSite=Lax` blocks the cross-site CSRF vector cheaply. If we ever add cross-origin admin APIs, revisit.
+- **Rate limiting** — handled at Cloudflare edge (WAF rules), not framework
+- **DDoS** — Cloudflare edge
+- **2FA** — not implemented; deferred until v3.x if requested
+- **Session revocation UI** — Better Auth stores sessions in D1; a "log out everywhere" UI would query `sessions` table but isn't wired
+
+## Threats considered
+
+| Threat | Mitigation |
+|---|---|
+| Stored XSS in comment body → steal admin cookie | `HttpOnly` on cookie + `script-src 'self'` CSP |
+| Stored XSS in article body (author-authored) | Same as above; author trust boundary applies |
+| Sibling-subdomain cookie tossing (if `www.` or `admin.` is ever added) | `__Host-` prefix mandates host-only |
+| Clickjacking of admin actions | `frame-ancestors 'none'` + `X-Frame-Options: DENY` |
+| CSRF against admin form actions | `SameSite=Lax` cookie + same-origin form-action CSP |
+| MIME sniffing (JS-as-HTML) | `X-Content-Type-Options: nosniff` |
+| Referrer leaking session URL params | `Referrer-Policy: strict-origin-when-cross-origin` (and no session-in-URL anyway) |
+| Domain takeover of a forgotten subdomain | Not us to fix, but `__Host-` cookie means the takeover doesn't get the session |
+| Sensor/payment/mic API abuse from injected content | `Permissions-Policy` denies these |
+| SQL injection | Drizzle parameterized queries — never string-interpolate SQL |
+
+## Verifying in a deployed Worker
+
+```bash
+# From your machine, hit the deployed URL and inspect headers
+curl -sI https://khaopad-example.codustry.workers.dev/ | grep -iE 'csp|content-security|x-frame|x-content|referrer|permissions'
+curl -sI https://khaopad-example.codustry.workers.dev/admin/login | grep -iE 'csp|content-security|x-frame|x-content|referrer|permissions'
+```
+
+Session cookie inspection (browser devtools → Application → Cookies):
+- Name: `__Host-khaopad_session`
+- `HttpOnly` ✓, `Secure` ✓, `SameSite` = Lax
+- Domain column: empty (host-only)
+- Path: `/`

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -308,6 +308,84 @@ const cacheHook: Handle = async ({ event, resolve }) => {
   return response;
 };
 
+/**
+ * Security headers hook.
+ *
+ * The real threat model on a same-host admin (`/admin` on the same origin
+ * as public content) is stored-XSS in user-generated content exfiltrating
+ * the admin session cookie. HttpOnly on the cookie blocks the primary
+ * `document.cookie` vector; CSP closes off script injection at the source.
+ *
+ * We ship separate CSP for public and admin surfaces:
+ *
+ * - Public: strict — script-src 'self', no inline scripts, no eval.
+ *   Public HTML never legitimately needs inline JS; a stored-XSS payload
+ *   that would `<script>` under a permissive policy just gets refused.
+ *   `img-src` and `media-src` include `data:` and `blob:` for markdown-
+ *   embedded images/media; `connect-src` allows same-origin fetch for
+ *   comment forms + newsletter subscribe.
+ *
+ * - Admin: relaxed only where the shadcn/svelte-sonner stack needs it
+ *   (inline style attributes from bits-ui components). Scripts still
+ *   locked to 'self'. Admin is authenticated so external content injection
+ *   isn't the same threat class.
+ *
+ * Same-origin defenses beyond CSP:
+ * - `X-Content-Type-Options: nosniff` — kills MIME sniffing attacks
+ * - `Referrer-Policy: strict-origin-when-cross-origin` — narrows leakage
+ * - `Permissions-Policy` — denies sensor/camera/mic access we never use
+ * - HSTS is set by Cloudflare in front of the Worker; not our job
+ */
+const SECURITY_HEADERS_STATIC: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
+  "X-Frame-Options": "DENY",
+};
+
+const CSP_PUBLIC = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'", // Tailwind emits some inline styles at build; svelte hydration attaches per-component styles
+  "img-src 'self' data: blob: https:", // https: allows R2 CDN + external cover images
+  "media-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+].join("; ");
+
+const CSP_ADMIN = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "media-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+].join("; ");
+
+const securityHeadersHook: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+
+  for (const [name, value] of Object.entries(SECURITY_HEADERS_STATIC)) {
+    if (!response.headers.has(name)) response.headers.set(name, value);
+  }
+
+  if (!response.headers.has("Content-Security-Policy")) {
+    const isAdmin = event.locals.surface === "admin";
+    response.headers.set("Content-Security-Policy", isAdmin ? CSP_ADMIN : CSP_PUBLIC);
+  }
+
+  return response;
+};
+
 export const handle = sequence(
   surfaceHook,
   bindingsHook,
@@ -315,4 +393,5 @@ export const handle = sequence(
   paraglideLocaleHook,
   authHook,
   cacheHook,
+  securityHeadersHook,
 );

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -76,6 +76,24 @@ export function createAuth(
         role: { type: "string", defaultValue: "author", input: false },
       },
     },
+    advanced: {
+      /**
+       * Force the __Host- cookie prefix on the session cookie.
+       *
+       * Better Auth's default in production is `__Secure-better-auth.session_token`,
+       * which requires Secure=true but permits Domain/Path variations. `__Host-`
+       * additionally mandates Path=/ and forbids Domain — the browser enforces
+       * that no subdomain (however friendly) can set a cookie with this name.
+       *
+       * Khao Pad already ships single-host at /admin — this is belt-and-braces
+       * against a future subdomain being added and inheriting cookie trust.
+       *
+       * See RFC 6265bis §4.1.3.2, OWASP Session Management Cheat Sheet.
+       */
+      cookies: {
+        session_token: { name: "__Host-khaopad_session" },
+      },
+    },
   });
 }
 


### PR DESCRIPTION
Follow-up to [#64](https://github.com/codustry/khaopad/issues/64) / [PR #65](https://github.com/codustry/khaopad/pull/65). Locks down the same-origin threat model that comes with public + admin sharing a host: **stored-XSS in user content stealing admin session cookies**.

Everything from the #64 spec that #65 deliberately deferred as \"conceptually separate.\"

## What ships

### 1. Session cookie hardening (`src/lib/server/auth/index.ts`)

- Cookie name forced to \`__Host-khaopad_session\` via Better Auth's \`advanced.cookies\` override
- Browser now enforces \`Secure=true\` + \`Path=/\` + no \`Domain\` — a rogue subdomain (if ever added) *cannot* set a cookie with this name
- Better Auth's other defaults already correct in prod: \`HttpOnly=true\`, \`SameSite=Lax\`, host-only

### 2. Content Security Policy (\`src/hooks.server.ts\`)

New \`securityHeadersHook\` at the end of \`sequence()\`. Per-surface CSP (public + admin both strict):

\`\`\`
default-src 'self';
script-src 'self';                 # kills primary stored-XSS vector
style-src 'self' 'unsafe-inline';  # svelte hydration + tailwind need it
img-src 'self' data: blob: https:; # data: for markdown, https: for R2 CDN
media-src 'self' data: blob: https:;
font-src 'self' data:;
connect-src 'self';
frame-ancestors 'none';            # clickjacking defense
form-action 'self';
base-uri 'self';
object-src 'none';
\`\`\`

### 3. Additional security headers

- \`X-Content-Type-Options: nosniff\`
- \`Referrer-Policy: strict-origin-when-cross-origin\`
- \`Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()\`
- \`X-Frame-Options: DENY\`

### 4. \`docs/security.md\` (new)

Full documentation of the threat model, cookie contract, CSP rationale, and a \`curl\` one-liner to verify headers post-deploy.

## Deliberately unchanged

- **\`SameSite=Lax\` (Better Auth default)** stays. \`SameSite=Strict\` breaks the return-from-email-verification flow.
- **HSTS not set here** — Cloudflare handles it at the edge.
- **No CSRF token library** — \`SameSite=Lax\` + same-origin \`form-action\` CSP cover SvelteKit's form actions.
- **2FA not added** — out of scope; deferred per #64.

## Threat table (from docs/security.md)

| Threat | Mitigation |
|---|---|
| Stored XSS in comment/article → steal admin cookie | \`HttpOnly\` cookie + \`script-src 'self'\` CSP |
| Sibling-subdomain cookie tossing (future \`admin.*\` or \`www.*\`) | \`__Host-\` prefix |
| Clickjacking of admin actions | \`frame-ancestors 'none'\` + \`X-Frame-Options: DENY\` |
| CSRF against admin form actions | \`SameSite=Lax\` + same-origin \`form-action\` |
| MIME sniffing (JS-as-HTML) | \`X-Content-Type-Options: nosniff\` |
| Sensor/mic/payment API abuse from injection | \`Permissions-Policy\` denies |
| SQL injection | Drizzle parameterized queries |

## Verify

- ✅ \`pnpm run check\`: 0 new errors (3 pre-existing paraglide errors, tracked in [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes in 11s

## Test plan

- [ ] Local: \`pnpm dev\`, login flow works end-to-end (cookie set correctly, session persists)
- [ ] Browser devtools → Application → Cookies: session cookie name is \`__Host-khaopad_session\` (dev may show without prefix on http; production only)
- [ ] Public page loads with no CSP violations in browser console
- [ ] Admin page loads with no CSP violations
- [ ] Markdown editor: image embed, media picker, all work
- [ ] Forms submit correctly (SvelteKit form actions)
- [ ] Post-deploy: \`curl -sI https://[url] | grep -iE 'csp|frame|content'\`

## Rollback

If CSP breaks something in production (rare, since we only forbid inline scripts):
- Comment out \`securityHeadersHook\` in the \`sequence()\` at bottom of \`src/hooks.server.ts\`
- Redeploy
- Investigate the violation via browser console \`Content-Security-Policy\` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)