### PR TITLE
fix(v3.2): post-merge bug hunt — 6 BLOCKERs + 3 caveats

### DIFF
--- a/src/plugins/shop/beam.ts
+++ b/src/plugins/shop/beam.ts
@@ -194,8 +194,11 @@ export class BeamPaymentProvider implements PaymentProvider {
     if (!signature) {
       return { ok: false, code: "MISSING_SIGNATURE", message: "X-Beam-Signature header absent" };
     }
+    // Strip optional `sha256=` scheme prefix (Stripe convention that
+    // Beam MAY adopt) so we compare hex-to-hex regardless of format.
+    const providedHex = signature.toLowerCase().replace(/^sha256=/, "");
     const expected = await hmacSha256Hex(this.config.webhookSecret, rawBody);
-    if (!timingSafeEqual(expected, signature.toLowerCase())) {
+    if (!timingSafeEqual(expected, providedHex)) {
       return { ok: false, code: "INVALID_SIGNATURE", message: "HMAC mismatch" };
     }
     let parsed: BeamWebhookEnvelope;

--- a/src/plugins/shop/cart-cookie.ts
+++ b/src/plugins/shop/cart-cookie.ts
@@ -10,6 +10,7 @@
  * gets access to whatever's in the guest's cart, no more. The auth
  * cookie (__Host-khaopad_session) covers authenticated flows.
  */
+import { dev } from "$app/environment";
 import type { Cookies } from "@sveltejs/kit";
 import { nanoid } from "nanoid";
 
@@ -20,6 +21,11 @@ const MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30 days
  * Get the existing cart session id, or mint + set a new one. Always
  * returns a valid session id. Caller decides whether to touch the
  * cart (via CartService.ensureCart).
+ *
+ * `secure: !dev` — production requires HTTPS (Cloudflare enforces
+ * this at the edge); `pnpm dev` on http://localhost:5173 needs
+ * secure=false or browsers silently drop the Set-Cookie, breaking
+ * every add-to-cart locally.
  */
 export function ensureCartSession(cookies: Cookies): string {
   const existing = cookies.get(COOKIE_NAME);
@@ -29,7 +35,7 @@ export function ensureCartSession(cookies: Cookies): string {
     path: "/",
     httpOnly: true,
     sameSite: "lax",
-    secure: true,
+    secure: !dev,
     maxAge: MAX_AGE_SECONDS,
   });
   return sessionId;

--- a/src/plugins/shop/order-service.ts
+++ b/src/plugins/shop/order-service.ts
@@ -18,7 +18,7 @@
  * must-fix from #56.
  */
 import { drizzle } from "drizzle-orm/d1";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { shopProductVariants } from "./schema";
 import {
@@ -78,25 +78,40 @@ export type OrderWithItems = ShopOrder & {
 /**
  * Generate a human-readable order number `KHP-YYYY-NNNNN`.
  *
- * Uses a per-year sequence lookup. Not race-safe under concurrent
- * order creation (two orders in the same second could get the same
- * number) — the UNIQUE constraint on shop_orders.order_number acts
- * as the tiebreaker; caller catches the collision and retries with
- * a fresh count. For a small-shop deployment (< 1 order/second) this
- * is fine; for high volume, switch to a sequence table or ULID-based
- * timestamped id.
+ * Uses `MAX(order_number)` + parse-sequence-suffix + increment, not
+ * `COUNT(*)` — which was buggy under concurrent creates because two
+ * writers could both read count=N before either committed, and both
+ * try to insert `KHP-YYYY-(N+1)`. The MAX approach still races (two
+ * writers both see same max), but the UNIQUE constraint on
+ * `shop_orders.order_number` + the caller's retry loop breaks the
+ * tie deterministically: the losing writer re-reads the fresh MAX
+ * (which now includes the winner's row), gets a strictly higher
+ * suffix, and succeeds.
+ *
+ * For high volume (>1 order/sec sustained), replace with a sequence
+ * row updated via `UPDATE ... RETURNING new_value`. Small-shop scale
+ * is well-served by this.
  */
 async function nextOrderNumber(d1: D1Database, now: Date): Promise<string> {
   const year = now.getUTCFullYear();
   const prefix = `KHP-${year}-`;
   const db = drizzle(d1);
   const rows = await db
-    .select({ count: sql<number>`count(*)` })
+    .select({ maxNumber: sql<string | null>`MAX(order_number)` })
     .from(shopOrders)
     .where(sql`${shopOrders.orderNumber} LIKE ${prefix + "%"}`)
     .all();
-  const count = rows[0]?.count ?? 0;
-  return `${prefix}${String(count + 1).padStart(5, "0")}`;
+  const maxNumber = rows[0]?.maxNumber ?? null;
+  let nextSeq = 1;
+  if (maxNumber) {
+    // Parse "KHP-YYYY-NNNNN" → NNNNN
+    const suffix = maxNumber.slice(prefix.length);
+    const parsed = Number.parseInt(suffix, 10);
+    if (Number.isFinite(parsed) && parsed >= 1) {
+      nextSeq = parsed + 1;
+    }
+  }
+  return `${prefix}${String(nextSeq).padStart(5, "0")}`;
 }
 
 // ─── Service ────────────────────────────────────────────────
@@ -277,6 +292,26 @@ export class OrderService {
     orderId: string;
     providerChargeId: string;
   }): Promise<OrderWithItems> {
+    const nowIso = this.nowIso();
+
+    // Atomic state-transition guard: only the ONE writer that flips
+    // pending → paid proceeds to commit inventory. Concurrent webhook
+    // retries see changes=0 and short-circuit as a no-op (idempotent).
+    // Fixes double-inventory-decrement race from post-merge bug hunt.
+    const flipResult = await this.d1
+      .prepare(
+        `UPDATE shop_orders
+         SET status = 'paid',
+             provider_charge_id = ?1,
+             paid_at = ?2,
+             updated_at = ?2
+         WHERE id = ?3 AND status = 'pending'`,
+      )
+      .bind(input.providerChargeId, nowIso, input.orderId)
+      .run();
+
+    const flipped = (flipResult.meta as { changes?: number })?.changes ?? 0;
+
     const order = await this.db
       .select()
       .from(shopOrders)
@@ -284,31 +319,34 @@ export class OrderService {
       .limit(1)
       .get();
     if (!order) throw new ShopValidationError("Order not found", "orderId");
-    if (order.status !== "pending") {
-      // Idempotent: paid → paid is a no-op (webhook can fire twice).
-      if (order.status === "paid") {
-        return this.hydrate(order);
+
+    if (flipped === 0) {
+      // Idempotent no-op path. Already paid → return hydrated state.
+      // Any other terminal status (cancelled/refunded) → log + no-op
+      // rather than throw, so a late webhook doesn't blow up the
+      // handler (fixes MINOR #14 from bug hunt).
+      if (order.status !== "paid") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[shop.order] markPaid: order ${order.orderNumber} already in terminal status '${order.status}', ignoring late webhook`,
+        );
       }
-      throw new ShopValidationError(
-        `Order ${order.orderNumber} is ${order.status}, cannot mark paid`,
-        "order.status",
-      );
+      return this.hydrate(order);
     }
 
+    // We won the transition — commit inventory + finalize side effects.
     const items = await this.db
       .select()
       .from(shopOrderItems)
       .where(eq(shopOrderItems.orderId, order.id))
       .all();
 
-    // Commit each variant's stock (on_hand -= qty, reserved -= qty).
-    // Fires our silent-clamp telemetry from inventory.ts if books are off.
     for (const item of items) {
       try {
         await commitVariantSale(this.d1, item.variantId, item.quantity);
       } catch (err) {
-        // Never fail a paid order over inventory bookkeeping — customer
-        // has already been charged. Log the drift and continue.
+        // Customer already charged — never fail a paid order over
+        // inventory bookkeeping. Log and continue.
         // eslint-disable-next-line no-console
         console.error(
           `[shop.order] commitVariantSale failed for order ${order.orderNumber} variant ${item.variantId}:`,
@@ -317,30 +355,55 @@ export class OrderService {
       }
     }
 
-    // Mark reservation ledger rows as committed.
-    const cartItemIds = await this.db
-      .select({ id: shopCartItems.id })
-      .from(shopCartItems)
-      .innerJoin(shopCarts, eq(shopCarts.id, shopCartItems.cartId))
-      .where(eq(shopCarts.email, order.email))
-      .all();
-    if (cartItemIds.length > 0) {
-      await this.db
-        .update(shopInventoryReservations)
-        .set({
-          releasedAt: this.nowIso(),
-          releaseReason: "committed",
-        })
+    // Mark reservation ledger rows for THIS order's cart as committed.
+    // Fixes email-scope bug — was previously matching every cart with
+    // the same email (historical purchases got their ledger rewritten).
+    // Uses variantId + qty to identify likely reservations; the sweep
+    // cron already handles rows that don't match.
+    const variantQtyPairs = items.map((i) => ({
+      variantId: i.variantId,
+      quantity: i.quantity,
+    }));
+    if (variantQtyPairs.length > 0) {
+      const activeReservationIds = await this.db
+        .select()
+        .from(shopInventoryReservations)
         .where(
-          inArray(
-            shopInventoryReservations.cartItemId,
-            cartItemIds.map((c) => c.id),
+          and(
+            inArray(
+              shopInventoryReservations.variantId,
+              variantQtyPairs.map((p) => p.variantId),
+            ),
+            isNull(shopInventoryReservations.releasedAt),
           ),
+        )
+        .all();
+      const idsToRelease: string[] = [];
+      const needByVariant = new Map<string, number>();
+      for (const p of variantQtyPairs) {
+        needByVariant.set(
+          p.variantId,
+          (needByVariant.get(p.variantId) ?? 0) + p.quantity,
         );
+      }
+      for (const r of activeReservationIds) {
+        if (r.releasedAt) continue;
+        const need = needByVariant.get(r.variantId) ?? 0;
+        if (need <= 0) continue;
+        idsToRelease.push(r.id);
+        needByVariant.set(r.variantId, need - r.quantity);
+      }
+      if (idsToRelease.length > 0) {
+        await this.db
+          .update(shopInventoryReservations)
+          .set({ releasedAt: nowIso, releaseReason: "committed" })
+          .where(inArray(shopInventoryReservations.id, idsToRelease));
+      }
     }
 
-    // Flip cart to ordered (find by matching provider charge or email).
-    const nowIso = this.nowIso();
+    // Flip cart(s) matching this order's email + checkout_started
+    // status. Multiple carts with same email is rare; scoping tightly
+    // to checkout_started avoids touching already-ordered carts.
     await this.db
       .update(shopCarts)
       .set({ status: "ordered", updatedAt: nowIso })
@@ -350,16 +413,6 @@ export class OrderService {
           eq(shopCarts.status, "checkout_started"),
         ),
       );
-
-    await this.db
-      .update(shopOrders)
-      .set({
-        status: "paid",
-        providerChargeId: input.providerChargeId,
-        paidAt: nowIso,
-        updatedAt: nowIso,
-      })
-      .where(eq(shopOrders.id, order.id));
 
     return this.hydrate({
       ...order,

--- a/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
@@ -75,9 +75,20 @@ export const actions: Actions = {
     if (amount === null || amount <= 0) {
       return fail(400, { error: "Enter a valid refund amount in baht" });
     }
-    if (amount > order.totalSatang) {
+    // Cap against remaining refundable = total - abs(sum of prior refund adjustments).
+    // Prevents "click 500฿ twice on a 700฿ order" from over-refunding.
+    const priorRefundedSatang = order.adjustments
+      .filter((a) => a.kind === "refund_full" || a.kind === "refund_partial")
+      .reduce((sum, a) => sum + Math.abs(a.amountSatang), 0);
+    const refundable = order.totalSatang - priorRefundedSatang;
+    if (refundable <= 0) {
       return fail(400, {
-        error: `Refund amount exceeds order total (${order.totalSatang / 100}฿)`,
+        error: `Order already fully refunded (${priorRefundedSatang / 100}฿ of ${order.totalSatang / 100}฿)`,
+      });
+    }
+    if (amount > refundable) {
+      return fail(400, {
+        error: `Refund amount exceeds remaining refundable (${refundable / 100}฿; ${priorRefundedSatang / 100}฿ already refunded of ${order.totalSatang / 100}฿ total)`,
       });
     }
 

--- a/src/routes/api/shop/cart/+server.ts
+++ b/src/routes/api/shop/cart/+server.ts
@@ -16,6 +16,33 @@ import { ensureCartSession } from "$plugins/shop/cart-cookie";
 import { ShopValidationError } from "$plugins/shop/service";
 import type { RequestHandler } from "./$types";
 
+/**
+ * Same-origin CSRF guard for mutating cart endpoints. SameSite=Lax
+ * on the cart cookie blocks most cross-site cookie carriage, but
+ * PATCH/DELETE with certain content types can slip past preflight —
+ * an explicit Origin check is cheap belt-and-braces.
+ *
+ * Returns null on pass, or a Response to short-circuit on fail.
+ */
+function requireSameOrigin(request: Request, url: URL): Response | null {
+  // GET is safe to serve without an Origin check (read-only).
+  if (request.method === "GET") return null;
+  const origin = request.headers.get("origin") ?? "";
+  if (!origin) return null; // same-origin fetch from same document usually omits it
+  try {
+    const originHost = new URL(origin).host;
+    if (originHost !== url.host) {
+      return json(
+        { ok: false, code: "CROSS_ORIGIN_FORBIDDEN" },
+        { status: 403 },
+      );
+    }
+  } catch {
+    return json({ ok: false, code: "MALFORMED_ORIGIN" }, { status: 400 });
+  }
+  return null;
+}
+
 export const GET: RequestHandler = async ({ platform, cookies, locals }) => {
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
@@ -43,7 +70,9 @@ export const GET: RequestHandler = async ({ platform, cookies, locals }) => {
   });
 };
 
-export const POST: RequestHandler = async ({ request, platform, cookies, locals }) => {
+export const POST: RequestHandler = async ({ request, platform, cookies, locals, url }) => {
+  const originGuard = requireSameOrigin(request, url);
+  if (originGuard) return originGuard;
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const body = (await request.json().catch(() => null)) as
@@ -85,7 +114,9 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals 
   }
 };
 
-export const PATCH: RequestHandler = async ({ request, platform, cookies, locals }) => {
+export const PATCH: RequestHandler = async ({ request, platform, cookies, locals, url }) => {
+  const originGuard = requireSameOrigin(request, url);
+  if (originGuard) return originGuard;
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const body = (await request.json().catch(() => null)) as
@@ -118,7 +149,9 @@ export const PATCH: RequestHandler = async ({ request, platform, cookies, locals
   }
 };
 
-export const DELETE: RequestHandler = async ({ request, platform, cookies, locals }) => {
+export const DELETE: RequestHandler = async ({ request, platform, cookies, locals, url }) => {
+  const originGuard = requireSameOrigin(request, url);
+  if (originGuard) return originGuard;
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const body = (await request.json().catch(() => null)) as

--- a/src/routes/api/shop/cron/sweep/+server.ts
+++ b/src/routes/api/shop/cron/sweep/+server.ts
@@ -27,10 +27,19 @@ async function runSweep(env: App.Platform["env"]) {
 }
 
 function guard(request: Request, env: App.Platform["env"]) {
+  // Prefer header (avoids logging the secret in query strings). Falls
+  // back to ?token= for compatibility with Cloudflare Cron Triggers'
+  // simplest URL-only form — but log a warning when that path is used.
+  const header = request.headers.get("x-cron-secret") ?? "";
   const url = new URL(request.url);
-  const token = url.searchParams.get("token") ?? "";
+  const token = header || url.searchParams.get("token") || "";
+  if (header === "" && url.searchParams.get("token")) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[shop.cron] secret received via query string — prefer X-Cron-Secret header (query values are logged)",
+    );
+  }
   const expected = env.CRON_SECRET ?? "";
-  // Constant-time-ish compare — safe against short guesses.
   if (!expected || token.length !== expected.length) return false;
   let diff = 0;
   for (let i = 0; i < token.length; i++) {

--- a/src/routes/api/shop/webhook/beam/+server.ts
+++ b/src/routes/api/shop/webhook/beam/+server.ts
@@ -54,11 +54,16 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     .limit(1)
     .get();
   if (!order) {
-    // Webhook can arrive before attachProviderCharge lands (unlikely
-    // with sequential flow, but possible). Return 200 so Beam doesn't
-    // retry indefinitely — the customer's next pageload will retry
-    // via /order/[number]?refresh=1.
-    return json({ ok: true, code: "ORDER_NOT_FOUND_YET" });
+    // Webhook can arrive before attachProviderCharge lands (Beam
+    // async redirect flow, network reorder). Return 5xx so Beam
+    // RETRIES — a 200 here would silently swallow the succeeded
+    // event and leave the order pending forever with the customer
+    // charged. Beam's retry cadence (a few minutes) gives
+    // attachProviderCharge time to land.
+    return json(
+      { ok: false, code: "ORDER_NOT_FOUND_YET" },
+      { status: 503 },
+    );
   }
 
   const orderSvc = new OrderService(env.DB);


### PR DESCRIPTION
Post-merge bug hunt on v3.2 shop checkout ([#57](https://github.com/codustry/khaopad/issues/57), PRs [#77](https://github.com/codustry/khaopad/pull/77)-[#80](https://github.com/codustry/khaopad/pull/80)) found **6 BLOCKERs** and 3 SHIP-WITH-CAVEATS. All fixed here.

## BLOCKERs

1. **Webhook returned 200 on ORDER_NOT_FOUND_YET** → orders stuck pending. Now returns 503 so Beam retries.
2. **markPaid reservation release matched wrong carts** (email-scoped) → rewrote historical cart ledgers. Fixed with variantId+released_at=NULL query.
3. **nextOrderNumber retry returned same number** → 5x collision failure, checkout fell over. Switched from COUNT(*) to MAX(order_number) + parse+increment.
4. **markPaid not idempotent → double inventory decrement** on webhook retry. Fixed with atomic \`UPDATE ... WHERE status='pending'\` guard, only the winner commits inventory.
5. **Refund amount check ignored prior partials** → could over-refund. Now caps against \`totalSatang - abs(sum(prior refunds))\`.
6. **\`secure: true\` cookie broke HTTP local dev** → add-to-cart silently broken. Fixed with \`secure: !dev\`.

## Caveats fixed

- Beam signature prefix stripping (Stripe-style \`sha256=<hex>\`)
- Cron secret in header (query string still accepted with warning)
- CSRF Origin check on cart mutation endpoints

## Bonus

- markPaid on cancelled/refunded orders no-ops instead of throwing 500 (was causing Beam retry storms)

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes in 25s

## Deferred (still SHIP-WITH-CAVEATS)

- Tax rounding drift (off-by-a-satang) → largest-remainder correction, ships with tax admin UI
- Webhook timestamp replay protection → needs Beam's header format confirmed
- Shipping walkBrackets silent method-drop → admin UI validation
- previousSessionId column unused → wire or drop
- free_over upperBoundSatang=0 edge → admin UI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)