### PR TITLE
feat(v3.1-2a): shop plugin skeleton — proves runtime accepts a 2nd plugin

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -7,7 +7,7 @@ Curated list of plugins for Khao Pad. See [docs/plugin-authoring.md](./plugin-au
 | Plugin | Purpose | Status |
 |---|---|---|
 | `@khaopad/plugin-hello` (in-tree at `src/plugins/hello/`) | Reference plugin — exercises every extension point (sidebar, migration, route, audit, webhook) | 🟢 Ships with v3.0 |
-| `@khaopad/plugin-shop` | Small ecommerce for Thailand-first sites: products, variants, cart, BeamCheckout | 🟡 Planned v3.1 ([#56](https://github.com/codustry/khaopad/issues/56)) |
+| `@khaopad/plugin-shop` (in-tree at `src/plugins/shop/`) | Small ecommerce for Thailand-first sites: products, variants, cart, BeamCheckout | 🟡 v3.1 in progress — skeleton merged, catalog + admin CRUD next ([#56](https://github.com/codustry/khaopad/issues/56)) |
 | `@khaopad/plugin-reviews` | Product reviews with moderation, star ratings, `AggregateRating` JSON-LD | 🟡 Planned v3.4 ([#60](https://github.com/codustry/khaopad/issues/60)) |
 
 ## Community plugins

--- a/src/lib/plugins/registrations.ts
+++ b/src/lib/plugins/registrations.ts
@@ -20,6 +20,7 @@
  * `enabledPlugins` array in `runtime.ts`.
  */
 import hello from "$plugins/hello";
+import shop from "$plugins/shop";
 
 // Silence unused-import warnings — the import is the point (side effects).
-export const _pluginModules = [hello];
+export const _pluginModules = [hello, shop];

--- a/src/lib/plugins/runtime.ts
+++ b/src/lib/plugins/runtime.ts
@@ -24,8 +24,9 @@ import "./registrations";
 // Keep this list in sync with the imports in registrations.ts.
 
 import hello from "$plugins/hello";
+import shop from "$plugins/shop";
 
-const enabledPlugins: KhaopadPlugin[] = [hello];
+const enabledPlugins: KhaopadPlugin[] = [hello, shop];
 
 let initialized = false;
 let initPromise: Promise<void> | null = null;

--- a/src/plugins/shop/index.ts
+++ b/src/plugins/shop/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @khaopad/plugin-shop — small ecommerce for Thailand-first sites.
+ *
+ * Ships as an optional plugin so sites that don't sell anything stay
+ * lean. Uses the v3.0 plugin runtime.
+ *
+ * v3.1 scope (#56, in progress):
+ *   - Product catalog + variants (this milestone, incremental sub-PRs)
+ *
+ * v3.2 scope (#57):
+ *   - Cart, checkout, Beam payments, orders, shipping, tax, refunds
+ *
+ * Later:
+ *   - v3.4 discounts + abandoned cart (#60)
+ *   - v3.x Stripe + Omise adapters (#61)
+ *
+ * This first sub-PR (2a) ships only the plugin skeleton: registers
+ * itself into the runtime, contributes an empty admin section, wires
+ * up a placeholder route so the sidebar entry doesn't 404. The real
+ * shop tables + admin CRUD land in follow-up sub-PRs.
+ */
+import { ShoppingCart, Package, Boxes } from "lucide-svelte";
+import { defineKhaopadPlugin } from "$lib/plugins/types";
+import { registerNavGroup } from "$lib/components/admin/sidebar-nav";
+
+// Module-load registration — runs before the first render in both
+// client and server bundles. See docs/plugin-authoring.md.
+registerNavGroup({
+  id: "shop",
+  title: () => "Shop",
+  items: [
+    {
+      href: "/admin/shop/products",
+      label: () => "Products",
+      icon: Package,
+      roles: ["super_admin", "admin", "editor"],
+    },
+    {
+      href: "/admin/shop/collections",
+      label: () => "Collections",
+      icon: Boxes,
+      roles: ["super_admin", "admin", "editor"],
+    },
+    {
+      href: "/admin/shop/orders",
+      label: () => "Orders",
+      icon: ShoppingCart,
+      roles: ["super_admin", "admin"],
+    },
+  ],
+});
+
+export default defineKhaopadPlugin({
+  slug: "shop",
+  name: "Shop",
+  version: "0.1.0",
+  description:
+    "Small ecommerce: products, variants, cart, checkout (BeamCheckout for Thailand)",
+});

--- a/src/routes/(admin)/admin/shop/collections/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/collections/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirect } from "@sveltejs/kit";
+import { hasRole } from "$lib/server/auth/permissions";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  return {};
+};

--- a/src/routes/(admin)/admin/shop/collections/+page.svelte
+++ b/src/routes/(admin)/admin/shop/collections/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { Boxes } from 'lucide-svelte';
+</script>
+
+<div class="max-w-2xl space-y-4 p-6">
+	<header class="flex items-center gap-3">
+		<Boxes class="h-6 w-6 text-muted-foreground" />
+		<h1 class="text-2xl font-semibold">Collections</h1>
+	</header>
+	<div class="rounded-lg border border-dashed border-border p-8 text-center">
+		<p class="text-sm text-muted-foreground">
+			Collections ship alongside the product catalog in v3.1.
+		</p>
+	</div>
+</div>

--- a/src/routes/(admin)/admin/shop/orders/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/orders/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirect } from "@sveltejs/kit";
+import { hasRole } from "$lib/server/auth/permissions";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  if (!hasRole(locals.user, "admin")) throw redirect(302, "/admin");
+  return {};
+};

--- a/src/routes/(admin)/admin/shop/orders/+page.svelte
+++ b/src/routes/(admin)/admin/shop/orders/+page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { ShoppingCart } from 'lucide-svelte';
+</script>
+
+<div class="max-w-2xl space-y-4 p-6">
+	<header class="flex items-center gap-3">
+		<ShoppingCart class="h-6 w-6 text-muted-foreground" />
+		<h1 class="text-2xl font-semibold">Orders</h1>
+	</header>
+	<div class="rounded-lg border border-dashed border-border p-8 text-center">
+		<p class="text-sm text-muted-foreground">
+			Cart / checkout / orders ship in v3.2 (<a
+				href="https://github.com/codustry/khaopad/issues/57"
+				class="underline"
+				target="_blank"
+				rel="noopener">#57</a
+			>).
+		</p>
+	</div>
+</div>

--- a/src/routes/(admin)/admin/shop/products/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/products/+page.server.ts
@@ -1,0 +1,18 @@
+/**
+ * /admin/shop/products — placeholder for v3.1 product catalog.
+ *
+ * The real product list ships in a follow-up sub-PR (2b/2c) with the
+ * 7-table schema + CRUD editor. For now this just proves the route
+ * mount works end-to-end from the plugin skeleton.
+ */
+import { redirect } from "@sveltejs/kit";
+import { hasRole } from "$lib/server/auth/permissions";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  if (!hasRole(locals.user, "editor")) {
+    throw redirect(302, "/admin");
+  }
+  return {};
+};

--- a/src/routes/(admin)/admin/shop/products/+page.svelte
+++ b/src/routes/(admin)/admin/shop/products/+page.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Package } from 'lucide-svelte';
+</script>
+
+<div class="max-w-2xl space-y-4 p-6">
+	<header class="flex items-center gap-3">
+		<Package class="h-6 w-6 text-muted-foreground" />
+		<h1 class="text-2xl font-semibold">Products</h1>
+	</header>
+	<div class="rounded-lg border border-dashed border-border p-8 text-center">
+		<p class="text-sm text-muted-foreground">
+			Product catalog ships in v3.1 (<a
+				href="https://github.com/codustry/khaopad/issues/56"
+				class="underline"
+				target="_blank"
+				rel="noopener">#56</a
+			>). This placeholder confirms the shop plugin's routes mount correctly
+			under <code>/admin/shop/*</code>.
+		</p>
+	</div>
+</div>


### PR DESCRIPTION
First sub-PR of the v3.1 shop plugin ([#56](https://github.com/codustry/khaopad/issues/56)). Ships only the plugin skeleton — enough to prove the v3.0 plugin runtime accepts a second, real-domain plugin cleanly. Real catalog + admin CRUD land in follow-up sub-PRs.

## What ships

- `src/plugins/shop/index.ts` — shop plugin with slug \"shop\", version 0.1.0. Registers a \"Shop\" nav group with 3 items (Products, Collections, Orders) at module load
- Wired into `registrations.ts` + `runtime.ts`'s `enabledPlugins`
- 3 placeholder routes so nav clicks don't 404, each pointing at the milestone (#56 catalog, #57 orders)
- `docs/PLUGINS.md` status updated

## Role gates (from ADR)

- **Products / Collections**: editor+
- **Orders**: admin+ only (financial data)

## Sub-PR roadmap

- **2a (this)**: skeleton
- **2b**: 7-table Drizzle schema + migration, with design-review must-fixes folded in (SKU UNIQUE, variant status enum, batched titleCached refresh, order line-item snapshots)
- **2c**: admin product editor + variant matrix
- **2d**: public `/products/[slug]` + Product+Offer JSON-LD
- **2e**: public read API + inventory 3-state model + acceptance test

## Verify

- ✅ `pnpm run check`: 0 new errors (only 3 pre-existing paraglide errors from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ `pnpm run build`: passes

## Test plan

- [ ] Local `pnpm dev`, log in as super_admin — sidebar shows new \"Shop\" group at bottom with 3 items
- [ ] Click Products/Collections/Orders — each loads placeholder pages (no 404)
- [ ] Log in as editor — Orders hidden (admin+ only), Products/Collections visible
- [ ] Log in as author — all 3 shop items hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)