### PR TITLE
feat(v3.2-3ab): cart + reservation ledger + orders schema + Beam adapter

### DIFF
--- a/drizzle/0014_plugin_shop_cart_orders.sql
+++ b/drizzle/0014_plugin_shop_cart_orders.sql
@@ -1,0 +1,107 @@
+-- @khaopad/plugin-shop v0.2.0 — cart + reservation ledger + orders
+-- Design decisions documented in src/plugins/shop/schema-cart.ts.
+-- Six tables:
+--   - shop_carts / shop_cart_items — session-cookie-scoped
+--   - shop_inventory_reservations — 15-min TTL ledger for the sweep cron
+--   - shop_orders / shop_order_items — with title/sku/price snapshot cols
+--   - shop_order_adjustments — refunds, withholding tax, manual credits
+
+CREATE TABLE `shop_carts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text,
+  `session_id` text NOT NULL,
+  `previous_session_id` text,
+  `email` text,
+  `status` text DEFAULT 'open' NOT NULL,
+  `checkout_started_at` text,
+  `discount_code` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `shop_carts_session_id_status_idx` ON `shop_carts` (`session_id`, `status`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_cart_items` (
+  `id` text PRIMARY KEY NOT NULL,
+  `cart_id` text NOT NULL,
+  `variant_id` text NOT NULL,
+  `quantity` integer NOT NULL,
+  `price_satang_at_add` integer NOT NULL,
+  `added_at` text NOT NULL,
+  FOREIGN KEY (`cart_id`) REFERENCES `shop_carts`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`variant_id`) REFERENCES `shop_product_variants`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_inventory_reservations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `cart_item_id` text NOT NULL,
+  `variant_id` text NOT NULL,
+  `quantity` integer NOT NULL,
+  `reserved_at` text NOT NULL,
+  `expires_at` text NOT NULL,
+  `released_at` text,
+  `release_reason` text
+);
+--> statement-breakpoint
+-- Sweep cron looks up expired active reservations. Index the pattern.
+CREATE INDEX `shop_reservations_active_idx` ON `shop_inventory_reservations` (`released_at`, `expires_at`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_orders` (
+  `id` text PRIMARY KEY NOT NULL,
+  `order_number` text NOT NULL,
+  `user_id` text,
+  `email` text NOT NULL,
+  `status` text DEFAULT 'pending' NOT NULL,
+  `provider_name` text,
+  `provider_charge_id` text,
+  `subtotal_satang` integer NOT NULL,
+  `shipping_satang` integer DEFAULT 0 NOT NULL,
+  `tax_satang` integer DEFAULT 0 NOT NULL,
+  `discount_satang` integer DEFAULT 0 NOT NULL,
+  `total_satang` integer NOT NULL,
+  `shipping_address_json` text,
+  `billing_address_json` text,
+  `discount_code_snapshot` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `paid_at` text,
+  `fulfilled_at` text,
+  `delivered_at` text,
+  `refunded_at` text,
+  `cancelled_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `shop_orders_order_number_unique` ON `shop_orders` (`order_number`);
+--> statement-breakpoint
+-- Support lookups: guest order lookup by email + order number.
+CREATE INDEX `shop_orders_email_idx` ON `shop_orders` (`email`);
+--> statement-breakpoint
+
+CREATE TABLE `shop_order_items` (
+  `id` text PRIMARY KEY NOT NULL,
+  `order_id` text NOT NULL,
+  `variant_id` text NOT NULL,
+  `quantity` integer NOT NULL,
+  `title_snapshot` text NOT NULL,
+  `sku_snapshot` text,
+  `price_snapshot_satang` integer NOT NULL,
+  `line_subtotal_satang` integer NOT NULL,
+  `line_tax_satang` integer DEFAULT 0 NOT NULL,
+  FOREIGN KEY (`order_id`) REFERENCES `shop_orders`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`variant_id`) REFERENCES `shop_product_variants`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+
+CREATE TABLE `shop_order_adjustments` (
+  `id` text PRIMARY KEY NOT NULL,
+  `order_id` text NOT NULL,
+  `kind` text NOT NULL,
+  `amount_satang` integer NOT NULL,
+  `reason` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`order_id`) REFERENCES `shop_orders`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1785276000000,
       "tag": "0013_plugin_shop_catalog",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1785318000000,
+      "tag": "0014_plugin_shop_cart_orders",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -45,6 +45,12 @@ declare global {
         CMS_SITE_URL: string;
         BETTER_AUTH_SECRET: string;
         BETTER_AUTH_URL: string;
+        // ─── @khaopad/plugin-shop (optional) ───────────────
+        // Present when the shop plugin's payment adapter is configured.
+        // Absent when the shop is running in browse-only mode (no checkout).
+        BEAM_API_KEY?: string;
+        BEAM_WEBHOOK_SECRET?: string;
+        BEAM_BASE_URL?: string;
       };
     }
   }

--- a/src/plugins/shop/beam.ts
+++ b/src/plugins/shop/beam.ts
@@ -1,0 +1,233 @@
+/**
+ * BeamCheckout adapter — implements the PaymentProvider interface for
+ * Thailand-first payment methods: PromptPay QR, credit/debit card,
+ * LINE Pay, TrueMoney.
+ *
+ * Beam is Thailand's answer to Stripe/Adyen — API surface is roughly
+ * Stripe-shaped (Charge object, webhooks with HMAC signatures) but
+ * with Thai payment method affinity built in. Reference implementation
+ * lives at codustry/bactrack-website; this adapter lifts the client
+ * shape but restructures for the plugin runtime.
+ *
+ * Configuration is via env vars (validated at construction time):
+ *   BEAM_API_KEY — secret key from beamcheckout.com dashboard
+ *   BEAM_WEBHOOK_SECRET — for HMAC signature verification
+ *   BEAM_BASE_URL — defaults to https://api.beamcheckout.com/v1
+ *
+ * Not shipped:
+ *   - Recurring payments / subscriptions (Beam doesn't support natively)
+ *   - Instalment plans (v3.5+, requires Beam Plus tier)
+ */
+import type {
+  ChargeInput,
+  ChargeResult,
+  PaymentProvider,
+  RefundInput,
+  RefundResult,
+  WebhookVerifyResult,
+} from "./payment";
+
+const DEFAULT_BEAM_BASE_URL = "https://api.beamcheckout.com/v1";
+
+export type BeamConfig = {
+  apiKey: string;
+  webhookSecret: string;
+  baseUrl?: string;
+};
+
+/**
+ * Compute HMAC-SHA256 hex signature — used both to sign outbound
+ * requests (Beam auth) and to verify inbound webhook signatures.
+ * Uses Web Crypto (available in Cloudflare Workers).
+ */
+async function hmacSha256Hex(secret: string, body: string): Promise<string> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", keyMaterial, enc.encode(body));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Constant-time string comparison for signature verification.
+ * Standard timing-attack mitigation for webhook secrets.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+type BeamChargeCreateResponse = {
+  id: string;
+  status: "pending" | "succeeded" | "failed";
+  amount: number;
+  currency: string;
+  payment_url?: string;
+  qr_code_url?: string; // PromptPay QR
+  metadata?: Record<string, string>;
+};
+
+type BeamRefundResponse = {
+  id: string;
+  charge_id: string;
+  amount: number;
+  status: "pending" | "succeeded" | "failed";
+};
+
+type BeamWebhookEnvelope = {
+  event_type: string;
+  data: {
+    id: string;
+    status: "pending" | "succeeded" | "failed" | "refunded";
+    amount?: number;
+  };
+};
+
+export class BeamPaymentProvider implements PaymentProvider {
+  readonly name = "beam";
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: BeamConfig) {
+    if (!config.apiKey) {
+      throw new Error("BeamPaymentProvider: apiKey is required");
+    }
+    if (!config.webhookSecret) {
+      throw new Error("BeamPaymentProvider: webhookSecret is required");
+    }
+    this.baseUrl = config.baseUrl ?? DEFAULT_BEAM_BASE_URL;
+  }
+
+  async createCharge(input: ChargeInput): Promise<ChargeResult> {
+    try {
+      const res = await fetch(`${this.baseUrl}/charges`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: JSON.stringify({
+          amount: input.amount,
+          currency: input.currency,
+          description: input.description,
+          customer_email: input.customerEmail,
+          return_url: input.returnUrl,
+          metadata: {
+            order_id: input.orderId,
+            ...(input.metadata ?? {}),
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        return {
+          ok: false,
+          code: `HTTP_${res.status}`,
+          message: text.slice(0, 500) || `Beam charge creation failed (${res.status})`,
+        };
+      }
+
+      const body = (await res.json()) as BeamChargeCreateResponse;
+      return {
+        ok: true,
+        providerChargeId: body.id,
+        paymentUrl: body.payment_url,
+        extra: body.qr_code_url ? { qrCodeUrl: body.qr_code_url } : undefined,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, code: "NETWORK_ERROR", message };
+    }
+  }
+
+  async refund(input: RefundInput): Promise<RefundResult> {
+    try {
+      const res = await fetch(`${this.baseUrl}/refunds`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: JSON.stringify({
+          charge_id: input.providerChargeId,
+          amount: input.amount,
+          currency: input.currency,
+          reason: input.reason,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        return {
+          ok: false,
+          code: `HTTP_${res.status}`,
+          message: text.slice(0, 500) || `Beam refund failed (${res.status})`,
+        };
+      }
+      const body = (await res.json()) as BeamRefundResponse;
+      if (body.status === "failed") {
+        return {
+          ok: false,
+          code: "REFUND_FAILED",
+          message: `Refund ${body.id} rejected by Beam`,
+        };
+      }
+      return { ok: true, providerRefundId: body.id };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, code: "NETWORK_ERROR", message };
+    }
+  }
+
+  async verifyWebhook(
+    rawBody: string,
+    signature: string,
+  ): Promise<WebhookVerifyResult> {
+    if (!signature) {
+      return { ok: false, code: "MISSING_SIGNATURE", message: "X-Beam-Signature header absent" };
+    }
+    const expected = await hmacSha256Hex(this.config.webhookSecret, rawBody);
+    if (!timingSafeEqual(expected, signature.toLowerCase())) {
+      return { ok: false, code: "INVALID_SIGNATURE", message: "HMAC mismatch" };
+    }
+    let parsed: BeamWebhookEnvelope;
+    try {
+      parsed = JSON.parse(rawBody) as BeamWebhookEnvelope;
+    } catch {
+      return { ok: false, code: "INVALID_JSON", message: "Body is not JSON" };
+    }
+    const beamStatus = parsed.data?.status;
+    if (!beamStatus) {
+      return {
+        ok: false,
+        code: "MALFORMED_PAYLOAD",
+        message: "data.status missing",
+      };
+    }
+    // Normalize Beam status → interface's canonical status.
+    const status: "succeeded" | "failed" | "refunded" | "pending" =
+      beamStatus === "succeeded"
+        ? "succeeded"
+        : beamStatus === "failed"
+          ? "failed"
+          : beamStatus === "refunded"
+            ? "refunded"
+            : "pending";
+    return {
+      ok: true,
+      eventType: parsed.event_type,
+      providerChargeId: parsed.data.id,
+      status,
+      amount: parsed.data.amount,
+      raw: parsed,
+    };
+  }
+}

--- a/src/plugins/shop/cart-service.ts
+++ b/src/plugins/shop/cart-service.ts
@@ -1,0 +1,608 @@
+/**
+ * Cart service — session-cookie-scoped, wired to inventory reservation
+ * primitives. Called by:
+ *   - POST /api/shop/cart/items — add/update/remove line items
+ *   - POST /api/shop/cart/checkout/start — flip cart to
+ *     checkout_started + reserve inventory for 15 minutes
+ *   - Scheduled Worker cron — sweep expired reservations
+ *
+ * Design decisions:
+ *
+ * 1. **One "open" cart per session at a time** (enforced by the
+ *    UNIQUE index on (session_id, status)). If a customer signs in
+ *    mid-cart, the sessionId rotates; the cart_carts.previousSessionId
+ *    column is set so a second browser tab of the same guest doesn't
+ *    lose items on refresh.
+ *
+ * 2. **Price snapshot on cart_items** — a variant price change while
+ *    the customer is shopping shows the new price at checkout as a
+ *    delta line, not silently rewrites the cart.
+ *
+ * 3. **Reservation happens at checkout-start, not add-to-cart** —
+ *    reserving on add would let stalled carts starve honest buyers.
+ *    Add-to-cart is O(1) and doesn't touch inventory. Reserve happens
+ *    when the customer commits to a payment intent.
+ *
+ * 4. **Reject-not-retry on race**. If two carts start checkout for the
+ *    same last unit, exactly one succeeds; the other gets a clean
+ *    OUT_OF_STOCK line-level error. Never sleep-and-retry.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, inArray, isNull, lt } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import {
+  shopProducts,
+  shopProductLocalizations,
+  shopProductVariants,
+  shopInventoryItems,
+  shopInventoryLevels,
+} from "./schema";
+import {
+  shopCarts,
+  shopCartItems,
+  shopInventoryReservations,
+  type ShopCart,
+  type ShopCartItem,
+  type ShopCartItemWithContext,
+} from "./schema-cart";
+import { reserveVariant, releaseVariant } from "./inventory";
+import { ShopValidationError } from "./service";
+
+// ─── Constants ──────────────────────────────────────────────
+
+/** 15 minutes in milliseconds — the reservation TTL from checkout-start. */
+export const RESERVATION_TTL_MS = 15 * 60 * 1000;
+
+/** 30 days in milliseconds — cart abandonment threshold. */
+export const CART_ABANDONMENT_MS = 30 * 24 * 60 * 60 * 1000;
+
+// ─── Errors ─────────────────────────────────────────────────
+
+export class CartError extends Error {
+  readonly code = "CART_ERROR";
+  constructor(
+    message: string,
+    public readonly reason:
+      | "CART_NOT_FOUND"
+      | "CART_LOCKED"
+      | "VARIANT_UNAVAILABLE"
+      | "OUT_OF_STOCK"
+      | "MAX_QUANTITY_EXCEEDED",
+    public readonly cartItemId?: string,
+  ) {
+    super(message);
+    this.name = "CartError";
+  }
+}
+
+// ─── Service ────────────────────────────────────────────────
+
+export class CartService {
+  private db: ReturnType<typeof drizzle>;
+
+  constructor(private readonly d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  private nowIso() {
+    return new Date().toISOString();
+  }
+
+  /**
+   * Get the open cart for a session, creating one lazily. Idempotent
+   * — safe to call on every request. If a `userId` is supplied and
+   * the cart's userId is null (guest), upgrades the cart to the user.
+   */
+  async ensureCart(input: {
+    sessionId: string;
+    userId?: string | null;
+  }): Promise<ShopCart> {
+    const existing = await this.db
+      .select()
+      .from(shopCarts)
+      .where(
+        and(
+          eq(shopCarts.sessionId, input.sessionId),
+          eq(shopCarts.status, "open"),
+        ),
+      )
+      .limit(1)
+      .get();
+    if (existing) {
+      if (input.userId && !existing.userId) {
+        await this.db
+          .update(shopCarts)
+          .set({ userId: input.userId, updatedAt: this.nowIso() })
+          .where(eq(shopCarts.id, existing.id));
+        return { ...existing, userId: input.userId };
+      }
+      return existing;
+    }
+
+    const id = nanoid();
+    const now = this.nowIso();
+    const row = {
+      id,
+      userId: input.userId ?? null,
+      sessionId: input.sessionId,
+      previousSessionId: null,
+      email: null,
+      status: "open" as const,
+      checkoutStartedAt: null,
+      discountCode: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.db.insert(shopCarts).values(row);
+    return row;
+  }
+
+  /**
+   * List cart items with the context needed to render the cart UI:
+   * variant title, product slug, current price (for delta detection),
+   * available stock.
+   */
+  async listCartItems(cartId: string): Promise<ShopCartItemWithContext[]> {
+    const items = await this.db
+      .select()
+      .from(shopCartItems)
+      .where(eq(shopCartItems.cartId, cartId))
+      .all();
+    if (items.length === 0) return [];
+
+    const variantIds = items.map((i) => i.variantId);
+
+    const variants = await this.db
+      .select()
+      .from(shopProductVariants)
+      .where(inArray(shopProductVariants.id, variantIds))
+      .all();
+    const variantById = new Map(variants.map((v) => [v.id, v]));
+
+    const productIds = Array.from(new Set(variants.map((v) => v.productId)));
+    const products = await this.db
+      .select()
+      .from(shopProducts)
+      .where(inArray(shopProducts.id, productIds))
+      .all();
+    const productById = new Map(products.map((p) => [p.id, p]));
+
+    const locs = await this.db
+      .select()
+      .from(shopProductLocalizations)
+      .where(
+        and(
+          inArray(shopProductLocalizations.productId, productIds),
+          eq(shopProductLocalizations.locale, "en"),
+        ),
+      )
+      .all();
+    const enTitleByProduct = new Map(locs.map((l) => [l.productId, l.title]));
+
+    const inventoryItems = await this.db
+      .select()
+      .from(shopInventoryItems)
+      .where(inArray(shopInventoryItems.variantId, variantIds))
+      .all();
+    const itemByVariant = new Map(inventoryItems.map((i) => [i.variantId, i]));
+
+    const levels = inventoryItems.length
+      ? await this.db
+          .select()
+          .from(shopInventoryLevels)
+          .where(
+            inArray(
+              shopInventoryLevels.itemId,
+              inventoryItems.map((i) => i.id),
+            ),
+          )
+          .all()
+      : [];
+    const levelByItem = new Map(levels.map((l) => [l.itemId, l]));
+
+    return items.map((ci) => {
+      const v = variantById.get(ci.variantId);
+      const p = v ? productById.get(v.productId) : null;
+      const invItem = itemByVariant.get(ci.variantId);
+      const level = invItem ? levelByItem.get(invItem.id) : null;
+      const available = level ? Math.max(0, level.onHand - level.reserved) : 0;
+      return {
+        ...ci,
+        variantTitle: v?.titleCached ?? "",
+        productSlug: p?.slug ?? "",
+        productTitle: p ? enTitleByProduct.get(p.id) ?? p.slug : "",
+        currentPriceSatang: v?.priceSatang ?? ci.priceSatangAtAdd,
+        availableStock: available,
+        mediaId: v?.mediaId ?? p?.featuredMediaId ?? null,
+      };
+    });
+  }
+
+  /**
+   * Add or update a line item. If the (cart, variant) combination
+   * already exists, quantities add (not replace) — matches Shopify's
+   * addToCart semantics. To set an exact quantity, use setQuantity().
+   */
+  async addItem(input: {
+    cartId: string;
+    variantId: string;
+    quantity: number;
+  }): Promise<ShopCartItem> {
+    if (input.quantity <= 0 || !Number.isInteger(input.quantity)) {
+      throw new ShopValidationError(
+        `quantity must be a positive integer, got ${input.quantity}`,
+        "quantity",
+      );
+    }
+    if (input.quantity > 999) {
+      throw new CartError(
+        "Quantity per line item is capped at 999",
+        "MAX_QUANTITY_EXCEEDED",
+      );
+    }
+
+    const cart = await this.db
+      .select()
+      .from(shopCarts)
+      .where(eq(shopCarts.id, input.cartId))
+      .limit(1)
+      .get();
+    if (!cart) throw new CartError("Cart not found", "CART_NOT_FOUND");
+    if (cart.status !== "open") {
+      throw new CartError(
+        `Cart is ${cart.status} — add items to a new cart instead`,
+        "CART_LOCKED",
+      );
+    }
+
+    const variant = await this.db
+      .select()
+      .from(shopProductVariants)
+      .where(eq(shopProductVariants.id, input.variantId))
+      .limit(1)
+      .get();
+    if (!variant || variant.status !== "active") {
+      throw new CartError(
+        `Variant ${input.variantId} is unavailable`,
+        "VARIANT_UNAVAILABLE",
+      );
+    }
+
+    // Deduplicate: existing line for this variant gets its quantity
+    // bumped rather than a second row inserted.
+    const existing = await this.db
+      .select()
+      .from(shopCartItems)
+      .where(
+        and(
+          eq(shopCartItems.cartId, input.cartId),
+          eq(shopCartItems.variantId, input.variantId),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    const now = this.nowIso();
+    if (existing) {
+      const newQty = existing.quantity + input.quantity;
+      if (newQty > 999) {
+        throw new CartError(
+          "Quantity per line item is capped at 999",
+          "MAX_QUANTITY_EXCEEDED",
+        );
+      }
+      await this.db
+        .update(shopCartItems)
+        .set({ quantity: newQty })
+        .where(eq(shopCartItems.id, existing.id));
+      await this.db
+        .update(shopCarts)
+        .set({ updatedAt: now })
+        .where(eq(shopCarts.id, cart.id));
+      return { ...existing, quantity: newQty };
+    }
+
+    const row: ShopCartItem = {
+      id: nanoid(),
+      cartId: input.cartId,
+      variantId: input.variantId,
+      quantity: input.quantity,
+      priceSatangAtAdd: variant.priceSatang,
+      addedAt: now,
+    };
+    await this.db.insert(shopCartItems).values(row);
+    await this.db
+      .update(shopCarts)
+      .set({ updatedAt: now })
+      .where(eq(shopCarts.id, cart.id));
+    return row;
+  }
+
+  async setQuantity(input: {
+    cartId: string;
+    cartItemId: string;
+    quantity: number;
+  }): Promise<ShopCartItem | null> {
+    if (input.quantity < 0 || !Number.isInteger(input.quantity)) {
+      throw new ShopValidationError(
+        `quantity must be a non-negative integer, got ${input.quantity}`,
+        "quantity",
+      );
+    }
+    if (input.quantity === 0) {
+      await this.removeItem({
+        cartId: input.cartId,
+        cartItemId: input.cartItemId,
+      });
+      return null;
+    }
+    if (input.quantity > 999) {
+      throw new CartError(
+        "Quantity per line item is capped at 999",
+        "MAX_QUANTITY_EXCEEDED",
+      );
+    }
+    await this.db
+      .update(shopCartItems)
+      .set({ quantity: input.quantity })
+      .where(
+        and(
+          eq(shopCartItems.id, input.cartItemId),
+          eq(shopCartItems.cartId, input.cartId),
+        ),
+      );
+    await this.db
+      .update(shopCarts)
+      .set({ updatedAt: this.nowIso() })
+      .where(eq(shopCarts.id, input.cartId));
+    const row = await this.db
+      .select()
+      .from(shopCartItems)
+      .where(eq(shopCartItems.id, input.cartItemId))
+      .limit(1)
+      .get();
+    return row ?? null;
+  }
+
+  async removeItem(input: {
+    cartId: string;
+    cartItemId: string;
+  }): Promise<void> {
+    await this.db
+      .delete(shopCartItems)
+      .where(
+        and(
+          eq(shopCartItems.id, input.cartItemId),
+          eq(shopCartItems.cartId, input.cartId),
+        ),
+      );
+    await this.db
+      .update(shopCarts)
+      .set({ updatedAt: this.nowIso() })
+      .where(eq(shopCarts.id, input.cartId));
+  }
+
+  /**
+   * Flip an open cart to `checkout_started` and reserve inventory
+   * for every line for 15 minutes. Atomic per-line: if any reserve
+   * fails, all previously-reserved lines in this call are released.
+   *
+   * Returns the reservation records so the checkout page can display
+   * "Reservation expires in 14:52" countdowns.
+   */
+  async startCheckout(input: {
+    cartId: string;
+    email: string;
+  }): Promise<{
+    cart: ShopCart;
+    reservations: Array<{
+      cartItemId: string;
+      variantId: string;
+      quantity: number;
+      expiresAt: string;
+    }>;
+  }> {
+    const cart = await this.db
+      .select()
+      .from(shopCarts)
+      .where(eq(shopCarts.id, input.cartId))
+      .limit(1)
+      .get();
+    if (!cart) throw new CartError("Cart not found", "CART_NOT_FOUND");
+    if (cart.status !== "open") {
+      throw new CartError(
+        `Cart is already ${cart.status}`,
+        "CART_LOCKED",
+      );
+    }
+
+    const items = await this.db
+      .select()
+      .from(shopCartItems)
+      .where(eq(shopCartItems.cartId, input.cartId))
+      .all();
+    if (items.length === 0) {
+      throw new ShopValidationError("Cart is empty", "cart");
+    }
+
+    // Try to reserve every line. Track successes so we can roll back
+    // on the first failure — atomic-per-cart even though the underlying
+    // reserves are per-line.
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + RESERVATION_TTL_MS).toISOString();
+    const reservationInserts: Array<{
+      id: string;
+      cartItemId: string;
+      variantId: string;
+      quantity: number;
+      reservedAt: string;
+      expiresAt: string;
+      releasedAt: null;
+      releaseReason: null;
+    }> = [];
+    const rolledBack: Array<{ variantId: string; quantity: number }> = [];
+
+    try {
+      for (const item of items) {
+        const outcome = await reserveVariant(
+          this.d1,
+          item.variantId,
+          item.quantity,
+        );
+        if (!outcome.ok) {
+          if (outcome.reason === "NOT_TRACKED") {
+            // Untracked stock: no reservation needed, but still record
+            // the ledger row so accounting downstream is uniform.
+            reservationInserts.push({
+              id: nanoid(),
+              cartItemId: item.id,
+              variantId: item.variantId,
+              quantity: item.quantity,
+              reservedAt: now.toISOString(),
+              expiresAt,
+              releasedAt: null,
+              releaseReason: null,
+            });
+            continue;
+          }
+          throw new CartError(
+            `Line ${item.id} could not be reserved: ${outcome.reason}`,
+            "OUT_OF_STOCK",
+            item.id,
+          );
+        }
+        rolledBack.push({
+          variantId: item.variantId,
+          quantity: item.quantity,
+        });
+        reservationInserts.push({
+          id: nanoid(),
+          cartItemId: item.id,
+          variantId: item.variantId,
+          quantity: item.quantity,
+          reservedAt: now.toISOString(),
+          expiresAt,
+          releasedAt: null,
+          releaseReason: null,
+        });
+      }
+    } catch (err) {
+      for (const back of rolledBack) {
+        try {
+          await releaseVariant(this.d1, back.variantId, back.quantity);
+        } catch {
+          /* best-effort rollback */
+        }
+      }
+      throw err;
+    }
+
+    // Persist the ledger + flip the cart status. Sequential is fine
+    // (single Worker request); a full D1 batch is a v3.2 refinement
+    // if this becomes a hot path.
+    await this.db.insert(shopInventoryReservations).values(reservationInserts);
+    await this.db
+      .update(shopCarts)
+      .set({
+        status: "checkout_started",
+        email: input.email,
+        checkoutStartedAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      })
+      .where(eq(shopCarts.id, input.cartId));
+
+    return {
+      cart: {
+        ...cart,
+        status: "checkout_started",
+        email: input.email,
+        checkoutStartedAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+      reservations: reservationInserts.map((r) => ({
+        cartItemId: r.cartItemId,
+        variantId: r.variantId,
+        quantity: r.quantity,
+        expiresAt: r.expiresAt,
+      })),
+    };
+  }
+
+  /**
+   * Sweep expired reservations. Called by the scheduled Worker cron
+   * every minute. Returns the number of reservations released.
+   *
+   * A reservation is expired when:
+   *   - `released_at IS NULL` (still active)
+   *   - `expires_at < now`
+   *
+   * The sweep calls releaseVariant() for each row, then marks the
+   * ledger row with release_reason='expired' and releasedAt=now.
+   *
+   * Idempotent — a second sweep in the same window is a no-op.
+   */
+  async sweepExpiredReservations(now: Date = new Date()): Promise<number> {
+    const nowIso = now.toISOString();
+    const expired = await this.db
+      .select()
+      .from(shopInventoryReservations)
+      .where(
+        and(
+          isNull(shopInventoryReservations.releasedAt),
+          lt(shopInventoryReservations.expiresAt, nowIso),
+        ),
+      )
+      .all();
+
+    let released = 0;
+    for (const r of expired) {
+      try {
+        await releaseVariant(this.d1, r.variantId, r.quantity);
+        released++;
+      } catch {
+        // Reservation refers to a deleted variant — skip, mark ledger
+        // as released anyway so we don't retry forever.
+      }
+      await this.db
+        .update(shopInventoryReservations)
+        .set({ releasedAt: nowIso, releaseReason: "expired" })
+        .where(eq(shopInventoryReservations.id, r.id));
+    }
+
+    // Also flip carts whose checkout_started is older than the TTL to
+    // 'expired' status so a re-visit from the same session starts a
+    // fresh cart. Cart items are preserved for one refresh so the
+    // customer can see what they lost.
+    const cutoff = new Date(now.getTime() - RESERVATION_TTL_MS).toISOString();
+    await this.db
+      .update(shopCarts)
+      .set({ status: "expired", updatedAt: nowIso })
+      .where(
+        and(
+          eq(shopCarts.status, "checkout_started"),
+          lt(shopCarts.checkoutStartedAt, cutoff),
+        ),
+      );
+
+    return released;
+  }
+
+  /**
+   * Sweep 30-day-old open carts to `abandoned`. Called by the same
+   * cron. Cart_items are NOT deleted — the abandoned-cart email flow
+   * in v3.4 walks these to build the recovery URL.
+   */
+  async sweepAbandonedCarts(now: Date = new Date()): Promise<number> {
+    const nowIso = now.toISOString();
+    const cutoff = new Date(now.getTime() - CART_ABANDONMENT_MS).toISOString();
+    const result = await this.d1
+      .prepare(
+        `UPDATE shop_carts
+         SET status = 'abandoned', updated_at = ?1
+         WHERE status = 'open' AND updated_at < ?2`,
+      )
+      .bind(nowIso, cutoff)
+      .run();
+    return (result.meta as { changes?: number })?.changes ?? 0;
+  }
+}

--- a/src/plugins/shop/index.ts
+++ b/src/plugins/shop/index.ts
@@ -66,7 +66,26 @@ registerNavGroup({
 export default defineKhaopadPlugin({
   slug: "shop",
   name: "Shop",
-  version: "0.1.0",
+  version: "0.2.0",
   description:
     "Small ecommerce: products, variants, cart, checkout (BeamCheckout for Thailand)",
+  async onInit(ctx) {
+    // Register BeamCheckout provider at first-request time (needs env).
+    // Skip silently when Beam credentials aren't set — the shop still
+    // ships product catalog + cart, checkout will surface a helpful
+    // 503 if a payment attempt fires without a configured provider.
+    const beamKey = ctx.env.BEAM_API_KEY;
+    const beamWebhookSecret = ctx.env.BEAM_WEBHOOK_SECRET;
+    if (beamKey && beamWebhookSecret) {
+      const { BeamPaymentProvider } = await import("./beam");
+      const { registerPaymentProvider } = await import("./payment");
+      registerPaymentProvider(
+        new BeamPaymentProvider({
+          apiKey: beamKey,
+          webhookSecret: beamWebhookSecret,
+          baseUrl: ctx.env.BEAM_BASE_URL,
+        }),
+      );
+    }
+  },
 });

--- a/src/plugins/shop/payment.ts
+++ b/src/plugins/shop/payment.ts
@@ -1,0 +1,109 @@
+/**
+ * Payment provider interface + registry.
+ *
+ * Providers are added to `providers` map at boot (see index.ts). v3.2
+ * ships BeamCheckout only; #61 adds Stripe + Omise. Interface is
+ * intentionally minimal — anything beyond create/refund/verify-webhook
+ * goes into provider-specific extensions callers can dispatch by
+ * `provider.name`.
+ *
+ * Money is always in the smallest unit: satang for THB, cents for USD.
+ * Providers translate internally. The `Satang` type is not enforced
+ * on the interface because a provider may charge in USD/JPY etc.
+ * (call sites in v3.2 always pass Satang — enforcement stays there.)
+ */
+import type { Satang } from "./money";
+
+export type ChargeInput = {
+  /** Store-side reference. Providers store this as their `metadata.orderId`. */
+  orderId: string;
+  /** Human-readable — printed on customer's statement / receipt. */
+  description: string;
+  amount: Satang | number;
+  currency: string; // ISO 4217, e.g. "THB"
+  /** Customer email — required by most providers for receipts. */
+  customerEmail: string;
+  /** Return URL after payment (BeamCheckout, Stripe Checkout, etc.). */
+  returnUrl: string;
+  /** Optional metadata forwarded to provider (surfaces on their dashboard). */
+  metadata?: Record<string, string>;
+};
+
+export type ChargeResult =
+  | {
+      ok: true;
+      /** Provider-native charge id (Beam chargeId, Stripe pi_..., etc.). */
+      providerChargeId: string;
+      /** URL to redirect the customer to for payment. */
+      paymentUrl?: string;
+      /** Extra provider-specific fields for the storefront (QR code URL, etc.). */
+      extra?: Record<string, unknown>;
+    }
+  | {
+      ok: false;
+      /** Machine code — 'INVALID_AMOUNT', 'PROVIDER_DOWN', 'CARD_DECLINED', etc. */
+      code: string;
+      message: string;
+    };
+
+export type RefundInput = {
+  providerChargeId: string;
+  amount: Satang | number;
+  currency: string;
+  reason?: string;
+};
+
+export type RefundResult =
+  | { ok: true; providerRefundId: string }
+  | { ok: false; code: string; message: string };
+
+export type WebhookVerifyResult =
+  | {
+      ok: true;
+      eventType: string;
+      providerChargeId: string;
+      /** 'succeeded' | 'failed' | 'refunded' | 'pending' — normalized status. */
+      status: "succeeded" | "failed" | "refunded" | "pending";
+      /** Amount at the event moment (for partial refunds this may differ from original charge). */
+      amount?: number;
+      raw: unknown;
+    }
+  | { ok: false; code: string; message: string };
+
+export interface PaymentProvider {
+  readonly name: string;
+
+  createCharge(input: ChargeInput): Promise<ChargeResult>;
+  refund(input: RefundInput): Promise<RefundResult>;
+
+  /**
+   * Verify a webhook signature and normalize the event.
+   * `signature` comes from the provider's header (Beam uses
+   * `X-Beam-Signature`, Stripe uses `Stripe-Signature`, etc.).
+   */
+  verifyWebhook(
+    rawBody: string,
+    signature: string,
+  ): WebhookVerifyResult | Promise<WebhookVerifyResult>;
+}
+
+// ─── Registry ───────────────────────────────────────────────
+
+const registeredProviders = new Map<string, PaymentProvider>();
+
+/**
+ * Register a payment provider at boot. Idempotent — a second call
+ * with the same name overwrites (useful for tests). Providers are
+ * only instantiated once, at the shop plugin's module load.
+ */
+export function registerPaymentProvider(provider: PaymentProvider): void {
+  registeredProviders.set(provider.name, provider);
+}
+
+export function getPaymentProvider(name: string): PaymentProvider | null {
+  return registeredProviders.get(name) ?? null;
+}
+
+export function listPaymentProviders(): PaymentProvider[] {
+  return Array.from(registeredProviders.values());
+}

--- a/src/plugins/shop/schema-cart.ts
+++ b/src/plugins/shop/schema-cart.ts
@@ -1,0 +1,277 @@
+/**
+ * Cart + reservation ledger + orders — v3.2 additions to the shop
+ * schema.
+ *
+ * Kept in a separate file from schema.ts (which is v3.1 catalog) so
+ * the split is legible: catalog is a stable long-lived model, cart
+ * data has a short TTL (30-day cart expiry, 15-min reservation TTL,
+ * orders forever).
+ *
+ * Design decisions:
+ *
+ * 1. **Cart is session-cookie-scoped** — cartId lives in a signed
+ *    HttpOnly cookie. Guest and logged-in checkout share the same
+ *    cart table; the `userId` column is null for guests, set when
+ *    the customer signs in mid-cart.
+ *
+ * 2. **Prices captured on cart_items at add-to-cart time** so a
+ *    price change mid-session doesn't surprise the customer. The
+ *    v3.2 checkout re-validates against current variant price and
+ *    surfaces the delta if it moved.
+ *
+ * 3. **Reservation ledger** (shop_inventory_reservations) records
+ *    every reservation with a 15-min TTL. Sweep cron (v3.2) walks
+ *    expired rows and calls `releaseVariant()` from inventory.ts.
+ *    Each ledger row references the cart_item so the sweep knows
+ *    which reserved qty to release.
+ *
+ * 4. **Order line-item snapshot** — shop_order_items carries
+ *    `titleSnapshot`, `skuSnapshot`, `priceSnapshotSatang`. Design-
+ *    review must-fix: never lazy-join the variant row for historical
+ *    receipts; the variant may be archived or the price changed.
+ *
+ * 5. **Order number is human-readable** — `KHP-YYYY-NNNNN` (Khao Pad
+ *    year 5-digit sequence). Stored separately from `id` (nanoid).
+ *    Customers reference the order number; the id is for internal use.
+ *
+ * 6. **Payment provider is opaque string** — `providerName` +
+ *    `providerChargeId` on shop_orders. Beam ships in v3.2; Stripe +
+ *    Omise ship in #61. Interface is the escape hatch.
+ */
+import {
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { shopProductVariants } from "./schema";
+
+// ─── Carts ──────────────────────────────────────────────────
+
+export const shopCarts = sqliteTable(
+  "shop_carts",
+  {
+    id: text("id").primaryKey(),
+    // Set when the customer signs in mid-cart; null for guests.
+    userId: text("user_id"),
+    // Session cookie value that opened the cart. Rotated on sign-in
+    // (session upgrade) — old value is preserved as `previousSessionId`
+    // so a race between two tabs of the same guest doesn't lose items.
+    sessionId: text("session_id").notNull(),
+    previousSessionId: text("previous_session_id"),
+    // Contact info collected during checkout. Nullable until customer
+    // starts entering it (the initial add-to-cart is fully anonymous).
+    email: text("email"),
+    // 'open' | 'checkout_started' | 'ordered' | 'abandoned' | 'expired'
+    // - open: normal browsing state
+    // - checkout_started: inventory reservations have been placed
+    //   (they hold for 15 minutes from this transition)
+    // - ordered: payment succeeded, order row created
+    // - abandoned: sweep detected no activity for 30 days
+    // - expired: sweep detected checkout_started > 15 min without pay
+    status: text("status", {
+      enum: ["open", "checkout_started", "ordered", "abandoned", "expired"],
+    })
+      .notNull()
+      .default("open"),
+    // Set when status flips to checkout_started — used to compute
+    // reservation expiry (checkoutStartedAt + 15 minutes).
+    checkoutStartedAt: text("checkout_started_at"),
+    // Optional discount code applied at checkout (v3.4 feature; column
+    // exists now so the shape is stable — no discount table until then).
+    discountCode: text("discount_code"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    sessionIdx: uniqueIndex("shop_carts_session_id_status_idx").on(
+      t.sessionId,
+      t.status,
+    ),
+  }),
+);
+
+export const shopCartItems = sqliteTable("shop_cart_items", {
+  id: text("id").primaryKey(),
+  cartId: text("cart_id")
+    .notNull()
+    .references(() => shopCarts.id, { onDelete: "cascade" }),
+  variantId: text("variant_id")
+    .notNull()
+    .references(() => shopProductVariants.id, { onDelete: "restrict" }),
+  quantity: integer("quantity").notNull(),
+  // Price snapshot at add-to-cart time. Never lazy-fetch — a price
+  // change mid-session would silently rewrite the customer's cart.
+  priceSatangAtAdd: integer("price_satang_at_add").notNull(),
+  addedAt: text("added_at").notNull(),
+});
+
+// ─── Reservation ledger ─────────────────────────────────────
+
+export const shopInventoryReservations = sqliteTable(
+  "shop_inventory_reservations",
+  {
+    id: text("id").primaryKey(),
+    // The cart_item this reservation is tied to. When the cart_item
+    // is deleted, the reservation is also released (via app-code
+    // callback into releaseVariant() — not FK cascade, because the
+    // reservation ledger persists after the reservation is released
+    // for audit purposes).
+    cartItemId: text("cart_item_id").notNull(),
+    variantId: text("variant_id").notNull(),
+    quantity: integer("quantity").notNull(),
+    // Set at reservation-create. `expiresAt = reservedAt + 15 min`.
+    // Sweep cron walks WHERE released_at IS NULL AND expires_at < now.
+    reservedAt: text("reserved_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+    // Filled when the reservation is either committed to a sale
+    // (payment success) or explicitly released (cart abandonment,
+    // sweep). Null while active.
+    releasedAt: text("released_at"),
+    // 'committed' | 'released' | 'expired'
+    releaseReason: text("release_reason", {
+      enum: ["committed", "released", "expired"],
+    }),
+  },
+);
+
+// ─── Orders ─────────────────────────────────────────────────
+
+export const shopOrders = sqliteTable(
+  "shop_orders",
+  {
+    id: text("id").primaryKey(),
+    // Human-readable — `KHP-YYYY-NNNNN`. Shown to customers, used in
+    // support requests, printed on receipts.
+    orderNumber: text("order_number").notNull().unique(),
+    // Set when the customer was signed in at checkout; null for guests.
+    userId: text("user_id"),
+    // Always populated — collected during checkout.
+    email: text("email").notNull(),
+    // 'pending' | 'paid' | 'fulfilled' | 'delivered' | 'refunded' | 'cancelled'
+    status: text("status", {
+      enum: [
+        "pending",
+        "paid",
+        "fulfilled",
+        "delivered",
+        "refunded",
+        "cancelled",
+      ],
+    })
+      .notNull()
+      .default("pending"),
+    // Payment provider that handled the charge. `beam` for v3.2;
+    // `stripe` / `omise` land in #61.
+    providerName: text("provider_name"),
+    // Opaque charge id from the provider (Beam's chargeId, Stripe's
+    // pi_..., etc.). Used to look up the charge for refunds.
+    providerChargeId: text("provider_charge_id"),
+    // Monetary totals, all in satang. Computed at checkout, frozen
+    // into the order row — subsequent variant/price/tax changes do
+    // not affect the historical order.
+    subtotalSatang: integer("subtotal_satang").notNull(),
+    shippingSatang: integer("shipping_satang").notNull().default(0),
+    taxSatang: integer("tax_satang").notNull().default(0),
+    discountSatang: integer("discount_satang").notNull().default(0),
+    totalSatang: integer("total_satang").notNull(),
+    // Shipping address (JSON blob — the shipping-zone matcher parses
+    // country_code; the rest is opaque to the shop plugin).
+    shippingAddressJson: text("shipping_address_json"),
+    // Billing address — often same as shipping. Nullable for digital-
+    // only orders (variant.requiresShipping=false for all lines).
+    billingAddressJson: text("billing_address_json"),
+    // Applied at checkout — snapshot the discount code even though
+    // shop_discount_codes table doesn't exist until v3.4. Text is
+    // fine, we're just recording what was used.
+    discountCodeSnapshot: text("discount_code_snapshot"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    // Set when status flips to `paid` — the moment inventory was
+    // committed and the customer got the receipt.
+    paidAt: text("paid_at"),
+    fulfilledAt: text("fulfilled_at"),
+    deliveredAt: text("delivered_at"),
+    refundedAt: text("refunded_at"),
+    cancelledAt: text("cancelled_at"),
+  },
+);
+
+// ─── Order line items ───────────────────────────────────────
+
+export const shopOrderItems = sqliteTable("shop_order_items", {
+  id: text("id").primaryKey(),
+  orderId: text("order_id")
+    .notNull()
+    .references(() => shopOrders.id, { onDelete: "cascade" }),
+  // Variant FK is `RESTRICT` (not CASCADE) — historical orders must
+  // always resolve back to a variant even if the product was later
+  // deleted. Enforced by the variant status=archived flow (never
+  // hard-delete a variant).
+  variantId: text("variant_id")
+    .notNull()
+    .references(() => shopProductVariants.id, { onDelete: "restrict" }),
+  quantity: integer("quantity").notNull(),
+  // Snapshot columns — design-review must-fix. Never lazy-join the
+  // variant row for historical receipts.
+  titleSnapshot: text("title_snapshot").notNull(),
+  skuSnapshot: text("sku_snapshot"),
+  priceSnapshotSatang: integer("price_snapshot_satang").notNull(),
+  // Line total = priceSnapshotSatang * quantity, stored so the order
+  // summary doesn't have to recompute on every read.
+  lineSubtotalSatang: integer("line_subtotal_satang").notNull(),
+  // Per-line tax (frozen at checkout).
+  lineTaxSatang: integer("line_tax_satang").notNull().default(0),
+});
+
+// ─── Order adjustments ──────────────────────────────────────
+
+/**
+ * Miscellaneous adjustments that apply to the order — refunds (partial
+ * or full), withholding tax lines, manual credits, etc. Sign convention:
+ *   - Positive = adds to what customer paid (e.g. a manual surcharge)
+ *   - Negative = reduces (refund, discount, withholding tax)
+ *
+ * Sums into the order's balance calculation; the running total is the
+ * source of truth for "what does the customer owe" during a dispute.
+ */
+export const shopOrderAdjustments = sqliteTable("shop_order_adjustments", {
+  id: text("id").primaryKey(),
+  orderId: text("order_id")
+    .notNull()
+    .references(() => shopOrders.id, { onDelete: "cascade" }),
+  kind: text("kind", {
+    enum: [
+      "refund_full",
+      "refund_partial",
+      "withholding_tax",
+      "manual_credit",
+      "manual_surcharge",
+    ],
+  }).notNull(),
+  amountSatang: integer("amount_satang").notNull(),
+  reason: text("reason"),
+  createdBy: text("created_by"),
+  createdAt: text("created_at").notNull(),
+});
+
+// ─── Type exports ───────────────────────────────────────────
+
+export type ShopCart = typeof shopCarts.$inferSelect;
+export type ShopCartItem = typeof shopCartItems.$inferSelect;
+export type ShopInventoryReservation =
+  typeof shopInventoryReservations.$inferSelect;
+export type ShopOrder = typeof shopOrders.$inferSelect;
+export type ShopOrderItem = typeof shopOrderItems.$inferSelect;
+export type ShopOrderAdjustment = typeof shopOrderAdjustments.$inferSelect;
+
+/** Cart items with variant + product context for rendering. */
+export type ShopCartItemWithContext = ShopCartItem & {
+  variantTitle: string;
+  productSlug: string;
+  productTitle: string;
+  currentPriceSatang: number; // for price-change detection at checkout
+  availableStock: number;
+  mediaId: string | null;
+};


### PR DESCRIPTION
First bundled sub-PR of v3.2 ([#57](https://github.com/codustry/khaopad/issues/57)). Ships cart data model + reservation ledger + BeamCheckout adapter. Sets up the ground for 3c/3d (order service + public checkout routes + webhook handler).

## What ships

### Schema (6 new tables, migration 0014)
- \`shop_carts\` + \`shop_cart_items\` — session-cookie-scoped
- \`shop_inventory_reservations\` — 15-min TTL ledger for sweep cron
- \`shop_orders\` + \`shop_order_items\` — with title/sku/price snapshot cols (design-review must-fix)
- \`shop_order_adjustments\` — refunds, withholding tax, manual credits

### Cart service
\`CartService\` — ensureCart, listCartItems, addItem, setQuantity, removeItem, **startCheckout** (atomic-per-cart with per-line reservation rollback on failure), **sweepExpiredReservations**, **sweepAbandonedCarts**.

### Payment interface
\`PaymentProvider\` + \`registerPaymentProvider\` + \`getPaymentProvider\`. Runtime registry so #61 slots in Stripe + Omise behind the same interface.

### Beam adapter
\`BeamPaymentProvider\` — createCharge / refund / verifyWebhook with HMAC-SHA256 + constant-time comparison. Registered in shop plugin's \`onInit(ctx)\` — needs env, not module load. Skipped silently when \`BEAM_API_KEY\` absent.

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes

## Next sub-PRs

- **3c+3d**: order service + public /cart, /checkout, /pay, /order/[number], /lookup routes + Beam webhook handler
- **3e**: admin order list + refund UI + sweep cron wiring + receipt emails
- **3f-3h**: shipping zones + tax rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)