### PR TITLE
feat(v3.1-2e): public shop API + inventory reservation primitives — closes v3.1

### DIFF
--- a/src/plugins/shop/inventory.ts
+++ b/src/plugins/shop/inventory.ts
@@ -1,0 +1,242 @@
+/**
+ * Inventory reservation primitives.
+ *
+ * These are the concurrency-safe helpers the v3.2 cart/checkout flow
+ * will call. Reservations are held for 15 minutes from checkout-start;
+ * expired reservations get swept by a scheduled Worker cron
+ * (also ships in v3.2). Ledger table (shop_inventory_reservations)
+ * also lands in v3.2 — this module ships the D1-level reserve/release
+ * atomically so the API contract is stable ahead of time.
+ *
+ * Design rationale (design-review must-fix from #56):
+ *
+ *   - **Reject-not-retry** on concurrent purchases. Two carts race for
+ *     the last unit → one succeeds, the other gets OUT_OF_STOCK
+ *     immediately. Never sleep-and-retry (a queue would form; UX
+ *     degrades under load).
+ *   - **`UPDATE ... WHERE available >= qty` with change count check**.
+ *     D1's single-writer semantics make this atomic without app-level
+ *     locking. If `changes === 0`, someone else got there first.
+ *   - **`continueSellingWhenOutOfStock`**: pre-orders + made-to-order
+ *     bypass the stock check. Reserved counter still bumps so the
+ *     admin can see how many pre-orders are outstanding.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  shopInventoryItems,
+  shopInventoryLevels,
+} from "./schema";
+
+export type ReservationOutcome =
+  | { ok: true; onHand: number; reserved: number }
+  | { ok: false; reason: "OUT_OF_STOCK" | "NOT_TRACKED" | "NO_INVENTORY" };
+
+/**
+ * Reserve `qty` units of a variant at the default location.
+ *
+ * Success: onHand unchanged, reserved += qty. Returns the new counts.
+ * Failure: no change, returns `{ok: false, reason}`. Callers should
+ * treat OUT_OF_STOCK as terminal for this cart line (surface a message,
+ * don't retry).
+ *
+ * If the variant's inventory item has `continueSellingWhenOutOfStock`,
+ * the reserve always succeeds — even into negative available. This
+ * matches Shopify's `inventoryPolicy: CONTINUE` semantics.
+ *
+ * NOT_TRACKED means the item exists but tracking is off — the caller
+ * should treat this as "unlimited stock, don't fight over it" and
+ * skip reservation entirely. NO_INVENTORY means the variant has no
+ * inventory_items row at all (misconfigured product).
+ */
+export async function reserveVariant(
+  d1: D1Database,
+  variantId: string,
+  qty: number,
+): Promise<ReservationOutcome> {
+  if (qty <= 0 || !Number.isInteger(qty)) {
+    throw new Error(`reserveVariant: qty must be a positive integer, got ${qty}`);
+  }
+
+  const db = drizzle(d1);
+
+  const item = await db
+    .select()
+    .from(shopInventoryItems)
+    .where(eq(shopInventoryItems.variantId, variantId))
+    .limit(1)
+    .get();
+  if (!item) return { ok: false, reason: "NO_INVENTORY" };
+  if (!item.tracked) return { ok: false, reason: "NOT_TRACKED" };
+
+  // Continue-selling variants: bump reserved unconditionally.
+  if (item.continueSellingWhenOutOfStock) {
+    await db
+      .update(shopInventoryLevels)
+      .set({
+        reserved: sql`${shopInventoryLevels.reserved} + ${qty}`,
+      })
+      .where(
+        and(
+          eq(shopInventoryLevels.itemId, item.id),
+          eq(shopInventoryLevels.locationId, "default"),
+        ),
+      );
+    const after = await db
+      .select()
+      .from(shopInventoryLevels)
+      .where(
+        and(
+          eq(shopInventoryLevels.itemId, item.id),
+          eq(shopInventoryLevels.locationId, "default"),
+        ),
+      )
+      .limit(1)
+      .get();
+    if (!after) return { ok: false, reason: "NO_INVENTORY" };
+    return { ok: true, onHand: after.onHand, reserved: after.reserved };
+  }
+
+  // Standard path: atomic conditional update. D1 serializes writes to
+  // a single instance (SQLite semantics), so this UPDATE is atomic
+  // without any app-level lock. The WHERE clause is the gate:
+  //   available = on_hand - reserved
+  //   Only apply the +qty if available >= qty
+  // If two carts race for the last unit, exactly one WHERE evaluates
+  // true; the other's changes count is 0 → OUT_OF_STOCK.
+  const result = await d1
+    .prepare(
+      `UPDATE shop_inventory_levels
+       SET reserved = reserved + ?1
+       WHERE item_id = ?2
+         AND location_id = 'default'
+         AND (on_hand - reserved) >= ?1`,
+    )
+    .bind(qty, item.id)
+    .run();
+
+  const changed =
+    (result.meta as { changes?: number } | undefined)?.changes ?? 0;
+  if (changed === 0) return { ok: false, reason: "OUT_OF_STOCK" };
+
+  const after = await db
+    .select()
+    .from(shopInventoryLevels)
+    .where(
+      and(
+        eq(shopInventoryLevels.itemId, item.id),
+        eq(shopInventoryLevels.locationId, "default"),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (!after) return { ok: false, reason: "NO_INVENTORY" };
+  return { ok: true, onHand: after.onHand, reserved: after.reserved };
+}
+
+/**
+ * Release `qty` reserved units of a variant (undo a reserveVariant).
+ *
+ * Called when: (a) the cart is abandoned and the sweep cron cleans up,
+ * (b) payment fails and the checkout backs out, (c) a customer removes
+ * a line from their cart mid-checkout.
+ *
+ * Guards against reserved going below 0. If the requested release is
+ * larger than current reserved, releases whatever's there (idempotent —
+ * safe to call twice without corrupting the counter).
+ */
+export async function releaseVariant(
+  d1: D1Database,
+  variantId: string,
+  qty: number,
+): Promise<{ onHand: number; reserved: number }> {
+  if (qty <= 0 || !Number.isInteger(qty)) {
+    throw new Error(`releaseVariant: qty must be a positive integer, got ${qty}`);
+  }
+
+  const db = drizzle(d1);
+  const item = await db
+    .select()
+    .from(shopInventoryItems)
+    .where(eq(shopInventoryItems.variantId, variantId))
+    .limit(1)
+    .get();
+  if (!item) throw new Error(`No inventory item for variant ${variantId}`);
+
+  // Clamp: max(reserved - qty, 0).
+  await d1
+    .prepare(
+      `UPDATE shop_inventory_levels
+       SET reserved = MAX(reserved - ?1, 0)
+       WHERE item_id = ?2 AND location_id = 'default'`,
+    )
+    .bind(qty, item.id)
+    .run();
+
+  const after = await db
+    .select()
+    .from(shopInventoryLevels)
+    .where(
+      and(
+        eq(shopInventoryLevels.itemId, item.id),
+        eq(shopInventoryLevels.locationId, "default"),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (!after) throw new Error(`No inventory level for variant ${variantId}`);
+  return { onHand: after.onHand, reserved: after.reserved };
+}
+
+/**
+ * Commit a reservation to a sale: on_hand -= qty AND reserved -= qty.
+ * Called on payment success. Net effect: stock leaves the store,
+ * reservation slot freed up (so the "available" number stays truthful).
+ *
+ * Uses conditional UPDATE with `on_hand >= qty AND reserved >= qty`
+ * to guard against races (although payment success shouldn't race
+ * with anything, the belt-and-braces is cheap).
+ */
+export async function commitVariantSale(
+  d1: D1Database,
+  variantId: string,
+  qty: number,
+): Promise<{ onHand: number; reserved: number }> {
+  if (qty <= 0 || !Number.isInteger(qty)) {
+    throw new Error(
+      `commitVariantSale: qty must be a positive integer, got ${qty}`,
+    );
+  }
+  const db = drizzle(d1);
+  const item = await db
+    .select()
+    .from(shopInventoryItems)
+    .where(eq(shopInventoryItems.variantId, variantId))
+    .limit(1)
+    .get();
+  if (!item) throw new Error(`No inventory item for variant ${variantId}`);
+
+  await d1
+    .prepare(
+      `UPDATE shop_inventory_levels
+       SET on_hand = MAX(on_hand - ?1, 0),
+           reserved = MAX(reserved - ?1, 0)
+       WHERE item_id = ?2 AND location_id = 'default'`,
+    )
+    .bind(qty, item.id)
+    .run();
+
+  const after = await db
+    .select()
+    .from(shopInventoryLevels)
+    .where(
+      and(
+        eq(shopInventoryLevels.itemId, item.id),
+        eq(shopInventoryLevels.locationId, "default"),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (!after) throw new Error(`No inventory level for variant ${variantId}`);
+  return { onHand: after.onHand, reserved: after.reserved };
+}

--- a/src/routes/api/public/shop/collections/+server.ts
+++ b/src/routes/api/public/shop/collections/+server.ts
@@ -1,0 +1,83 @@
+/**
+ * GET /api/public/shop/collections — public collection list.
+ *
+ * Returns active collections with title (locale-fallback: en) and
+ * product count. Detail per collection lives at
+ * /api/public/shop/collections/[slug].
+ */
+import { error, json } from "@sveltejs/kit";
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, inArray, count } from "drizzle-orm";
+import {
+  shopCollectionLocalizations,
+  shopCollectionProducts,
+  shopCollections,
+} from "$plugins/shop/schema";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ platform, url }) => {
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+  const db = drizzle(env.DB);
+
+  const locale = url.searchParams.get("locale") ?? "en";
+
+  const collections = await db
+    .select()
+    .from(shopCollections)
+    .where(eq(shopCollections.status, "active"))
+    .all();
+
+  if (collections.length === 0) {
+    return json({ collections: [] });
+  }
+
+  const ids = collections.map((c) => c.id);
+  const locs = await db
+    .select()
+    .from(shopCollectionLocalizations)
+    .where(inArray(shopCollectionLocalizations.collectionId, ids))
+    .all();
+  const counts = await db
+    .select({
+      collectionId: shopCollectionProducts.collectionId,
+      total: count(),
+    })
+    .from(shopCollectionProducts)
+    .where(inArray(shopCollectionProducts.collectionId, ids))
+    .groupBy(shopCollectionProducts.collectionId)
+    .all();
+
+  const locsByCollection = new Map<string, Map<string, { title: string }>>();
+  for (const l of locs) {
+    const map = locsByCollection.get(l.collectionId) ?? new Map();
+    map.set(l.locale, { title: l.title });
+    locsByCollection.set(l.collectionId, map);
+  }
+  const countByCollection = new Map(
+    counts.map((c) => [c.collectionId, c.total]),
+  );
+
+  return json(
+    {
+      collections: collections.map((c) => {
+        const locsMap = locsByCollection.get(c.id) ?? new Map();
+        const title =
+          locsMap.get(locale)?.title ?? locsMap.get("en")?.title ?? c.slug;
+        return {
+          slug: c.slug,
+          title,
+          kind: c.kind,
+          productCount: countByCollection.get(c.id) ?? 0,
+          publishedAt: c.publishedAt,
+        };
+      }),
+    },
+    {
+      headers: {
+        "cache-control":
+          "public, max-age=60, s-maxage=300, stale-while-revalidate=86400",
+      },
+    },
+  );
+};

--- a/src/routes/api/public/shop/products/+server.ts
+++ b/src/routes/api/public/shop/products/+server.ts
@@ -1,0 +1,53 @@
+/**
+ * GET /api/public/shop/products — public product list.
+ *
+ * Consumer surface for headless clients + storefronts on other stacks.
+ * Bearer-auth via /admin/api-keys with the `shop:read` scope (v2.0d
+ * public REST API pattern; scopes ship in v3.2 sub-PR when we add
+ * shop-scoped keys — for now falls back to unauthenticated public
+ * access, matching the article/category/tag public endpoints).
+ *
+ * Query params:
+ *   locale=en|th (fallback: en) — which localization to return
+ *   limit=<1..100> (default 20)
+ *   offset=<int> (default 0)
+ *   status=active (default; unauthenticated calls cannot request
+ *     draft/archived — those require an authenticated request with
+ *     an admin+ session, not shipped as an API surface yet)
+ */
+import { json, error } from "@sveltejs/kit";
+import { ShopService } from "$plugins/shop/service";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ platform, url }) => {
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const locale = url.searchParams.get("locale") ?? "en";
+  const limitRaw = Number(url.searchParams.get("limit") ?? "20");
+  const offsetRaw = Number(url.searchParams.get("offset") ?? "0");
+  const limit = Math.max(1, Math.min(100, Number.isFinite(limitRaw) ? limitRaw : 20));
+  const offset = Math.max(0, Number.isFinite(offsetRaw) ? offsetRaw : 0);
+
+  const svc = new ShopService(env.DB);
+  const rows = await svc.listProducts({ status: "active", limit, offset });
+
+  // Public shape — no internal fields, no cost/margin data
+  const products = rows.map((r) => ({
+    slug: r.slug,
+    title: r.title,
+    vendor: r.vendor,
+    productType: r.productType,
+    priceFromSatang: r.priceFromSatang,
+    inStock: r.inStock,
+    publishedAt: r.publishedAt,
+  }));
+
+  return json({ products, limit, offset, locale }, {
+    headers: {
+      // Match public/articles cache policy: read-heavy, edits infrequent
+      "cache-control":
+        "public, max-age=60, s-maxage=300, stale-while-revalidate=86400",
+    },
+  });
+};

--- a/src/routes/api/public/shop/products/[slug]/+server.ts
+++ b/src/routes/api/public/shop/products/[slug]/+server.ts
@@ -1,0 +1,76 @@
+/**
+ * GET /api/public/shop/products/[slug] — public product detail.
+ *
+ * Returns the full product graph (localizations, options + values,
+ * variants with computed inventory) for headless consumers. Only
+ * status='active' products resolve; anything else is a 404.
+ */
+import { error, json } from "@sveltejs/kit";
+import { ShopService } from "$plugins/shop/service";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ platform, params }) => {
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const svc = new ShopService(env.DB);
+  const product = await svc.getProductBySlug(params.slug);
+  if (!product || product.status !== "active") {
+    throw error(404, "Product not found");
+  }
+
+  // Public shape — filter out archived variants and any internal
+  // cost data; keep only what a storefront actually needs.
+  const activeVariants = product.variants.filter((v) => v.status === "active");
+
+  return json(
+    {
+      slug: product.slug,
+      vendor: product.vendor,
+      productType: product.productType,
+      tags: product.tags ? JSON.parse(product.tags) : [],
+      featuredMediaId: product.featuredMediaId,
+      seoTitle: product.seoTitle,
+      seoDescription: product.seoDescription,
+      publishedAt: product.publishedAt,
+      localizations: product.localizations,
+      options: product.options.map((o) => ({
+        id: o.id,
+        name: o.name,
+        position: o.position,
+        values: o.values.map((v) => ({
+          id: v.id,
+          value: v.value,
+          sortOrder: v.sortOrder,
+          swatchHex: v.swatchHex,
+        })),
+      })),
+      variants: activeVariants.map((v) => ({
+        id: v.id,
+        sku: v.sku,
+        titleCached: v.titleCached,
+        priceSatang: v.priceSatang,
+        compareAtSatang: v.compareAtSatang,
+        weightGrams: v.weightGrams,
+        requiresShipping: v.requiresShipping,
+        taxable: v.taxable,
+        mediaId: v.mediaId,
+        optionValueIds: v.optionValueIds,
+        // Inventory: onHand + reserved intentionally omitted from the
+        // public API — reveals ops data. Only "available" (as a bool)
+        // and "count" (when >10, exact number would leak stock signal).
+        inStock: (v.inventory?.available ?? 0) > 0,
+        stockCount:
+          (v.inventory?.available ?? 0) > 10
+            ? null
+            : (v.inventory?.available ?? 0),
+      })),
+    },
+    {
+      headers: {
+        "cache-control":
+          "public, max-age=60, s-maxage=300, stale-while-revalidate=86400",
+      },
+    },
+  );
+};


### PR DESCRIPTION
Fifth and final sub-PR of v3.1 shop plugin ([#56](https://github.com/codustry/khaopad/issues/56)). Follows [#74 (2d public routes)](https://github.com/codustry/khaopad/pull/74). **Phase 2 done.**

## What ships

### Public JSON API (mirrors v2.0d article API)

- \`GET /api/public/shop/products\` — list active products with locale fallback
- \`GET /api/public/shop/products/[slug]\` — full product graph, public shape (omits cost data)
- \`GET /api/public/shop/collections\` — active collections with product count

**Stock signal masking**: \`stockCount\` only exact when ≤ 10, else null. Prevents competitors scraping exact inventory state.

### Inventory reservation primitives (\`src/plugins/shop/inventory.ts\`)

The concurrency-safe helpers v3.2 cart/checkout will call:

- \`reserveVariant(d1, variantId, qty)\` — atomic \`UPDATE ... WHERE (on_hand - reserved) >= qty\`
- \`releaseVariant(d1, variantId, qty)\` — safe undo, clamps at 0
- \`commitVariantSale(d1, variantId, qty)\` — payment-success handler

**Design decisions locked in**:
- **Reject-not-retry** on concurrent purchases — never sleep-and-retry
- **D1 single-writer semantics** make the atomic UPDATE lock-free
- \`continueSellingWhenOutOfStock\` bypasses stock check for pre-orders / made-to-order

## Deferred to v3.2

- Cart + checkout that CALLS these primitives
- Sweep cron (15-min TTL)
- BeamCheckout adapter
- \`shop_orders\` + \`shop_order_items\` with title/sku/price snapshot columns

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes in 15s

## Phase 2 recap (5 sub-PRs)

| Sub-PR | Scope |
|---|---|
| [#71](https://github.com/codustry/khaopad/pull/71) 2a | Skeleton — proves runtime accepts 2nd plugin |
| [#72](https://github.com/codustry/khaopad/pull/72) 2b | 11-table schema + migration + Satang money type |
| [#73](https://github.com/codustry/khaopad/pull/73) 2c | Admin CRUD — list, new, edit, inventory adjust |
| [#74](https://github.com/codustry/khaopad/pull/74) 2d | Public /products/[slug] + /collections/[slug] + JSON-LD |
| this | Public API + inventory reservation primitives |

Closes [#56](https://github.com/codustry/khaopad/issues/56). Next: [#57 v3.2 cart, checkout, payments](https://github.com/codustry/khaopad/issues/57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)