### PR TITLE
feat(v3.3-4c): Merchant Center feed + noindex,follow on facets — closes v3.3

### DIFF
--- a/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
@@ -13,6 +13,7 @@ import { logAudit } from "$lib/server/audit";
 import { OrderService } from "$plugins/shop/order-service";
 import { getPaymentProvider } from "$plugins/shop/payment";
 import { parseBahtToSatang } from "$plugins/shop/money";
+import { track, buildEventContext } from "$lib/server/analytics/track";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform, params }) => {
@@ -49,7 +50,7 @@ export const actions: Actions = {
     return { success: true, message: "Marked delivered" };
   },
 
-  refund: async ({ request, locals, platform, params }) => {
+  refund: async ({ request, locals, platform, params, url }) => {
     if (!locals.user) throw redirect(302, "/admin/login");
     if (!hasRole(locals.user, "admin")) return fail(403, { error: "Forbidden" });
     const env = platform?.env;
@@ -123,6 +124,23 @@ export const actions: Actions = {
       kind,
       providerRefundId: refundResult.providerRefundId,
     });
+    // Fire refund analytics event. Admin action, so context uses the
+    // admin's session id (event dashboards will filter by name only).
+    void track(
+      env.DB,
+      "refund",
+      {
+        orderId: params.id,
+        amountSatang: amount,
+        kind: kind === "refund_full" ? "full" : "partial",
+      },
+      buildEventContext({
+        url,
+        request,
+        sessionId: locals.user.id,
+        userId: locals.user.id,
+      }),
+    );
     return {
       success: true,
       message: `Refund of ${amount / 100}฿ processed (${refundResult.providerRefundId})`,

--- a/src/routes/(www)/[locale]/collections/[slug]/+page.server.ts
+++ b/src/routes/(www)/[locale]/collections/[slug]/+page.server.ts
@@ -148,6 +148,28 @@ export const load: PageServerLoad = async ({ params, url, platform }) => {
     productSlugs: orderedProducts.map((p) => p.slug),
   });
 
+  // v3.3 SEO polish: any filter/facet query param (e.g. ?color=red,
+  // ?size=m, ?sort=price-asc) turns the URL into a facet page — mark
+  // noindex,follow so Google follows out-links but doesn't index the
+  // filter permutation. Prevents crawl-budget bleed. Canonical still
+  // points at the base collection URL so link equity consolidates.
+  //
+  // The check is on ANY unknown param: known display flags (utm_*,
+  // ref, gclid) are ignored — they're marketing tokens, not facets.
+  const KNOWN_NON_FACET_PARAMS = new Set([
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "ref",
+    "gclid",
+    "fbclid",
+  ]);
+  const hasFacetParam = Array.from(url.searchParams.keys()).some(
+    (k) => !KNOWN_NON_FACET_PARAMS.has(k),
+  );
+
   const seo: PageSeo = {
     title: collection.seoTitle ?? localization.title,
     description:
@@ -157,6 +179,7 @@ export const load: PageServerLoad = async ({ params, url, platform }) => {
         : undefined),
     canonical,
     ogType: "website",
+    robots: hasFacetParam ? "noindex,follow" : undefined,
   };
 
   return {

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -7,6 +7,8 @@ import {
 } from "$lib/server/forms";
 import { logAudit } from "$lib/server/audit";
 import { commentsAllowedForArticle } from "$lib/server/comments";
+import { track, buildEventContext } from "$lib/server/analytics/track";
+import { ensureCartSession } from "$plugins/shop/cart-cookie";
 import type { RequestHandler } from "./$types";
 
 const MAX_NAME = 80;
@@ -33,6 +35,8 @@ export const POST: RequestHandler = async ({
   locals,
   platform,
   getClientAddress,
+  cookies,
+  url,
 }) => {
   let payload: Record<string, FormDataEntryValue>;
   try {
@@ -111,6 +115,20 @@ export const POST: RequestHandler = async ({
       "comment.create",
       comment.id,
       { articleId: article.id, slug: article.slug },
+    );
+    // Fire comment_submit analytics event — feeds the per-article
+    // engagement metrics.
+    const sessionId = ensureCartSession(cookies);
+    void track(
+      platform.env.DB,
+      "comment_submit",
+      { articleId: article.id },
+      buildEventContext({
+        url,
+        request,
+        sessionId,
+        userId: locals.user?.id ?? null,
+      }),
     );
   }
 

--- a/src/routes/feeds/google-merchant.xml/+server.ts
+++ b/src/routes/feeds/google-merchant.xml/+server.ts
@@ -1,0 +1,197 @@
+/**
+ * GET /feeds/google-merchant.xml — Google Merchant Center product feed.
+ *
+ * Format: Google's RSS 2.0 dialect with the `g:` namespace, described
+ * at https://support.google.com/merchants/answer/7052112.
+ *
+ * Emits every active shop product with a purchasable variant. The
+ * canonical URL points at the product page (not a variant param) so
+ * Google consolidates equity to one URL — matching the design-review
+ * variants-as-query-param decision from #56.
+ *
+ * Cached at the edge for an hour — Merchant Center polls a few times
+ * a day, more frequent updates aren't worth the D1 hit.
+ *
+ * v3.3 minimum viable emit: id / title / description / link / image_link
+ * (when featured media exists) / availability / price / brand.
+ * v3.4+ additions: gtin/mpn, additional_image_link, shipping,
+ * item_group_id for variants.
+ */
+import { error } from "@sveltejs/kit";
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, inArray } from "drizzle-orm";
+import { resolveOrigin } from "$lib/seo";
+import {
+  shopInventoryItems,
+  shopInventoryLevels,
+  shopProductLocalizations,
+  shopProductVariants,
+  shopProducts,
+} from "$plugins/shop/schema";
+import type { RequestHandler } from "./$types";
+
+function escapeXml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export const GET: RequestHandler = async ({ platform, url }) => {
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+  const db = drizzle(env.DB);
+
+  const origin = resolveOrigin(url, env.PUBLIC_SITE_URL);
+
+  // Every active product with at least one active variant + inventory > 0.
+  const products = await db
+    .select()
+    .from(shopProducts)
+    .where(eq(shopProducts.status, "active"))
+    .all();
+
+  const productIds = products.map((p) => p.id);
+  if (productIds.length === 0) {
+    return new Response(emptyFeed(origin), {
+      headers: xmlHeaders(),
+    });
+  }
+
+  const variants = await db
+    .select()
+    .from(shopProductVariants)
+    .where(
+      and(
+        inArray(shopProductVariants.productId, productIds),
+        eq(shopProductVariants.status, "active"),
+      ),
+    )
+    .all();
+
+  const variantIds = variants.map((v) => v.id);
+  const invItems = variantIds.length
+    ? await db
+        .select()
+        .from(shopInventoryItems)
+        .where(inArray(shopInventoryItems.variantId, variantIds))
+        .all()
+    : [];
+  const itemsByVariant = new Map(invItems.map((i) => [i.variantId, i]));
+  const invIds = invItems.map((i) => i.id);
+  const invLevels = invIds.length
+    ? await db
+        .select()
+        .from(shopInventoryLevels)
+        .where(inArray(shopInventoryLevels.itemId, invIds))
+        .all()
+    : [];
+  const levelsByItem = new Map(invLevels.map((l) => [l.itemId, l]));
+
+  // English localizations for title/description (feed doesn't yet do
+  // per-locale variants — v3.4 will emit language-tagged copies).
+  const enLocs = await db
+    .select()
+    .from(shopProductLocalizations)
+    .where(
+      and(
+        inArray(shopProductLocalizations.productId, productIds),
+        eq(shopProductLocalizations.locale, "en"),
+      ),
+    )
+    .all();
+  const enByProduct = new Map(enLocs.map((l) => [l.productId, l]));
+
+  const variantsByProduct = new Map<string, typeof variants>();
+  for (const v of variants) {
+    const arr = variantsByProduct.get(v.productId) ?? [];
+    arr.push(v);
+    variantsByProduct.set(v.productId, arr);
+  }
+
+  const items: string[] = [];
+  for (const product of products) {
+    const prodVariants = variantsByProduct.get(product.id) ?? [];
+    if (prodVariants.length === 0) continue;
+
+    // Determine stock: any variant with available > 0 (or untracked
+    // inventory items) → in stock.
+    let inStock = false;
+    for (const v of prodVariants) {
+      const inv = itemsByVariant.get(v.id);
+      if (!inv?.tracked) {
+        inStock = true;
+        break;
+      }
+      const level = levelsByItem.get(inv.id);
+      if (level && level.onHand - level.reserved > 0) {
+        inStock = true;
+        break;
+      }
+    }
+    if (!inStock) continue;
+
+    // Cheapest variant price for the feed. Google treats this as the
+    // display price; variants share one product listing.
+    const minPriceSatang = Math.min(...prodVariants.map((v) => v.priceSatang));
+    if (!Number.isFinite(minPriceSatang) || minPriceSatang <= 0) continue;
+
+    const loc = enByProduct.get(product.id);
+    const title = loc?.title ?? product.slug;
+    const description = loc?.descriptionMarkdown ?? title;
+    const link = `${origin}/en/products/${product.slug}`;
+    const priceStr = `${(minPriceSatang / 100).toFixed(2)} THB`;
+    const availability = "in_stock";
+
+    const parts = [
+      `      <g:id>${escapeXml(product.id)}</g:id>`,
+      `      <title>${escapeXml(title.slice(0, 150))}</title>`,
+      `      <description>${escapeXml(description.slice(0, 5000))}</description>`,
+      `      <link>${escapeXml(link)}</link>`,
+      `      <g:condition>new</g:condition>`,
+      `      <g:availability>${availability}</g:availability>`,
+      `      <g:price>${escapeXml(priceStr)}</g:price>`,
+    ];
+    if (product.featuredMediaId) {
+      const imageLink = `${origin}/api/media/${product.featuredMediaId}`;
+      parts.push(`      <g:image_link>${escapeXml(imageLink)}</g:image_link>`);
+    }
+    if (product.vendor) {
+      parts.push(`      <g:brand>${escapeXml(product.vendor.slice(0, 70))}</g:brand>`);
+    }
+
+    items.push(`    <item>\n${parts.join("\n")}\n    </item>`);
+  }
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">
+  <channel>
+    <title>Khao Pad shop</title>
+    <link>${escapeXml(origin)}</link>
+    <description>Product feed for Google Merchant Center.</description>
+${items.join("\n")}
+  </channel>
+</rss>`;
+
+  return new Response(xml, { headers: xmlHeaders() });
+};
+
+function xmlHeaders() {
+  return {
+    "content-type": "application/xml; charset=utf-8",
+    "cache-control": "public, max-age=3600, s-maxage=3600",
+  };
+}
+
+function emptyFeed(origin: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">
+  <channel>
+    <title>Khao Pad shop</title>
+    <link>${escapeXml(origin)}</link>
+    <description>Product feed for Google Merchant Center.</description>
+  </channel>
+</rss>`;
+}


### PR DESCRIPTION
Final sub-PR of v3.3 ([#58](https://github.com/codustry/khaopad/issues/58)). Closes Phase 4.

## What ships

- **\`/feeds/google-merchant.xml\`** — RSS 2.0 with \`g:\` namespace, one entry per active in-stock product. Cached 1h at edge.
- **noindex,follow on facet URLs** — \`/collections/[slug]?color=red\` marked noindex so Google consolidates equity to the base collection URL. Skips utm_*/ref/gclid/fbclid params (marketing tokens ≠ facets).
- **Two more events instrumented**: \`refund\` (from admin refund action) + \`comment_submit\` (from public comment POST).

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes

## v3.3 recap (3 sub-PRs)

| PR | Scope |
|---|---|
| [#82](https://github.com/codustry/khaopad/pull/82) 4a | events table + typed track() + 4 shop funnel events |
| [#83](https://github.com/codustry/khaopad/pull/83) 4b | page_view hook + ArticleReadTracker + 2 admin dashboards |
| this 4c | Merchant Center feed + facet noindex + refund/comment events |

Closes [#58](https://github.com/codustry/khaopad/issues/58).

## Not yet shipped (deferred to follow-ups; not blocking)

- Remaining 8 canonical events (search, cta_click, add_payment_info, remove_from_cart, subscribe, form_submit) — 10-line adds at their POST sites
- INP web-vital client instrumentation
- Per-line purchase events (unlocks revenue attribution in per-product dashboard)
- Slug → article id map for page_view tagging (per-article pageViews reads 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)