### PR TITLE
feat(v3.1-2d): public /products/[slug] + /collections/[slug] + JSON-LD

### DIFF
--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -25,7 +25,7 @@ export type PageSeo = {
   /** OG image absolute URL (1200×630 ideal). */
   image?: string;
   /** og:type. Defaults to "website" for index pages, "article" for posts. */
-  ogType?: "website" | "article";
+  ogType?: "website" | "article" | "product";
   /** ISO datetime — only meaningful for ogType="article". */
   publishedTime?: string;
   /** ISO datetime — only meaningful for ogType="article". */

--- a/src/plugins/shop/jsonld.ts
+++ b/src/plugins/shop/jsonld.ts
@@ -1,0 +1,131 @@
+/**
+ * Schema.org JSON-LD emitters for shop entities.
+ *
+ * Emitted as inline <script type="application/ld+json"> in the page
+ * <head>. Google's Rich Results Test is the acceptance target
+ * (google.com/rich-results). Keep serialization deterministic — no
+ * Date.now(), no Math.random() — so cache-key stability is preserved.
+ *
+ * Canonical URL rules (must-fix from #56 design review):
+ *   - Product pages canonicalize to /products/<slug> (no variant params)
+ *   - Variant selection uses ?variant=<sku> but SEO consolidates to
+ *     the base URL — one canonical per product, not per variant
+ *
+ * Not shipped yet:
+ *   - AggregateRating (waits for @khaopad/plugin-reviews in v3.4 —
+ *     never emit fake AggregateRating; Google flags fabricated
+ *     review schema as manipulation)
+ *   - Multi-variant Offers with priceSpecification — the current
+ *     emitter picks the min variant price. When variants have
+ *     meaningfully different prices, upgrade to itemOffered.Offer[].
+ */
+import { type Satang } from "./money";
+
+type Money = Satang | number;
+
+export type ProductJsonLdVariant = {
+  sku: string | null;
+  priceSatang: Money;
+  available: number; // 0 = out of stock, >0 = in stock
+};
+
+export type ProductJsonLdInput = {
+  siteOrigin: string; // e.g. "https://example.com"
+  slug: string;
+  title: string;
+  description?: string | null;
+  brand?: string | null;
+  vendor?: string | null; // synonym for brand — brand wins if both set
+  featuredImageUrl?: string | null;
+  variants: ProductJsonLdVariant[];
+  currency?: string; // ISO 4217, defaults to THB
+};
+
+/**
+ * Emit Product + Offer JSON-LD. When there's one variant, uses a
+ * single Offer. When there are multiple, uses AggregateOffer with
+ * lowPrice/highPrice/offerCount. Google's Rich Results validates
+ * both shapes.
+ */
+export function buildProductJsonLd(input: ProductJsonLdInput): string {
+  const canonicalUrl = `${input.siteOrigin}/products/${input.slug}`;
+  const currency = input.currency ?? "THB";
+  const brand = input.brand ?? input.vendor ?? null;
+
+  const activeVariants = input.variants.filter((v) => v.priceSatang > 0);
+  const hasAnyStock = activeVariants.some((v) => v.available > 0);
+
+  const base: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: input.title,
+    url: canonicalUrl,
+  };
+  if (input.description) base.description = input.description;
+  if (brand) base.brand = { "@type": "Brand", name: brand };
+  if (input.featuredImageUrl) base.image = input.featuredImageUrl;
+
+  // Google Merchant / rich results reads Offer.availability
+  const availability = hasAnyStock
+    ? "https://schema.org/InStock"
+    : "https://schema.org/OutOfStock";
+
+  if (activeVariants.length === 1) {
+    const v = activeVariants[0]!;
+    base.offers = {
+      "@type": "Offer",
+      url: canonicalUrl,
+      priceCurrency: currency,
+      // Schema.org wants a decimal number as a string — never scientific,
+      // never rounded to fewer than 2 decimal places for currency.
+      price: (v.priceSatang / 100).toFixed(2),
+      availability,
+      ...(v.sku ? { sku: v.sku } : {}),
+    };
+  } else if (activeVariants.length > 1) {
+    const prices = activeVariants.map((v) => v.priceSatang);
+    const lowPrice = Math.min(...prices);
+    const highPrice = Math.max(...prices);
+    base.offers = {
+      "@type": "AggregateOffer",
+      url: canonicalUrl,
+      priceCurrency: currency,
+      lowPrice: (lowPrice / 100).toFixed(2),
+      highPrice: (highPrice / 100).toFixed(2),
+      offerCount: activeVariants.length,
+      availability,
+    };
+  }
+
+  return JSON.stringify(base);
+}
+
+export type CollectionJsonLdInput = {
+  siteOrigin: string;
+  slug: string;
+  title: string;
+  description?: string | null;
+  productSlugs: string[]; // for ItemList
+};
+
+/** ItemList JSON-LD for collection pages. Helps Google understand catalog structure. */
+export function buildCollectionJsonLd(input: CollectionJsonLdInput): string {
+  const canonicalUrl = `${input.siteOrigin}/collections/${input.slug}`;
+  const items = input.productSlugs.map((slug, i) => ({
+    "@type": "ListItem",
+    position: i + 1,
+    url: `${input.siteOrigin}/products/${slug}`,
+  }));
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: input.title,
+    url: canonicalUrl,
+    ...(input.description ? { description: input.description } : {}),
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: items,
+      numberOfItems: items.length,
+    },
+  });
+}

--- a/src/routes/(www)/[locale]/collections/[slug]/+page.server.ts
+++ b/src/routes/(www)/[locale]/collections/[slug]/+page.server.ts
@@ -1,0 +1,173 @@
+/**
+ * /[locale]/collections/[slug] — public collection page.
+ *
+ * Manual collections resolve via shop_collection_products join. Smart
+ * collections' rules engine ships in a follow-up.
+ */
+import { error } from "@sveltejs/kit";
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, inArray } from "drizzle-orm";
+import { marked } from "marked";
+import { toLocale } from "$lib/i18n";
+import { canonicalUrl, resolveOrigin, type PageSeo } from "$lib/seo";
+import {
+  shopCollectionLocalizations,
+  shopCollectionProducts,
+  shopCollections,
+  shopProductLocalizations,
+  shopProductVariants,
+  shopProducts,
+} from "$plugins/shop/schema";
+import { buildCollectionJsonLd } from "$plugins/shop/jsonld";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ params, url, platform }) => {
+  const locale = toLocale(params.locale);
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+  const db = drizzle(env.DB);
+
+  // 1) The collection itself
+  const collection = await db
+    .select()
+    .from(shopCollections)
+    .where(eq(shopCollections.slug, params.slug))
+    .limit(1)
+    .get();
+  if (!collection || collection.status !== "active") {
+    throw error(404, "Collection not found");
+  }
+
+  // 2) Localization (English fallback)
+  const locs = await db
+    .select()
+    .from(shopCollectionLocalizations)
+    .where(eq(shopCollectionLocalizations.collectionId, collection.id))
+    .all();
+  const localization =
+    locs.find((l) => l.locale === locale) ??
+    locs.find((l) => l.locale === "en");
+  if (!localization) throw error(404, "Collection not available");
+
+  // 3) Products in the collection (manual only for now — smart rules
+  // engine ships in a follow-up sub-PR)
+  const links = await db
+    .select()
+    .from(shopCollectionProducts)
+    .where(eq(shopCollectionProducts.collectionId, collection.id))
+    .orderBy(shopCollectionProducts.position)
+    .all();
+  const productIds = links.map((l) => l.productId);
+
+  const products = productIds.length
+    ? await db
+        .select()
+        .from(shopProducts)
+        .where(
+          and(
+            inArray(shopProducts.id, productIds),
+            eq(shopProducts.status, "active"),
+          ),
+        )
+        .all()
+    : [];
+
+  // Titles + price-from
+  const productLocs = productIds.length
+    ? await db
+        .select()
+        .from(shopProductLocalizations)
+        .where(inArray(shopProductLocalizations.productId, productIds))
+        .all()
+    : [];
+  const variants = productIds.length
+    ? await db
+        .select()
+        .from(shopProductVariants)
+        .where(
+          and(
+            inArray(shopProductVariants.productId, productIds),
+            eq(shopProductVariants.status, "active"),
+          ),
+        )
+        .all()
+    : [];
+
+  const locsByProduct = new Map<string, Map<string, { title: string }>>();
+  for (const l of productLocs) {
+    const map = locsByProduct.get(l.productId) ?? new Map();
+    map.set(l.locale, { title: l.title });
+    locsByProduct.set(l.productId, map);
+  }
+  const variantsByProduct = new Map<
+    string,
+    Array<typeof shopProductVariants.$inferSelect>
+  >();
+  for (const v of variants) {
+    const arr = variantsByProduct.get(v.productId) ?? [];
+    arr.push(v);
+    variantsByProduct.set(v.productId, arr);
+  }
+
+  // Preserve manual collection ordering
+  const orderedProducts = productIds
+    .map((id) => products.find((p) => p.id === id))
+    .filter((p): p is (typeof products)[number] => Boolean(p))
+    .map((product) => {
+      const locsMap = locsByProduct.get(product.id) ?? new Map();
+      const title =
+        locsMap.get(locale)?.title ??
+        locsMap.get("en")?.title ??
+        product.slug;
+      const prices = (variantsByProduct.get(product.id) ?? []).map(
+        (v) => v.priceSatang,
+      );
+      const priceFromSatang = prices.length ? Math.min(...prices) : null;
+      return {
+        slug: product.slug,
+        title,
+        priceFromSatang,
+      };
+    });
+
+  const origin = resolveOrigin(url, env.PUBLIC_SITE_URL);
+  const canonical = canonicalUrl(
+    origin,
+    `/${locale}/collections/${collection.slug}`,
+  );
+
+  const descriptionHtml = localization.descriptionMarkdown
+    ? await marked.parse(localization.descriptionMarkdown, { async: true })
+    : null;
+
+  const jsonLd = buildCollectionJsonLd({
+    siteOrigin: origin,
+    slug: collection.slug,
+    title: localization.title,
+    description: localization.descriptionMarkdown,
+    productSlugs: orderedProducts.map((p) => p.slug),
+  });
+
+  const seo: PageSeo = {
+    title: collection.seoTitle ?? localization.title,
+    description:
+      collection.seoDescription ??
+      (localization.descriptionMarkdown
+        ? localization.descriptionMarkdown.slice(0, 200)
+        : undefined),
+    canonical,
+    ogType: "website",
+  };
+
+  return {
+    collection: {
+      slug: collection.slug,
+      title: localization.title,
+    },
+    products: orderedProducts,
+    descriptionHtml,
+    seo,
+    jsonLd,
+    locale,
+  };
+};

--- a/src/routes/(www)/[locale]/collections/[slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/collections/[slug]/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { formatSatang, type Satang } from '$plugins/shop/money';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+</script>
+
+<!-- SEO is rendered by the layout via page.data.seo. Only the
+     CollectionPage JSON-LD is injected inline. -->
+
+<svelte:head>
+	{@html `<script type="application/ld+json">${data.jsonLd}</script>`}
+</svelte:head>
+
+<div class="mx-auto max-w-4xl px-6 py-10">
+	<header class="mb-8 space-y-2">
+		<h1 class="text-3xl font-semibold tracking-tight">
+			{data.collection.title}
+		</h1>
+		{#if data.descriptionHtml}
+			<div class="prose prose-sm max-w-none dark:prose-invert">
+				{@html data.descriptionHtml}
+			</div>
+		{/if}
+	</header>
+
+	{#if data.products.length === 0}
+		<p class="text-sm text-muted-foreground">
+			No products in this collection yet.
+		</p>
+	{:else}
+		<ul class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+			{#each data.products as product (product.slug)}
+				<li>
+					<a
+						href="/{data.locale}/products/{product.slug}"
+						class="block rounded-lg border border-border p-4 transition-colors hover:bg-muted"
+					>
+						<div class="font-medium">{product.title}</div>
+						{#if product.priceFromSatang != null}
+							<div class="mt-1 text-sm tabular-nums text-muted-foreground">
+								From {formatSatang(
+									product.priceFromSatang as Satang,
+									data.locale === 'th' ? 'th' : 'en',
+								)}
+							</div>
+						{/if}
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/src/routes/(www)/[locale]/products/[slug]/+page.server.ts
+++ b/src/routes/(www)/[locale]/products/[slug]/+page.server.ts
@@ -1,0 +1,107 @@
+/**
+ * /[locale]/products/[slug] — public product detail page.
+ *
+ * Uses the site's locale-prefixed URL convention (matches
+ * /[locale]/blog/[slug]) so hreflang alternates work automatically.
+ * The canonical URL strips ?variant=<sku> — variants are query-param,
+ * not path — so Google consolidates link equity to one URL per product.
+ *
+ * Owned by @khaopad/plugin-shop. This route lives here (in-tree) as
+ * the v3.0 plugin-runtime convention: plugins drop route files into
+ * src/routes/(www) or (admin) directly.
+ */
+import { error } from "@sveltejs/kit";
+import { marked } from "marked";
+import { toLocale } from "$lib/i18n";
+import { canonicalUrl, resolveOrigin, type PageSeo } from "$lib/seo";
+import { ShopService } from "$plugins/shop/service";
+import { buildProductJsonLd } from "$plugins/shop/jsonld";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ params, url, platform, locals }) => {
+  const locale = toLocale(params.locale);
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const svc = new ShopService(env.DB);
+  const product = await svc.getProductBySlug(params.slug);
+  if (!product) throw error(404, "Product not found");
+  if (product.status !== "active") throw error(404, "Product not found");
+
+  // Slug is shared across locales; fall back to English if the
+  // requested locale's content is missing. Matches article convention.
+  const localization =
+    product.localizations[locale] ?? product.localizations["en"];
+  if (!localization) throw error(404, "Product not available");
+
+  // Selected variant from ?variant=<sku> query param. Falls back to
+  // the first active variant if the SKU is unknown or missing.
+  const skuParam = url.searchParams.get("variant");
+  const activeVariants = product.variants.filter((v) => v.status === "active");
+  const selectedVariant =
+    (skuParam
+      ? activeVariants.find((v) => v.sku === skuParam)
+      : null) ?? activeVariants[0];
+  if (!selectedVariant) throw error(404, "No purchasable variants");
+
+  // Origin used for canonical URL + JSON-LD. Prefer PUBLIC_SITE_URL
+  // env when set (production), otherwise derive from the request URL.
+  const origin = resolveOrigin(url, env.PUBLIC_SITE_URL);
+  const canonical = canonicalUrl(origin, `/${locale}/products/${product.slug}`);
+
+  // Render markdown → HTML server-side. Same helper as articles.
+  const descriptionHtml = localization.descriptionMarkdown
+    ? await marked.parse(localization.descriptionMarkdown, { async: true })
+    : null;
+
+  // JSON-LD payload — one Offer per active variant OR AggregateOffer
+  // when there are ≥2. Availability keys off computed available count.
+  const jsonLd = buildProductJsonLd({
+    siteOrigin: origin,
+    slug: product.slug,
+    title: localization.title,
+    description: localization.descriptionMarkdown,
+    brand: product.vendor,
+    featuredImageUrl: null, // media resolution ships when the media picker lands for shop
+    variants: activeVariants.map((v) => ({
+      sku: v.sku,
+      priceSatang: v.priceSatang,
+      available: v.inventory?.available ?? 0,
+    })),
+    currency: "THB",
+  });
+
+  const seo: PageSeo = {
+    title: product.seoTitle ?? localization.title,
+    description:
+      product.seoDescription ??
+      (localization.descriptionMarkdown
+        ? localization.descriptionMarkdown.slice(0, 200)
+        : undefined),
+    canonical,
+    ogType: "product",
+  };
+
+  return {
+    product: {
+      slug: product.slug,
+      status: product.status,
+      vendor: product.vendor,
+      variants: activeVariants.map((v) => ({
+        id: v.id,
+        sku: v.sku,
+        titleCached: v.titleCached,
+        priceSatang: v.priceSatang,
+        compareAtSatang: v.compareAtSatang,
+        available: v.inventory?.available ?? 0,
+        onHand: v.inventory?.onHand ?? 0,
+      })),
+      selectedVariantId: selectedVariant.id,
+    },
+    localization,
+    descriptionHtml,
+    seo,
+    jsonLd,
+    locale,
+  };
+};

--- a/src/routes/(www)/[locale]/products/[slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/products/[slug]/+page.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { formatSatang, type Satang } from '$plugins/shop/money';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const product = $derived(data.product);
+	const localization = $derived(data.localization);
+
+	// Bindable variant selector — updates ?variant= without page reload
+	// via goto({ replaceState: true, noScroll: true }).
+	let selectedId = $state<string>(product.selectedVariantId);
+	const selectedVariant = $derived(
+		product.variants.find((v) => v.id === selectedId) ?? product.variants[0],
+	);
+
+	function onSelectVariant(id: string) {
+		selectedId = id;
+		const variant = product.variants.find((v) => v.id === id);
+		if (!variant?.sku) return;
+		const params = new URLSearchParams(page.url.searchParams);
+		params.set('variant', variant.sku);
+		goto(`?${params}`, { replaceState: true, noScroll: true, keepFocus: true });
+	}
+</script>
+
+<!-- SEO is rendered by the layout via page.data.seo. Only the Product
+     JSON-LD is injected inline — schema.org rich results validation. -->
+<svelte:head>
+	{@html `<script type="application/ld+json">${data.jsonLd}</script>`}
+</svelte:head>
+
+<article class="mx-auto max-w-3xl px-6 py-10">
+	<header class="mb-6 space-y-2">
+		<h1 class="text-3xl font-semibold tracking-tight">
+			{localization.title}
+		</h1>
+		{#if product.vendor}
+			<p class="text-sm text-muted-foreground">by {product.vendor}</p>
+		{/if}
+	</header>
+
+	<section class="mb-8 space-y-4">
+		<div class="flex items-baseline gap-3">
+			<span class="text-2xl font-semibold tabular-nums">
+				{formatSatang(selectedVariant.priceSatang as Satang, data.locale === 'th' ? 'th' : 'en')}
+			</span>
+			{#if selectedVariant.compareAtSatang && selectedVariant.compareAtSatang > selectedVariant.priceSatang}
+				<span class="text-sm text-muted-foreground line-through tabular-nums">
+					{formatSatang(selectedVariant.compareAtSatang as Satang, data.locale === 'th' ? 'th' : 'en')}
+				</span>
+			{/if}
+		</div>
+
+		{#if selectedVariant.available > 0}
+			<p class="text-sm text-green-700">
+				{selectedVariant.available > 10
+					? 'In stock'
+					: `Only ${selectedVariant.available} left`}
+			</p>
+		{:else}
+			<p class="text-sm text-destructive">Sold out</p>
+		{/if}
+	</section>
+
+	{#if product.variants.length > 1}
+		<section class="mb-8 space-y-2">
+			<h2 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+				Select variant
+			</h2>
+			<div class="flex flex-wrap gap-2">
+				{#each product.variants as variant (variant.id)}
+					<button
+						type="button"
+						onclick={() => onSelectVariant(variant.id)}
+						class="rounded-md border px-3 py-2 text-sm transition-colors {selectedId ===
+						variant.id
+							? 'border-primary bg-primary text-primary-foreground'
+							: 'border-input hover:bg-muted'} {variant.available === 0
+							? 'opacity-60 line-through'
+							: ''}"
+						aria-pressed={selectedId === variant.id}
+					>
+						{variant.titleCached || 'Default'}
+					</button>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
+	{#if data.descriptionHtml}
+		<section class="prose prose-sm max-w-none dark:prose-invert">
+			{@html data.descriptionHtml}
+		</section>
+	{/if}
+
+	<footer class="mt-10 border-t border-border pt-6">
+		<p class="text-sm text-muted-foreground">
+			Cart + checkout ship in v3.2 (<a
+				href="https://github.com/codustry/khaopad/issues/57"
+				class="underline"
+				target="_blank"
+				rel="noopener">#57</a
+			>). Currently browse-only.
+		</p>
+	</footer>
+</article>


### PR DESCRIPTION
Fourth sub-PR of v3.1 shop plugin ([#56](https://github.com/codustry/khaopad/issues/56)). Follows [#73 (2c admin CRUD)](https://github.com/codustry/khaopad/pull/73). Ships the public storefront side: product detail + collection listing + JSON-LD.

## What ships

- \`src/plugins/shop/jsonld.ts\` — \`buildProductJsonLd()\` (auto-switches Offer ↔ AggregateOffer) + \`buildCollectionJsonLd()\`
- \`/[locale]/products/[slug]\` — variant selector via \`?variant=SKU\`, canonical strips the param, price + compareAt display, in-stock / sold-out messaging
- \`/[locale]/collections/[slug]\` — manual collection listing (preserves position ordering)
- Extended \`ogType\` union with \`'product'\`

## Design decisions

- **Layout owns SEO rendering** — pages return \`{seo}\` from load(); only JSON-LD injected inline
- **Variants as query params, single canonical** — design-review must-fix (prevents Google indexing dupes)
- **No fake AggregateRating** — waits for reviews plugin in v3.4
- **Locale-prefixed URLs** — hreflang alternates automatic via layout

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes in 15s

## Sub-PR roadmap remaining

- **2e**: public read API (JSON) + inventory reservation stubs → Phase 2 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)