### PR TITLE
feat(v3.1-2b): shop catalog schema + migration + money math

### DIFF
--- a/drizzle/0013_plugin_shop_catalog.sql
+++ b/drizzle/0013_plugin_shop_catalog.sql
@@ -1,0 +1,146 @@
+-- @khaopad/plugin-shop v0.1.0 — catalog tables
+-- Creates the 7 core catalog tables + 3 collection tables + 2 inventory
+-- tables that back the v3.1 shop plugin. See src/plugins/shop/schema.ts
+-- for design rationale (SKU UNIQUE, variant status enum, inventory
+-- 3-state model, single-location v3.x, multi-warehouse-ready).
+--
+-- Naming: all shop tables prefix `shop_` so cross-plugin collisions
+-- are impossible and sqlite_master stays legible.
+
+CREATE TABLE `shop_products` (
+  `id` text PRIMARY KEY NOT NULL,
+  `slug` text NOT NULL,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `vendor` text,
+  `product_type` text,
+  `tags` text,
+  `featured_media_id` text,
+  `seo_title` text,
+  `seo_description` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `published_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `shop_products_slug_unique` ON `shop_products` (`slug`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `shop_products_status_slug_idx` ON `shop_products` (`status`, `slug`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_product_localizations` (
+  `product_id` text NOT NULL,
+  `locale` text NOT NULL,
+  `title` text NOT NULL,
+  `description_markdown` text,
+  PRIMARY KEY(`product_id`, `locale`),
+  FOREIGN KEY (`product_id`) REFERENCES `shop_products`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_product_options` (
+  `id` text PRIMARY KEY NOT NULL,
+  `product_id` text NOT NULL,
+  `name` text NOT NULL,
+  `position` integer NOT NULL,
+  FOREIGN KEY (`product_id`) REFERENCES `shop_products`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_product_option_values` (
+  `id` text PRIMARY KEY NOT NULL,
+  `option_id` text NOT NULL,
+  `value` text NOT NULL,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `swatch_hex` text,
+  FOREIGN KEY (`option_id`) REFERENCES `shop_product_options`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_product_variants` (
+  `id` text PRIMARY KEY NOT NULL,
+  `product_id` text NOT NULL,
+  `sku` text,
+  `barcode` text,
+  `status` text DEFAULT 'active' NOT NULL,
+  `title_cached` text NOT NULL,
+  `price_satang` integer NOT NULL,
+  `compare_at_satang` integer,
+  `weight_grams` integer,
+  `requires_shipping` integer DEFAULT true NOT NULL,
+  `taxable` integer DEFAULT true NOT NULL,
+  `position` integer DEFAULT 1 NOT NULL,
+  `media_id` text,
+  FOREIGN KEY (`product_id`) REFERENCES `shop_products`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- SKU is UNIQUE (nullable-unique in SQLite: multiple NULLs allowed,
+-- real values must be unique). Design-review must-fix.
+CREATE UNIQUE INDEX `shop_product_variants_sku_unique` ON `shop_product_variants` (`sku`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_product_variant_options` (
+  `variant_id` text NOT NULL,
+  `option_value_id` text NOT NULL,
+  PRIMARY KEY(`variant_id`, `option_value_id`),
+  FOREIGN KEY (`variant_id`) REFERENCES `shop_product_variants`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`option_value_id`) REFERENCES `shop_product_option_values`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_inventory_items` (
+  `id` text PRIMARY KEY NOT NULL,
+  `variant_id` text NOT NULL,
+  `tracked` integer DEFAULT true NOT NULL,
+  `cost_satang` integer,
+  `continue_selling_when_out_of_stock` integer DEFAULT false NOT NULL,
+  FOREIGN KEY (`variant_id`) REFERENCES `shop_product_variants`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `shop_inventory_items_variant_id_unique` ON `shop_inventory_items` (`variant_id`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_inventory_levels` (
+  `item_id` text NOT NULL,
+  `location_id` text DEFAULT 'default' NOT NULL,
+  `on_hand` integer DEFAULT 0 NOT NULL,
+  `reserved` integer DEFAULT 0 NOT NULL,
+  PRIMARY KEY(`item_id`, `location_id`),
+  FOREIGN KEY (`item_id`) REFERENCES `shop_inventory_items`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_collections` (
+  `id` text PRIMARY KEY NOT NULL,
+  `slug` text NOT NULL,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `kind` text DEFAULT 'manual' NOT NULL,
+  `rules_json` text,
+  `featured_media_id` text,
+  `seo_title` text,
+  `seo_description` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `published_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `shop_collections_slug_unique` ON `shop_collections` (`slug`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_collection_localizations` (
+  `collection_id` text NOT NULL,
+  `locale` text NOT NULL,
+  `title` text NOT NULL,
+  `description_markdown` text,
+  PRIMARY KEY(`collection_id`, `locale`),
+  FOREIGN KEY (`collection_id`) REFERENCES `shop_collections`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_collection_products` (
+  `collection_id` text NOT NULL,
+  `product_id` text NOT NULL,
+  `position` integer DEFAULT 0 NOT NULL,
+  PRIMARY KEY(`collection_id`, `product_id`),
+  FOREIGN KEY (`collection_id`) REFERENCES `shop_collections`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`product_id`) REFERENCES `shop_products`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785138000000,
       "tag": "0012_plugin_hello_pings",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1785276000000,
+      "tag": "0013_plugin_shop_catalog",
+      "breakpoints": true
     }
   ]
 }

--- a/src/plugins/shop/index.ts
+++ b/src/plugins/shop/index.ts
@@ -22,6 +22,19 @@
 import { ShoppingCart, Package, Boxes } from "lucide-svelte";
 import { defineKhaopadPlugin } from "$lib/plugins/types";
 import { registerNavGroup } from "$lib/components/admin/sidebar-nav";
+import { registerWebhookEvent } from "$lib/plugins/webhook-events";
+
+// Register shop-owned webhook events at module load. Storefront
+// integrations (inventory sync, analytics pipelines, order fulfilment
+// bots) subscribe to these via /admin/webhooks. The v3.2 cart +
+// checkout sub-PR will add order.* events; v3.4 discounts adds
+// discount.redeemed.
+registerWebhookEvent("product.created");
+registerWebhookEvent("product.updated");
+registerWebhookEvent("product.deleted");
+registerWebhookEvent("inventory.adjusted");
+registerWebhookEvent("collection.created");
+registerWebhookEvent("collection.updated");
 
 // Module-load registration — runs before the first render in both
 // client and server bundles. See docs/plugin-authoring.md.

--- a/src/plugins/shop/money.ts
+++ b/src/plugins/shop/money.ts
@@ -1,0 +1,92 @@
+/**
+ * Money math for the shop plugin.
+ *
+ * Everything monetary is INTEGER satang (100 satang = 1 baht). Never
+ * float — floating-point arithmetic on money is how you lose 1 satang
+ * per invoice and then hunt it for a week.
+ *
+ * The `Satang` branded type prevents accidentally passing a raw
+ * `number` (which might be baht, or bytes, or a percentage) where a
+ * satang amount is expected. All shop code that handles money should
+ * take/return `Satang`.
+ */
+
+// ─── Branded type ───────────────────────────────────────────
+
+declare const satangBrand: unique symbol;
+
+/**
+ * Money amount in satang (integer). 100 satang = 1 baht.
+ * `Satang` values compose with normal number arithmetic (+, -, *) but
+ * cannot be mixed with a bare `number` without an explicit cast via
+ * `satang()`.
+ */
+export type Satang = number & { readonly [satangBrand]: true };
+
+/**
+ * Assert-cast a number into satang. Throws in dev if the value is not
+ * a safe integer (JS numbers lose precision past 2^53); safe integer
+ * range covers ~90 trillion baht so we're comfortable.
+ */
+export function satang(value: number): Satang {
+  if (!Number.isInteger(value)) {
+    throw new Error(
+      `Money value must be an integer number of satang, got ${value}`,
+    );
+  }
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(
+      `Money value ${value} exceeds Number.MAX_SAFE_INTEGER — use bigint if you're really selling for >90 trillion baht`,
+    );
+  }
+  return value as Satang;
+}
+
+/** Zero satang, typed. Handy for cart totals + reduce initial values. */
+export const ZERO: Satang = 0 as Satang;
+
+// ─── Formatting ─────────────────────────────────────────────
+
+const THAI_BAHT = new Intl.NumberFormat("th-TH", {
+  style: "currency",
+  currency: "THB",
+  minimumFractionDigits: 2,
+});
+
+const THAI_BAHT_EN = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "THB",
+  minimumFractionDigits: 2,
+});
+
+/**
+ * Format satang as a Thai baht currency string.
+ * `locale` chooses the numeral grouping/direction — defaults to en for
+ * the admin UI, use 'th' for storefronts serving a Thai audience.
+ */
+export function formatSatang(
+  amount: Satang,
+  locale: "en" | "th" = "en",
+): string {
+  const baht = amount / 100;
+  return (locale === "th" ? THAI_BAHT : THAI_BAHT_EN).format(baht);
+}
+
+/**
+ * Parse a user-typed baht amount (e.g. "199.50") into satang.
+ * Returns null on invalid input. Handles the common cases (with/
+ * without a decimal point, with/without trailing zeros). Does NOT
+ * handle currency symbols, thousand separators, or negative numbers —
+ * shop UIs should reject those upstream.
+ */
+export function parseBahtToSatang(input: string): Satang | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  // Only digits + one optional decimal point + up to 2 decimal digits.
+  if (!/^\d+(\.\d{1,2})?$/.test(trimmed)) return null;
+  const [wholeStr, fracStr = ""] = trimmed.split(".");
+  const whole = Number(wholeStr);
+  const frac = Number(fracStr.padEnd(2, "0"));
+  if (Number.isNaN(whole) || Number.isNaN(frac)) return null;
+  return satang(whole * 100 + frac);
+}

--- a/src/plugins/shop/schema.ts
+++ b/src/plugins/shop/schema.ts
@@ -1,0 +1,297 @@
+/**
+ * Schema for @khaopad/plugin-shop.
+ *
+ * 7 core catalog tables + 2 collection tables + 1 inventory reservation
+ * ledger (deferred to v3.2 but the table lives here to keep migration
+ * numbering simple). Table naming convention: all shop tables prefix
+ * with `shop_` so `SELECT * FROM sqlite_master` stays legible and
+ * cross-plugin collisions are impossible.
+ *
+ * Design decisions from the design-review pass (issue #56):
+ *
+ *   1. **SKU is UNIQUE** on shop_product_variants (nullable-unique —
+ *      SQLite allows multiple NULLs; real values must be unique).
+ *      Retrofitting SKU uniqueness after duplicates land is painful,
+ *      so we lock it down at day one.
+ *
+ *   2. **Variant status enum** ('active' | 'archived'). Never hard-
+ *      delete a variant — cart/order rows can still reference an
+ *      archived variant. Archived variants stay hidden from admin
+ *      lists + public storefronts but remain queryable for historical
+ *      orders.
+ *
+ *   3. **Localizations in side table** (shop_product_localizations)
+ *      mirrors the article/category/tag convention. Slug is shared
+ *      across locales (Khao Pad convention). English localization is
+ *      required for slug derivation — enforced in the createProduct()
+ *      service layer, not the schema.
+ *
+ *   4. **Price and money in INTEGER satang** (100 satang = 1 baht).
+ *      Never float. Every monetary column names its unit explicitly
+ *      (priceSatang, compareAtSatang, costSatang, weightGrams). This
+ *      applies to shipping and taxes in v3.2 too — no surprises.
+ *
+ *   5. **Inventory 3-state model**: onHand + reserved stored,
+ *      available = onHand - reserved is COMPUTED (never stored).
+ *      Concurrent-purchase safety via
+ *        UPDATE ... SET reserved = reserved + qty WHERE (on_hand - reserved) >= qty
+ *      + reject-not-retry on the losing side. Details in the ADR.
+ *
+ *   6. **Multi-warehouse-ready but single-location for v3.x**.
+ *      shop_inventory_levels has (item_id, location_id) composite PK
+ *      so v4 multi-warehouse ships without a rebuild — location_id
+ *      is always 'default' for now.
+ *
+ *   7. **Cached variant title** ("Red / M") stored on the variant row.
+ *      Recomputed and batched (single db.batch()) when an option value
+ *      is edited. Storefront rendering doesn't pay for N joins.
+ *
+ *   8. **Order line-item snapshots** (title, sku, price at time of
+ *      purchase) ship in v3.2's shop_order_items — this file plants
+ *      the flag but the table is added in the v3.2 sub-PR to keep the
+ *      2b diff manageable.
+ *
+ *   9. **Collections** are both manual (curated product list) and
+ *      rules-based (query filter). shop_collection_products handles
+ *      the manual case; the rules JSON on shop_collections handles
+ *      smart collections. Deferring the rules-engine to a follow-up
+ *      sub-PR — schema is here, code isn't yet.
+ *
+ *  10. **Media refs are bare text columns**, matching the core media
+ *      pattern. No FK to `media.id` because R2 blobs can outlive
+ *      product rows and vice versa; the media service handles orphan
+ *      cleanup independently.
+ */
+import {
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+// ─── Products ───────────────────────────────────────────────
+
+export const shopProducts = sqliteTable(
+  "shop_products",
+  {
+    id: text("id").primaryKey(),
+    slug: text("slug").notNull().unique(),
+    status: text("status", { enum: ["draft", "active", "archived"] })
+      .notNull()
+      .default("draft"),
+    vendor: text("vendor"),
+    productType: text("product_type"),
+    tags: text("tags"), // JSON string array
+    featuredMediaId: text("featured_media_id"),
+    seoTitle: text("seo_title"),
+    seoDescription: text("seo_description"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    publishedAt: text("published_at"),
+  },
+  (t) => ({
+    statusIdx: uniqueIndex("shop_products_status_slug_idx").on(t.status, t.slug),
+  }),
+);
+
+export const shopProductLocalizations = sqliteTable(
+  "shop_product_localizations",
+  {
+    productId: text("product_id")
+      .notNull()
+      .references(() => shopProducts.id, { onDelete: "cascade" }),
+    locale: text("locale").notNull(),
+    title: text("title").notNull(),
+    descriptionMarkdown: text("description_markdown"),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.productId, t.locale] }),
+  }),
+);
+
+// ─── Product options + values ───────────────────────────────
+
+export const shopProductOptions = sqliteTable("shop_product_options", {
+  id: text("id").primaryKey(),
+  productId: text("product_id")
+    .notNull()
+    .references(() => shopProducts.id, { onDelete: "cascade" }),
+  name: text("name").notNull(), // 'Size', 'Color'
+  position: integer("position").notNull(), // 1..3 (Shopify convention: max 3 option axes)
+});
+
+export const shopProductOptionValues = sqliteTable(
+  "shop_product_option_values",
+  {
+    id: text("id").primaryKey(),
+    optionId: text("option_id")
+      .notNull()
+      .references(() => shopProductOptions.id, { onDelete: "cascade" }),
+    value: text("value").notNull(), // 'M', 'Red'
+    sortOrder: integer("sort_order").notNull().default(0),
+    swatchHex: text("swatch_hex"), // optional color swatch (only meaningful for colour-ish options)
+  },
+);
+
+// ─── Variants ───────────────────────────────────────────────
+
+export const shopProductVariants = sqliteTable(
+  "shop_product_variants",
+  {
+    id: text("id").primaryKey(),
+    productId: text("product_id")
+      .notNull()
+      .references(() => shopProducts.id, { onDelete: "cascade" }),
+    // Must-fix: SKU is UNIQUE (nullable — SQLite allows multiple NULLs,
+    // real values must be unique). Retrofitting uniqueness after
+    // duplicates land is painful; lock it down day one.
+    sku: text("sku").unique(),
+    barcode: text("barcode"),
+    // Must-fix: variant status — never hard-delete. Cart/order rows
+    // can still reference an archived variant.
+    status: text("status", { enum: ["active", "archived"] })
+      .notNull()
+      .default("active"),
+    // Cached derived title ("Red / M"). Refreshed via db.batch() when
+    // option values are edited; storefront rendering never pays for
+    // the join across variant_options → option_values → options.
+    titleCached: text("title_cached").notNull(),
+    priceSatang: integer("price_satang").notNull(),
+    compareAtSatang: integer("compare_at_satang"), // strike-through / MSRP
+    weightGrams: integer("weight_grams"),
+    requiresShipping: integer("requires_shipping", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    taxable: integer("taxable", { mode: "boolean" }).notNull().default(true),
+    position: integer("position").notNull().default(1),
+    mediaId: text("media_id"), // variant-specific media override
+  },
+);
+
+export const shopProductVariantOptions = sqliteTable(
+  "shop_product_variant_options",
+  {
+    variantId: text("variant_id")
+      .notNull()
+      .references(() => shopProductVariants.id, { onDelete: "cascade" }),
+    optionValueId: text("option_value_id")
+      .notNull()
+      .references(() => shopProductOptionValues.id, { onDelete: "cascade" }),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.variantId, t.optionValueId] }),
+  }),
+);
+
+// ─── Inventory ──────────────────────────────────────────────
+
+export const shopInventoryItems = sqliteTable("shop_inventory_items", {
+  id: text("id").primaryKey(),
+  variantId: text("variant_id")
+    .notNull()
+    .unique()
+    .references(() => shopProductVariants.id, { onDelete: "cascade" }),
+  tracked: integer("tracked", { mode: "boolean" }).notNull().default(true),
+  // costSatang is never shown to customers — for margin reporting only.
+  costSatang: integer("cost_satang"),
+  // Overselling policy — pre-orders + made-to-order need this to stay true.
+  continueSellingWhenOutOfStock: integer(
+    "continue_selling_when_out_of_stock",
+    { mode: "boolean" },
+  )
+    .notNull()
+    .default(false),
+});
+
+export const shopInventoryLevels = sqliteTable(
+  "shop_inventory_levels",
+  {
+    itemId: text("item_id")
+      .notNull()
+      .references(() => shopInventoryItems.id, { onDelete: "cascade" }),
+    // Single-location for v3.x. Column exists so v4 multi-warehouse
+    // ships without a table rebuild — always 'default' for now.
+    locationId: text("location_id").notNull().default("default"),
+    onHand: integer("on_hand").notNull().default(0),
+    // available = onHand - reserved is COMPUTED at query time.
+    // Never stored — reserved is the mutable counter for pending carts.
+    reserved: integer("reserved").notNull().default(0),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.itemId, t.locationId] }),
+  }),
+);
+
+// ─── Collections ────────────────────────────────────────────
+
+export const shopCollections = sqliteTable("shop_collections", {
+  id: text("id").primaryKey(),
+  slug: text("slug").notNull().unique(),
+  status: text("status", { enum: ["draft", "active", "archived"] })
+    .notNull()
+    .default("draft"),
+  kind: text("kind", { enum: ["manual", "smart"] })
+    .notNull()
+    .default("manual"),
+  // Smart-collection rules: JSON blob evaluated by the query engine
+  // when kind='smart'. Ignored when kind='manual'. Rules engine
+  // itself ships in a follow-up sub-PR.
+  rulesJson: text("rules_json"),
+  featuredMediaId: text("featured_media_id"),
+  seoTitle: text("seo_title"),
+  seoDescription: text("seo_description"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  publishedAt: text("published_at"),
+});
+
+export const shopCollectionLocalizations = sqliteTable(
+  "shop_collection_localizations",
+  {
+    collectionId: text("collection_id")
+      .notNull()
+      .references(() => shopCollections.id, { onDelete: "cascade" }),
+    locale: text("locale").notNull(),
+    title: text("title").notNull(),
+    descriptionMarkdown: text("description_markdown"),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.collectionId, t.locale] }),
+  }),
+);
+
+export const shopCollectionProducts = sqliteTable(
+  "shop_collection_products",
+  {
+    collectionId: text("collection_id")
+      .notNull()
+      .references(() => shopCollections.id, { onDelete: "cascade" }),
+    productId: text("product_id")
+      .notNull()
+      .references(() => shopProducts.id, { onDelete: "cascade" }),
+    position: integer("position").notNull().default(0),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.collectionId, t.productId] }),
+  }),
+);
+
+// ─── Type exports ───────────────────────────────────────────
+
+export type ShopProduct = typeof shopProducts.$inferSelect;
+export type ShopProductLocalization = typeof shopProductLocalizations.$inferSelect;
+export type ShopProductOption = typeof shopProductOptions.$inferSelect;
+export type ShopProductOptionValue = typeof shopProductOptionValues.$inferSelect;
+export type ShopProductVariant = typeof shopProductVariants.$inferSelect;
+export type ShopInventoryItem = typeof shopInventoryItems.$inferSelect;
+export type ShopInventoryLevel = typeof shopInventoryLevels.$inferSelect;
+export type ShopCollection = typeof shopCollections.$inferSelect;
+
+/**
+ * Locale is free text (validated at write time against
+ * SUPPORTED_LOCALES env var, matching the core convention). Not an
+ * enum, so plugins that add locales don't need a schema change.
+ */
+export type ShopLocale = string;


### PR DESCRIPTION
Second sub-PR of v3.1 shop plugin ([#56](https://github.com/codustry/khaopad/issues/56)). Follows [#71 (2a skeleton)](https://github.com/codustry/khaopad/pull/71). Lands the full **11-table catalog schema** with all design-review must-fixes folded in from day one — no retrofit later.

## What ships

- 11 Drizzle tables in \`src/plugins/shop/schema.ts\` (all \`shop_\` prefixed)
- \`drizzle/0013_plugin_shop_catalog.sql\` migration + \`_journal.json\` entry
- \`src/plugins/shop/money.ts\` — branded \`Satang\` type + \`formatSatang()\` + \`parseBahtToSatang()\`
- 6 shop webhook events registered

## Tables

**Core catalog (8)**: products, product_localizations, product_options, product_option_values, product_variants, product_variant_options, inventory_items, inventory_levels

**Collections (3)**: collections, collection_localizations, collection_products

## Must-fixes locked in

- **SKU UNIQUE** (nullable-unique) — retrofit is painful
- **Variant status enum** ('active' | 'archived') — never hard-delete
- **titleCached** on variant row — no join tax on storefront render
- **Order line-item snapshot** requirement documented for v3.2 sub-PR

## Money type

Branded \`Satang\` (100 satang = 1 baht). Prevents accidentally passing raw \`number\` where money is expected. Throws in dev on non-integer or overflow. Matches Payload's proven convention and the v3.2 payment/refund sub-PR relies on it.

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide errors from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes in 8.5s

## Test plan (post-2c when writes exist)

- [ ] \`pnpm run db:migrate\` (local D1) — verify 11 tables created
- [ ] Direct SQL insert into shop_products + variant + variant_options — round-trips
- [ ] Concurrent variant SKU insert (same string, two clients) — one succeeds, one fails on UNIQUE

## Sub-PR roadmap remaining

- **2c**: admin CRUD service + product editor with variant matrix
- **2d**: public \`/products/[slug]\` + Product+Offer JSON-LD
- **2e**: public read API + inventory reservation stubs (real cart flow lands in v3.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)