### PR TITLE
feat(v3.0-1b): sidebar nav registry for plugin extensibility

### DIFF
--- a/src/lib/components/admin/Sidebar.svelte
+++ b/src/lib/components/admin/Sidebar.svelte
@@ -3,7 +3,7 @@
 	import { ChevronLeft, LogOut } from 'lucide-svelte';
 	import { Avatar, Separator } from '$lib/components/ui';
 	import { cn } from '$lib/utils';
-	import { navGroups, type NavItem } from './sidebar-nav';
+	import { listNavGroups, type NavItem } from './sidebar-nav';
 
 	type User = { name: string; role: string };
 
@@ -32,6 +32,11 @@
 	}
 
 	const currentPath = $derived(page.url.pathname);
+
+	// Snapshot the registry once per render — plugin boot must complete
+	// before the sidebar mounts, which it does since plugins register
+	// server-side at module load. Re-reading each render is cheap.
+	const groups = $derived(listNavGroups());
 
 	function isActive(href: string) {
 		// Exact match wins; otherwise treat as section root (e.g. /admin/articles
@@ -87,7 +92,7 @@
 
 	<!-- Navigation groups -->
 	<nav class="flex-1 overflow-y-auto p-2">
-		{#each navGroups as group, i (group.id)}
+		{#each groups as group, i (group.id)}
 			{@const items = visibleItems(group.items)}
 			{#if items.length > 0}
 				{#if i > 0}

--- a/src/lib/components/admin/sidebar-nav.ts
+++ b/src/lib/components/admin/sidebar-nav.ts
@@ -36,94 +36,188 @@ export type NavGroup = {
   items: ReadonlyArray<NavItem>;
 };
 
-export const navGroups: ReadonlyArray<NavGroup> = [
-  {
-    id: "main",
-    title: m.cms_app_name,
-    items: [
-      { href: "/admin/dashboard", label: m.cms_dashboard, icon: LayoutDashboard },
-      { href: "/admin/articles", label: m.cms_articles, icon: FileText },
-      {
-        href: "/admin/pages",
-        label: m.cms_pages,
-        icon: FilePlus,
-        roles: ["super_admin", "admin", "editor"],
-      },
-      { href: "/admin/media", label: m.cms_media, icon: ImageIcon },
-      {
-        href: "/admin/navigation",
-        label: m.cms_navigation,
-        icon: MenuIcon,
-        roles: ["super_admin", "admin", "editor"],
-      },
-    ],
+/**
+ * Runtime nav registry.
+ *
+ * Core groups + items are seeded at module load (below). Plugins call
+ * `registerNavGroup()` or `registerNavItem()` at boot to contribute
+ * their own entries — plugin groups appear after core groups in the
+ * sidebar; plugin items appended to an existing group appear after
+ * that group's core items.
+ *
+ * The Map preserves insertion order (ES2015+ guarantee) so ordering
+ * is stable + predictable. `listNavGroups()` returns a fresh snapshot
+ * on each call — do NOT hold onto the reference across plugin
+ * registrations, or you'll miss late-registering plugins.
+ */
+const registry = new Map<string, { title: () => string; items: NavItem[] }>();
+
+/**
+ * Register a new nav group. Idempotent on id — a second call with the
+ * same id updates the title (last write wins) but preserves items.
+ * Plugins wanting to contribute to an existing core group should use
+ * `registerNavItem()` instead.
+ */
+export function registerNavGroup(group: NavGroup): void {
+  const existing = registry.get(group.id);
+  if (existing) {
+    existing.title = group.title;
+    // Merge items — new ones appended, preserving core order.
+    for (const item of group.items) {
+      if (!existing.items.some((i) => i.href === item.href)) {
+        existing.items.push(item);
+      }
+    }
+    return;
+  }
+  registry.set(group.id, {
+    title: group.title,
+    items: [...group.items],
+  });
+}
+
+/**
+ * Append a nav item to an existing group. Silently no-ops if the
+ * group doesn't exist — plugins should register their group first
+ * (or accept that their items will only appear when the group
+ * they targeted is registered by someone else).
+ *
+ * Duplicate items (same href) are ignored — safe to call at every
+ * plugin boot.
+ */
+export function registerNavItem(groupId: string, item: NavItem): void {
+  const group = registry.get(groupId);
+  if (!group) return;
+  if (group.items.some((i) => i.href === item.href)) return;
+  group.items.push(item);
+}
+
+/**
+ * Snapshot of current nav groups. Called by Sidebar.svelte on each
+ * render (Svelte re-runs the derived that reads it whenever
+ * dependencies change). Returns groups in registration order.
+ */
+export function listNavGroups(): ReadonlyArray<NavGroup> {
+  return Array.from(registry.entries()).map(([id, { title, items }]) => ({
+    id,
+    title,
+    items: [...items] as ReadonlyArray<NavItem>,
+  }));
+}
+
+// ─── Core registration ─────────────────────────────────────────
+// Core groups + items registered at module load. Order determines
+// sidebar order; plugin groups will render after these.
+
+registerNavGroup({
+  id: "main",
+  title: m.cms_app_name,
+  items: [
+    { href: "/admin/dashboard", label: m.cms_dashboard, icon: LayoutDashboard },
+    { href: "/admin/articles", label: m.cms_articles, icon: FileText },
+    {
+      href: "/admin/pages",
+      label: m.cms_pages,
+      icon: FilePlus,
+      roles: ["super_admin", "admin", "editor"],
+    },
+    { href: "/admin/media", label: m.cms_media, icon: ImageIcon },
+    {
+      href: "/admin/navigation",
+      label: m.cms_navigation,
+      icon: MenuIcon,
+      roles: ["super_admin", "admin", "editor"],
+    },
+  ],
+});
+
+registerNavGroup({
+  id: "taxonomy",
+  title: m.cms_categories,
+  items: [
+    { href: "/admin/categories", label: m.cms_categories, icon: Folder },
+    { href: "/admin/tags", label: m.cms_tags, icon: Tag },
+    {
+      href: "/admin/blocks",
+      label: m.cms_blocks,
+      icon: Puzzle,
+      roles: ["super_admin", "admin", "editor"],
+    },
+    {
+      href: "/admin/forms",
+      label: m.cms_forms,
+      icon: Inbox,
+      roles: ["super_admin", "admin", "editor"],
+    },
+    {
+      href: "/admin/comments",
+      label: m.cms_comments,
+      icon: MessageSquare,
+      roles: ["super_admin", "admin", "editor"],
+    },
+  ],
+});
+
+registerNavGroup({
+  id: "admin",
+  title: m.cms_admin,
+  items: [
+    {
+      href: "/admin/users",
+      label: m.cms_users,
+      icon: Users,
+      roles: ["super_admin", "admin"],
+    },
+    {
+      href: "/admin/audit",
+      label: m.cms_audit,
+      icon: ScrollText,
+      roles: ["super_admin", "admin"],
+    },
+    {
+      href: "/admin/subscribers",
+      label: m.cms_subscribers,
+      icon: Mail,
+      roles: ["super_admin", "admin"],
+    },
+    {
+      href: "/admin/webhooks",
+      label: m.cms_webhooks,
+      icon: Webhook,
+      roles: ["super_admin", "admin"],
+    },
+    {
+      href: "/admin/api-keys",
+      label: m.cms_api_keys,
+      icon: KeyRound,
+      roles: ["super_admin", "admin"],
+    },
+    {
+      href: "/admin/settings",
+      label: m.cms_settings,
+      icon: Settings,
+      roles: ["super_admin", "admin"],
+    },
+  ],
+});
+
+/**
+ * @deprecated Use `listNavGroups()` — the direct array export captured
+ * groups at module load time and missed plugin registrations that
+ * happened after import. Kept as a live getter (Proxy) so old imports
+ * still work and always see the current set.
+ */
+export const navGroups = new Proxy([] as NavGroup[], {
+  get(_t, prop, receiver) {
+    return Reflect.get(listNavGroups(), prop, receiver);
   },
-  {
-    id: "taxonomy",
-    title: m.cms_categories,
-    items: [
-      { href: "/admin/categories", label: m.cms_categories, icon: Folder },
-      { href: "/admin/tags", label: m.cms_tags, icon: Tag },
-      {
-        href: "/admin/blocks",
-        label: m.cms_blocks,
-        icon: Puzzle,
-        roles: ["super_admin", "admin", "editor"],
-      },
-      {
-        href: "/admin/forms",
-        label: m.cms_forms,
-        icon: Inbox,
-        roles: ["super_admin", "admin", "editor"],
-      },
-      {
-        href: "/admin/comments",
-        label: m.cms_comments,
-        icon: MessageSquare,
-        roles: ["super_admin", "admin", "editor"],
-      },
-    ],
+  has(_t, prop) {
+    return Reflect.has(listNavGroups(), prop);
   },
-  {
-    id: "admin",
-    title: m.cms_admin,
-    items: [
-      {
-        href: "/admin/users",
-        label: m.cms_users,
-        icon: Users,
-        roles: ["super_admin", "admin"],
-      },
-      {
-        href: "/admin/audit",
-        label: m.cms_audit,
-        icon: ScrollText,
-        roles: ["super_admin", "admin"],
-      },
-      {
-        href: "/admin/subscribers",
-        label: m.cms_subscribers,
-        icon: Mail,
-        roles: ["super_admin", "admin"],
-      },
-      {
-        href: "/admin/webhooks",
-        label: m.cms_webhooks,
-        icon: Webhook,
-        roles: ["super_admin", "admin"],
-      },
-      {
-        href: "/admin/api-keys",
-        label: m.cms_api_keys,
-        icon: KeyRound,
-        roles: ["super_admin", "admin"],
-      },
-      {
-        href: "/admin/settings",
-        label: m.cms_settings,
-        icon: Settings,
-        roles: ["super_admin", "admin"],
-      },
-    ],
+  ownKeys(_t) {
+    return Reflect.ownKeys(listNavGroups());
   },
-];
+  getOwnPropertyDescriptor(_t, prop) {
+    return Object.getOwnPropertyDescriptor(listNavGroups(), prop);
+  },
+});


### PR DESCRIPTION
Second of ~5 sub-PRs building the v3.0 plugin runtime ([#55](https://github.com/codustry/khaopad/issues/55)). Follows [#67](https://github.com/codustry/khaopad/pull/67) (1a: open unions). Turns the hardcoded \`navGroups\` literal into a runtime registry.

## New API

\`\`\`ts
// $lib/components/admin/sidebar-nav.ts

registerNavGroup(group: NavGroup): void
  // Idempotent on id — second call updates title, merges items.
  // New groups appear after core groups (Map insertion order).

registerNavItem(groupId: string, item: NavItem): void
  // Appends to an existing group. No-ops if the group doesn't exist.
  // Duplicate hrefs ignored — safe to call at every plugin boot.

listNavGroups(): ReadonlyArray<NavGroup>
  // Fresh snapshot each call. Do NOT cache across plugin boot.
\`\`\`

## Refactor pattern

Core groups (\`main\`, \`taxonomy\`, \`admin\`) now register via the same \`registerNavGroup()\` API at module load. **Behavior identical** — same order, same items, same role gates, same look.

\`Sidebar.svelte\` switched from \`import { navGroups }\` (frozen literal) to \`import { listNavGroups }\` + a \`$derived\` snapshot. Cheap re-read each render; plugin registrations that happen server-side at module load are always visible.

## Backwards-compat

The old \`navGroups\` export stays as a **live Proxy** — reads from the registry each access, so any consumer that did \`import { navGroups }\` (there are none in this repo, but there could be in downstream forks) sees the current state including plugin registrations. Marked \`@deprecated\` in JSDoc.

## How a plugin will use this (preview — plugin runtime lands in 1d/1e)

\`\`\`ts
// src/plugins/shop/index.ts (hypothetical)
import { registerNavGroup, registerNavItem } from '\$lib/components/admin/sidebar-nav';
import { ShoppingCart, Package } from 'lucide-svelte';
import * as m from '\$lib/paraglide/messages';

registerNavGroup({
  id: 'shop',
  title: () => 'Shop',  // (plugin i18n will fold into paraglide in 1e)
  items: [
    { href: '/admin/shop/products', label: () => 'Products', icon: Package },
    { href: '/admin/shop/orders', label: () => 'Orders', icon: ShoppingCart, roles: ['super_admin', 'admin'] },
  ],
});

// Or contribute one item to an existing group:
registerNavItem('main', {
  href: '/admin/shop/dashboard',
  label: () => 'Shop overview',
  icon: LayoutDashboard,
});
\`\`\`

## Deliberately unchanged

- \`NavItem\` / \`NavGroup\` type shapes (no new fields)
- Role gate values (\`super_admin\` | \`admin\` | \`editor\` | \`author\` — plugins can't invent new roles yet, deferred until real need)
- \`Sidebar.svelte\` visual rendering — pixel-identical output

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only the 3 pre-existing paraglide errors from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes

## Test plan

- [ ] Local \`pnpm dev\`, log in as super_admin, visit \`/admin\` — sidebar renders identically to before (3 groups, same items, same order)
- [ ] Log out, log in as \`author\` (or lowest role) — role-gated items still hidden
- [ ] Collapse/expand sidebar — behavior unchanged
- [ ] Open devtools console and manually call \`(await import('\$lib/components/admin/sidebar-nav')).registerNavGroup({id:'test', title:()=>'Test', items:[{href:'/admin/test', label:()=>'Test item', icon: ...}]})\` — new group appears in sidebar (proves runtime registry works)

## Follow-ups

- **1c** — plugin schema concatenation + per-plugin migration folders (biggest lift)
- **1d** — Vite plugin for plugin route mounting + \`defineKhaopadPlugin()\`
- **1e** — \`@khaopad/plugin-hello\` + CLI + docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)