### PR TITLE
fix(v3.1): post-merge bug hunt — 3 BLOCKERs + 3 caveats

### DIFF
--- a/src/plugins/shop/inventory.ts
+++ b/src/plugins/shop/inventory.ts
@@ -22,7 +22,7 @@
  *     admin can see how many pre-orders are outstanding.
  */
 import { drizzle } from "drizzle-orm/d1";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   shopInventoryItems,
   shopInventoryLevels,
@@ -70,29 +70,20 @@ export async function reserveVariant(
   if (!item.tracked) return { ok: false, reason: "NOT_TRACKED" };
 
   // Continue-selling variants: bump reserved unconditionally.
+  // RETURNING gives us the post-update counts atomically in the same
+  // statement — no race where a follow-up SELECT sees a different
+  // increment from a concurrent reserver.
   if (item.continueSellingWhenOutOfStock) {
-    await db
-      .update(shopInventoryLevels)
-      .set({
-        reserved: sql`${shopInventoryLevels.reserved} + ${qty}`,
-      })
-      .where(
-        and(
-          eq(shopInventoryLevels.itemId, item.id),
-          eq(shopInventoryLevels.locationId, "default"),
-        ),
-      );
-    const after = await db
-      .select()
-      .from(shopInventoryLevels)
-      .where(
-        and(
-          eq(shopInventoryLevels.itemId, item.id),
-          eq(shopInventoryLevels.locationId, "default"),
-        ),
+    const rows = await d1
+      .prepare(
+        `UPDATE shop_inventory_levels
+         SET reserved = reserved + ?1
+         WHERE item_id = ?2 AND location_id = 'default'
+         RETURNING on_hand AS onHand, reserved`,
       )
-      .limit(1)
-      .get();
+      .bind(qty, item.id)
+      .all<{ onHand: number; reserved: number }>();
+    const after = rows.results?.[0];
     if (!after) return { ok: false, reason: "NO_INVENTORY" };
     return { ok: true, onHand: after.onHand, reserved: after.reserved };
   }
@@ -103,34 +94,24 @@ export async function reserveVariant(
   //   available = on_hand - reserved
   //   Only apply the +qty if available >= qty
   // If two carts race for the last unit, exactly one WHERE evaluates
-  // true; the other's changes count is 0 → OUT_OF_STOCK.
-  const result = await d1
+  // true; the other's RETURNING is empty → OUT_OF_STOCK.
+  // Using RETURNING (not a follow-up SELECT) so the returned counts
+  // reflect *this* reserver's post-state, not whatever a concurrent
+  // reserver's update landed after.
+  const rows = await d1
     .prepare(
       `UPDATE shop_inventory_levels
        SET reserved = reserved + ?1
        WHERE item_id = ?2
          AND location_id = 'default'
-         AND (on_hand - reserved) >= ?1`,
+         AND (on_hand - reserved) >= ?1
+       RETURNING on_hand AS onHand, reserved`,
     )
     .bind(qty, item.id)
-    .run();
+    .all<{ onHand: number; reserved: number }>();
 
-  const changed =
-    (result.meta as { changes?: number } | undefined)?.changes ?? 0;
-  if (changed === 0) return { ok: false, reason: "OUT_OF_STOCK" };
-
-  const after = await db
-    .select()
-    .from(shopInventoryLevels)
-    .where(
-      and(
-        eq(shopInventoryLevels.itemId, item.id),
-        eq(shopInventoryLevels.locationId, "default"),
-      ),
-    )
-    .limit(1)
-    .get();
-  if (!after) return { ok: false, reason: "NO_INVENTORY" };
+  const after = rows.results?.[0];
+  if (!after) return { ok: false, reason: "OUT_OF_STOCK" };
   return { ok: true, onHand: after.onHand, reserved: after.reserved };
 }
 
@@ -163,27 +144,19 @@ export async function releaseVariant(
     .get();
   if (!item) throw new Error(`No inventory item for variant ${variantId}`);
 
-  // Clamp: max(reserved - qty, 0).
-  await d1
+  // Clamp: max(reserved - qty, 0). RETURNING gives us the atomic
+  // post-state so a concurrent reserver's update doesn't skew the
+  // reported counts.
+  const rows = await d1
     .prepare(
       `UPDATE shop_inventory_levels
        SET reserved = MAX(reserved - ?1, 0)
-       WHERE item_id = ?2 AND location_id = 'default'`,
+       WHERE item_id = ?2 AND location_id = 'default'
+       RETURNING on_hand AS onHand, reserved`,
     )
     .bind(qty, item.id)
-    .run();
-
-  const after = await db
-    .select()
-    .from(shopInventoryLevels)
-    .where(
-      and(
-        eq(shopInventoryLevels.itemId, item.id),
-        eq(shopInventoryLevels.locationId, "default"),
-      ),
-    )
-    .limit(1)
-    .get();
+    .all<{ onHand: number; reserved: number }>();
+  const after = rows.results?.[0];
   if (!after) throw new Error(`No inventory level for variant ${variantId}`);
   return { onHand: after.onHand, reserved: after.reserved };
 }
@@ -216,17 +189,9 @@ export async function commitVariantSale(
     .get();
   if (!item) throw new Error(`No inventory item for variant ${variantId}`);
 
-  await d1
-    .prepare(
-      `UPDATE shop_inventory_levels
-       SET on_hand = MAX(on_hand - ?1, 0),
-           reserved = MAX(reserved - ?1, 0)
-       WHERE item_id = ?2 AND location_id = 'default'`,
-    )
-    .bind(qty, item.id)
-    .run();
-
-  const after = await db
+  // Read pre-state so we can log accounting divergence (reserved
+  // clamped means the reservation was mismatched — books off).
+  const pre = await db
     .select()
     .from(shopInventoryLevels)
     .where(
@@ -237,6 +202,32 @@ export async function commitVariantSale(
     )
     .limit(1)
     .get();
+  if (pre) {
+    if (pre.onHand < qty) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[shop.inventory] commitVariantSale silently clamps on_hand for variant ${variantId}: on_hand=${pre.onHand}, qty=${qty}`,
+      );
+    }
+    if (pre.reserved < qty) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[shop.inventory] commitVariantSale silently clamps reserved for variant ${variantId}: reserved=${pre.reserved}, qty=${qty}. Books likely off — reservation may have been double-released.`,
+      );
+    }
+  }
+
+  const rows = await d1
+    .prepare(
+      `UPDATE shop_inventory_levels
+       SET on_hand = MAX(on_hand - ?1, 0),
+           reserved = MAX(reserved - ?1, 0)
+       WHERE item_id = ?2 AND location_id = 'default'
+       RETURNING on_hand AS onHand, reserved`,
+    )
+    .bind(qty, item.id)
+    .all<{ onHand: number; reserved: number }>();
+  const after = rows.results?.[0];
   if (!after) throw new Error(`No inventory level for variant ${variantId}`);
   return { onHand: after.onHand, reserved: after.reserved };
 }

--- a/src/plugins/shop/jsonld.ts
+++ b/src/plugins/shop/jsonld.ts
@@ -42,6 +42,20 @@ export type ProductJsonLdInput = {
 };
 
 /**
+ * Escape any `<` in JSON output so an embedded `</script>` in the
+ * source data cannot break out of a `<script type="application/ld+json">`
+ * container and execute attacker-controlled HTML. Classic stored-XSS
+ * vector for JSON-LD.
+ *
+ * `JSON.stringify` does NOT escape `<` by default — this replace runs
+ * on the finished string to catch every occurrence regardless of where
+ * in the JSON structure it landed.
+ */
+function escapeForScriptTag(json: string): string {
+  return json.replace(/</g, "\\u003c");
+}
+
+/**
  * Emit Product + Offer JSON-LD. When there's one variant, uses a
  * single Offer. When there are multiple, uses AggregateOffer with
  * lowPrice/highPrice/offerCount. Google's Rich Results validates
@@ -97,7 +111,7 @@ export function buildProductJsonLd(input: ProductJsonLdInput): string {
     };
   }
 
-  return JSON.stringify(base);
+  return escapeForScriptTag(JSON.stringify(base));
 }
 
 export type CollectionJsonLdInput = {
@@ -116,16 +130,18 @@ export function buildCollectionJsonLd(input: CollectionJsonLdInput): string {
     position: i + 1,
     url: `${input.siteOrigin}/products/${slug}`,
   }));
-  return JSON.stringify({
-    "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    name: input.title,
-    url: canonicalUrl,
-    ...(input.description ? { description: input.description } : {}),
-    mainEntity: {
-      "@type": "ItemList",
-      itemListElement: items,
-      numberOfItems: items.length,
-    },
-  });
+  return escapeForScriptTag(
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      name: input.title,
+      url: canonicalUrl,
+      ...(input.description ? { description: input.description } : {}),
+      mainEntity: {
+        "@type": "ItemList",
+        itemListElement: items,
+        numberOfItems: items.length,
+      },
+    }),
+  );
 }

--- a/src/plugins/shop/service.ts
+++ b/src/plugins/shop/service.ts
@@ -493,6 +493,23 @@ export class ShopService {
       );
     }
 
+    // Pre-check slug uniqueness so callers get a nice validation error
+    // instead of a D1 UNIQUE constraint 500. Race between two creates
+    // for the same slug: one wins, the second hits the D1 UNIQUE at
+    // insert time — the catch below rethrows as ShopValidationError.
+    const existing = await this.db
+      .select({ id: shopProducts.id })
+      .from(shopProducts)
+      .where(eq(shopProducts.slug, slug))
+      .limit(1)
+      .get();
+    if (existing) {
+      throw new ShopValidationError(
+        `A product with slug "${slug}" already exists. Choose a different title or set an explicit slug.`,
+        "slug",
+      );
+    }
+
     const productId = nanoid();
     const now = nowIso();
     const publishedAt =
@@ -611,20 +628,37 @@ export class ShopService {
     // insert fails, cascading FKs mean deleting the product row cleans
     // up everything downstream — see `deleteProduct()`. Full D1 batch
     // atomicity is a v3.2 concern (wrap in this.d1.batch() then).
-    await this.db.insert(shopProducts).values({
-      id: productId,
-      slug,
-      status: input.status ?? "draft",
-      vendor: input.vendor ?? null,
-      productType: input.productType ?? null,
-      tags: input.tags ? JSON.stringify(input.tags) : null,
-      featuredMediaId: input.featuredMediaId ?? null,
-      seoTitle: input.seoTitle ?? null,
-      seoDescription: input.seoDescription ?? null,
-      createdAt: now,
-      updatedAt: now,
-      publishedAt,
-    });
+    //
+    // The pre-check above catches the common slug-collision case, but
+    // a race between two concurrent creates for the same slug still
+    // lands here — one wins, the other's INSERT trips the D1 UNIQUE
+    // constraint. Catch and rethrow as ShopValidationError so the
+    // caller gets a nice 400 instead of a 500 with a leaked D1 error.
+    try {
+      await this.db.insert(shopProducts).values({
+        id: productId,
+        slug,
+        status: input.status ?? "draft",
+        vendor: input.vendor ?? null,
+        productType: input.productType ?? null,
+        tags: input.tags ? JSON.stringify(input.tags) : null,
+        featuredMediaId: input.featuredMediaId ?? null,
+        seoTitle: input.seoTitle ?? null,
+        seoDescription: input.seoDescription ?? null,
+        createdAt: now,
+        updatedAt: now,
+        publishedAt,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("UNIQUE") && msg.includes("shop_products.slug")) {
+        throw new ShopValidationError(
+          `A product with slug "${slug}" already exists.`,
+          "slug",
+        );
+      }
+      throw err;
+    }
     await this.db.insert(shopProductLocalizations).values(
       Object.entries(input.localizations).map(([locale, loc]) => ({
         productId,

--- a/src/routes/api/public/shop/collections/+server.ts
+++ b/src/routes/api/public/shop/collections/+server.ts
@@ -7,7 +7,8 @@
  */
 import { error, json } from "@sveltejs/kit";
 import { drizzle } from "drizzle-orm/d1";
-import { and, eq, inArray, count } from "drizzle-orm";
+import { eq, inArray, count } from "drizzle-orm";
+import { toLocale } from "$lib/i18n";
 import {
   shopCollectionLocalizations,
   shopCollectionProducts,
@@ -20,7 +21,7 @@ export const GET: RequestHandler = async ({ platform, url }) => {
   if (!env) throw error(503, "Platform not ready");
   const db = drizzle(env.DB);
 
-  const locale = url.searchParams.get("locale") ?? "en";
+  const locale = toLocale(url.searchParams.get("locale") ?? "en");
 
   const collections = await db
     .select()

--- a/src/routes/api/public/shop/products/+server.ts
+++ b/src/routes/api/public/shop/products/+server.ts
@@ -16,6 +16,7 @@
  *     an admin+ session, not shipped as an API surface yet)
  */
 import { json, error } from "@sveltejs/kit";
+import { toLocale } from "$lib/i18n";
 import { ShopService } from "$plugins/shop/service";
 import type { RequestHandler } from "./$types";
 
@@ -23,7 +24,11 @@ export const GET: RequestHandler = async ({ platform, url }) => {
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 
-  const locale = url.searchParams.get("locale") ?? "en";
+  // Validate locale against SUPPORTED_LOCALES; unknown values fall
+  // back to the default (`en`). Prevents echoing arbitrary garbage
+  // in the response and prevents future locale-scoped queries from
+  // reading a bogus value.
+  const locale = toLocale(url.searchParams.get("locale") ?? "en");
   const limitRaw = Number(url.searchParams.get("limit") ?? "20");
   const offsetRaw = Number(url.searchParams.get("offset") ?? "0");
   const limit = Math.max(1, Math.min(100, Number.isFinite(limitRaw) ? limitRaw : 20));

--- a/src/routes/api/public/shop/products/[slug]/+server.ts
+++ b/src/routes/api/public/shop/products/[slug]/+server.ts
@@ -59,11 +59,15 @@ export const GET: RequestHandler = async ({ platform, params }) => {
         // Inventory: onHand + reserved intentionally omitted from the
         // public API — reveals ops data. Only "available" (as a bool)
         // and "count" (when >10, exact number would leak stock signal).
+        // Clamp to 0 before masking: continue-selling variants can go
+        // negative (available = on_hand - reserved past on_hand); a
+        // negative stockCount in the public payload leaks that state.
         inStock: (v.inventory?.available ?? 0) > 0,
-        stockCount:
-          (v.inventory?.available ?? 0) > 10
-            ? null
-            : (v.inventory?.available ?? 0),
+        stockCount: (() => {
+          const raw = v.inventory?.available ?? 0;
+          const clamped = Math.max(0, raw);
+          return clamped > 10 ? null : clamped;
+        })(),
       })),
     },
     {


### PR DESCRIPTION
Post-merge bug hunt on the v3.1 shop plugin ([#56](https://github.com/codustry/khaopad/issues/56), PRs [#71](https://github.com/codustry/khaopad/pull/71)-[#75](https://github.com/codustry/khaopad/pull/75)) found **3 BLOCKERs** that would bite in production. Fixed here + a few SHIP-WITH-CAVEATS caught in the same sweep.

## BLOCKERs

### 1. JSON-LD XSS via \`</script>\` in product description
- **File**: \`src/plugins/shop/jsonld.ts\`
- Admin creates product with title \`Evil</script><script>alert(1)</script>\` → **stored XSS** on every visitor of \`/en/products/evil…\`
- \`JSON.stringify\` doesn't escape \`/\` by default; embedded \`</script>\` breaks out of the container
- **Fix**: \`escapeForScriptTag()\` replaces \`<\` with \`\\u003c\` — applied to both Product and Collection JSON-LD

### 2. \`reserveVariant\` returned counts are racy
- **File**: \`src/plugins/shop/inventory.ts\`
- The atomic UPDATE was correct, but the returned \`onHand\`/\`reserved\` came from a **separate SELECT** — two concurrent reservers' responses could reflect each other's post-state
- **Fix**: use \`RETURNING on_hand, reserved\` on the UPDATE. Atomic, exact. Applied to all 3 primitives (reserveVariant both paths + releaseVariant + commitVariantSale)

### 3. Negative \`stockCount\` leak in public API
- **File**: \`src/routes/api/public/shop/products/[slug]/+server.ts\`
- Continue-selling variant that oversold has \`available < 0\` → public API returned the negative number (mask only kicked in for \`> 10\`)
- **Fix**: \`Math.max(0, available)\` before the mask

## SHIP-WITH-CAVEATS fixed

### 4. Slug collision → nice error instead of 500
- Two products titled "Classic Tee" → second create hit D1 UNIQUE 500 with no user feedback
- **Fix**: pre-check SELECT + catch UNIQUE error at INSERT time, rethrow as \`ShopValidationError\`

### 5. \`commitVariantSale\` silent-clamp telemetry
- \`MAX(x, 0)\` clamps could mask reservation-accounting drift silently
- **Fix**: pre-read state, \`console.warn\` when either counter would go negative

### 6. Locale param validation
- \`?locale=nonsense\` was accepted and echoed
- **Fix**: pass through \`toLocale()\` (validates against \`SUPPORTED_LOCALES\`)

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes in 15s

## Deferred (still SHIP-WITH-CAVEATS, not blocking)

- N+1 duplicate queries in \`hydrateProduct\` — 5 wasted round-trips per product detail view. Not race-unsafe, just wasteful. Best refactored during [#68](https://github.com/codustry/khaopad/issues/68) Phase 1 query-layer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)