### PR TITLE
fix(v3.3): post-merge bug hunt — 3 BLOCKERs + 1 caveat

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -443,12 +443,26 @@ const analyticsPageViewHook: Handle = async ({ event, resolve }) => {
     ) {
       return response;
     }
-    if (response.status >= 400) return response;
-    // JSON client-navigation fetches (data.json) — skip.
-    const accept = event.request.headers.get("accept") ?? "";
-    if (accept.includes("application/json") && !accept.includes("text/html")) {
+    // SPA client-navigation data fetches — SvelteKit hits
+    // `/<path>/__data.json?...` on every soft nav; if we don't skip
+    // these, every navigation fires TWO page_views (initial SSR + the
+    // subsequent data-only fetch). The `Accept: application/json`
+    // check from the initial commit isn't reliable — SvelteKit sends
+    // default Accept. Filter on the URL shape + on SvelteKit's
+    // `isDataRequest` flag (set by the runtime for internal fetches).
+    if (
+      path.endsWith("/__data.json") ||
+      event.url.searchParams.has("x-sveltekit-invalidated") ||
+      // isDataRequest exists on SvelteKit >=2 for exactly this case
+      (event as unknown as { isDataRequest?: boolean }).isDataRequest === true
+    ) {
       return response;
     }
+    // Count only successful renders (2xx). 3xx redirects don't count
+    // as viewed pages — an auth redirect at `/admin` → `/admin/login`
+    // shouldn't inflate homepage view counts. 4xx/5xx errors also
+    // aren't real content-served pages.
+    if (response.status >= 300) return response;
     const env = event.platform?.env;
     if (!env) return response;
     const { track, buildEventContext } = await import(

--- a/src/routes/(www)/[locale]/collections/[slug]/+page.server.ts
+++ b/src/routes/(www)/[locale]/collections/[slug]/+page.server.ts
@@ -156,6 +156,9 @@ export const load: PageServerLoad = async ({ params, url, platform }) => {
   //
   // The check is on ANY unknown param: known display flags (utm_*,
   // ref, gclid) are ignored — they're marketing tokens, not facets.
+  // Marketing tokens + pagination + sort are NOT facets — allow them
+  // to stay indexable. Everything else (color, size, price-range, etc.)
+  // becomes a facet permutation we don't want in the index.
   const KNOWN_NON_FACET_PARAMS = new Set([
     "utm_source",
     "utm_medium",
@@ -165,6 +168,8 @@ export const load: PageServerLoad = async ({ params, url, platform }) => {
     "ref",
     "gclid",
     "fbclid",
+    "page", // pagination — /collections/tees?page=2 must stay indexable
+    "sort", // sort variant of a canonical collection
   ]);
   const hasFacetParam = Array.from(url.searchParams.keys()).some(
     (k) => !KNOWN_NON_FACET_PARAMS.has(k),

--- a/src/routes/(www)/[locale]/products/[slug]/+page.server.ts
+++ b/src/routes/(www)/[locale]/products/[slug]/+page.server.ts
@@ -84,6 +84,10 @@ export const load: PageServerLoad = async ({ params, url, platform, locals }) =>
 
   return {
     product: {
+      // Canonical product id — analytics event tagging relies on this
+      // so the per-product dashboard's queries by product.id resolve.
+      // Previously fired with `product.slug` which broke the join.
+      id: product.id,
       slug: product.slug,
       status: product.status,
       vendor: product.vendor,

--- a/src/routes/(www)/[locale]/products/[slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/products/[slug]/+page.svelte
@@ -27,13 +27,13 @@
 		goto(`?${params}`, { replaceState: true, noScroll: true, keepFocus: true });
 	}
 
-	// Fire product_view once on mount. Includes selected variant so
-	// per-variant conversion funnels can be sliced (though the
-	// dashboard v4a doesn't split by variant yet).
+	// Fire product_view once on mount. Tagged with the canonical
+	// product id so the per-product dashboard's queries (which key
+	// on the same id) actually find these rows.
 	onMount(() => {
 		if (!selectedVariant) return;
 		track('product_view', {
-			productId: product.slug, // storefront doesn't expose product id — use slug
+			productId: product.id,
 			variantId: selectedVariant.id,
 			priceSatang: selectedVariant.priceSatang,
 		});

--- a/src/routes/api/shop/cart/+server.ts
+++ b/src/routes/api/shop/cart/+server.ts
@@ -11,9 +11,12 @@
  * the cart to the user id automatically.
  */
 import { error, json } from "@sveltejs/kit";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
 import { CartService, CartError } from "$plugins/shop/cart-service";
 import { ensureCartSession } from "$plugins/shop/cart-cookie";
 import { ShopValidationError } from "$plugins/shop/service";
+import { shopProductVariants } from "$plugins/shop/schema";
 import { track, buildEventContext } from "$lib/server/analytics/track";
 import type { RequestHandler } from "./$types";
 
@@ -97,24 +100,39 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals,
       variantId: body.variantId,
       quantity,
     });
-    // Fire add_to_cart. Fire-and-forget — analytics failure never
-    // blocks the cart write.
-    void track(
-      env.DB,
-      "add_to_cart",
-      {
-        productId: item.variantId, // v3.3 stores variantId, dashboards can join to product
-        variantId: item.variantId,
-        quantity: item.quantity,
-        priceSatang: item.priceSatangAtAdd,
-      },
-      buildEventContext({
-        url,
-        request,
-        sessionId,
-        userId: locals.user?.id ?? null,
-      }),
-    );
+    // Fire add_to_cart tagged with the canonical productId (not the
+    // variantId — that broke the per-product dashboard's join).
+    // Resolve productId via a single-row select — cheap; fire-and-forget.
+    void (async () => {
+      try {
+        const dbLite = drizzle(env.DB);
+        const variantRow = await dbLite
+          .select({ productId: shopProductVariants.productId })
+          .from(shopProductVariants)
+          .where(eq(shopProductVariants.id, item.variantId))
+          .limit(1)
+          .get();
+        if (!variantRow) return;
+        await track(
+          env.DB,
+          "add_to_cart",
+          {
+            productId: variantRow.productId,
+            variantId: item.variantId,
+            quantity: item.quantity,
+            priceSatang: item.priceSatangAtAdd,
+          },
+          buildEventContext({
+            url,
+            request,
+            sessionId,
+            userId: locals.user?.id ?? null,
+          }),
+        );
+      } catch {
+        /* analytics failure never blocks — swallow */
+      }
+    })();
     return json({ ok: true, item });
   } catch (err) {
     if (err instanceof CartError) {

--- a/src/routes/api/shop/webhook/beam/+server.ts
+++ b/src/routes/api/shop/webhook/beam/+server.ts
@@ -17,8 +17,8 @@ import { getPaymentProvider } from "$plugins/shop/payment";
 import { OrderService } from "$plugins/shop/order-service";
 import { sendOrderReceipt } from "$plugins/shop/email";
 import { drizzle } from "drizzle-orm/d1";
-import { eq } from "drizzle-orm";
-import { shopOrders } from "$plugins/shop/schema-cart";
+import { and, eq, desc } from "drizzle-orm";
+import { shopCarts, shopOrders } from "$plugins/shop/schema-cart";
 import { track, buildEventContext } from "$lib/server/analytics/track";
 import type { RequestHandler } from "./$types";
 
@@ -80,11 +80,23 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
       sendOrderReceipt(env, paid).catch(() => {
         /* email module already logs failures */
       });
-      // Fire analytics purchase event. The webhook has no cookies/URL
-      // context (Beam calls us server-to-server), so we synthesize a
-      // minimal context — session id falls back to the order id itself
-      // so per-session funnel queries don't lose the event; the shop
-      // funnel dashboard groups by attributedArticleId anyway.
+      // Fire analytics purchase event. Look up the cart that was
+      // ordered to reuse the visitor's session id — otherwise the
+      // funnel (product_view → add_to_cart → begin_checkout →
+      // purchase) can't join by session_id and conversion looks 0.
+      const cartRow = await drizzle(env.DB)
+        .select({ sessionId: shopCarts.sessionId })
+        .from(shopCarts)
+        .where(
+          and(
+            eq(shopCarts.email, paid.email),
+            eq(shopCarts.status, "ordered"),
+          ),
+        )
+        .orderBy(desc(shopCarts.updatedAt))
+        .limit(1)
+        .get();
+      const sessionIdForFunnel = cartRow?.sessionId ?? paid.id;
       await track(
         env.DB,
         "purchase",
@@ -97,7 +109,7 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
         buildEventContext({
           url,
           request,
-          sessionId: paid.id,
+          sessionId: sessionIdForFunnel,
           userId: paid.userId ?? null,
           locale: "en",
         }),


### PR DESCRIPTION
Post-merge bug hunt on v3.3 ([#58](https://github.com/codustry/khaopad/issues/58), PRs [#82](https://github.com/codustry/khaopad/pull/82)-[#84](https://github.com/codustry/khaopad/pull/84)) found **3 BLOCKERs**.

1. **Product analytics dashboard always showed 0** — three different id spaces in `product_id` column. Fixed by exposing canonical product.id + resolving variant→product server-side.
2. **page_view double-fires on SPA navigation** — SvelteKit's `__data.json` fetches passed the Accept check. Fixed with URL-shape + `isDataRequest` filter. Also tightened to `status < 300`.
3. **Purchase event orphaned from funnel** — sessionId=paid.id created session-of-one. Fixed with cart lookup at webhook time.

Plus caveat: facet detector marked `?page=2` noindex (dropped paginated pages from index). Fixed.

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)