### PR TITLE
feat(v3.4): article ↔ product federation + purchase attribution — closes v3.4

### DIFF
--- a/drizzle/0017_plugin_shop_federation.sql
+++ b/drizzle/0017_plugin_shop_federation.sql
@@ -1,0 +1,20 @@
+-- @khaopad/plugin-shop v0.4.0 — article ↔ product federation.
+-- One join table for the "Related products" / "Featured on articles"
+-- relationships. Design in src/plugins/shop/schema-federation.ts.
+
+CREATE TABLE `shop_article_product_refs` (
+  `article_id` text NOT NULL,
+  `product_id` text NOT NULL,
+  `ref_kind` text DEFAULT 'mentioned' NOT NULL,
+  `position` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  `created_by` text,
+  PRIMARY KEY(`article_id`, `product_id`, `ref_kind`),
+  FOREIGN KEY (`product_id`) REFERENCES `shop_products`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- Support "products for this article" AND "articles for this product"
+-- lookup paths equally cheaply.
+CREATE INDEX `shop_article_product_refs_article_idx` ON `shop_article_product_refs` (`article_id`);
+--> statement-breakpoint
+CREATE INDEX `shop_article_product_refs_product_idx` ON `shop_article_product_refs` (`product_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785330000000,
       "tag": "0016_analytics_events",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1785333000000,
+      "tag": "0017_plugin_shop_federation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/admin/RelatedProductsEditor.svelte
+++ b/src/lib/components/admin/RelatedProductsEditor.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+	/**
+	 * v3.4 federation editor — pick products + refKind to attach to an
+	 * article. Submits as `refs[]=productId:refKind` form values so the
+	 * server action parses without any JSON dance.
+	 *
+	 * Ships as a compact section in the article editor. When the shop
+	 * plugin isn't enabled, productChoices arrives empty and the whole
+	 * section shows a friendly disabled state.
+	 */
+	import { enhance } from '$app/forms';
+	import { Package, Save } from 'lucide-svelte';
+	import { Button } from '$lib/components/ui';
+
+	type RefKind = 'featured' | 'mentioned' | 'promoted';
+	type Ref = { productId: string; refKind: RefKind };
+	type ProductChoice = { id: string; title: string; slug: string };
+
+	let {
+		currentRefs,
+		productChoices,
+	}: {
+		currentRefs: Array<{ productId: string; refKind: RefKind }>;
+		productChoices: ProductChoice[];
+	} = $props();
+
+	// Build a local editable state: for each product, remember which
+	// ref kind (if any) is currently selected. 'none' means unlinked.
+	type Selection = 'none' | RefKind;
+	const initial = $derived(
+		new Map<string, Selection>(
+			productChoices.map((p) => {
+				const existing = currentRefs.find((r) => r.productId === p.id);
+				return [p.id, (existing?.refKind ?? 'none') as Selection];
+			}),
+		),
+	);
+	let selection = $state<Map<string, Selection>>(new Map(initial));
+	let submitting = $state(false);
+
+	// Recompute selection when the source data changes (route nav).
+	$effect(() => {
+		selection = new Map(initial);
+	});
+
+	function setKind(productId: string, kind: Selection) {
+		const next = new Map(selection);
+		next.set(productId, kind);
+		selection = next;
+	}
+</script>
+
+<section class="space-y-4 rounded-lg border border-border p-4">
+	<div class="flex items-center gap-3">
+		<Package class="h-5 w-5 text-muted-foreground" />
+		<h2 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+			Related products
+		</h2>
+	</div>
+
+	{#if productChoices.length === 0}
+		<p class="text-sm text-muted-foreground">
+			No published products to link. When the shop plugin has active
+			products, they'll appear here for cross-referencing.
+		</p>
+	{:else}
+		<form
+			method="POST"
+			action="?/saveProductRefs"
+			use:enhance={() => {
+				submitting = true;
+				return async ({ update }) => {
+					await update({ reset: false });
+					submitting = false;
+				};
+			}}
+			class="space-y-3"
+		>
+			<!-- Submit one hidden input per non-'none' selection -->
+			{#each Array.from(selection.entries()) as [productId, kind] (productId)}
+				{#if kind !== 'none'}
+					<input type="hidden" name="refs" value="{productId}:{kind}" />
+				{/if}
+			{/each}
+
+			<div class="space-y-1 max-h-72 overflow-y-auto rounded border border-input p-2">
+				{#each productChoices as product (product.id)}
+					{@const currentKind = selection.get(product.id) ?? 'none'}
+					<label class="flex items-center gap-3 rounded px-2 py-1.5 hover:bg-muted">
+						<span class="flex-1 truncate text-sm">
+							{product.title}
+							<code class="ml-1 text-xs text-muted-foreground">{product.slug}</code>
+						</span>
+						<select
+							value={currentKind}
+							onchange={(e) =>
+								setKind(product.id, (e.target as HTMLSelectElement).value as Selection)}
+							class="rounded border border-input bg-transparent px-2 py-1 text-xs"
+							disabled={submitting}
+						>
+							<option value="none">—</option>
+							<option value="featured">featured</option>
+							<option value="mentioned">mentioned</option>
+							<option value="promoted">promoted</option>
+						</select>
+					</label>
+				{/each}
+			</div>
+
+			<div class="flex justify-end">
+				<Button type="submit" size="sm" disabled={submitting}>
+					<Save class="mr-2 h-3.5 w-3.5" />
+					{submitting ? 'Saving…' : 'Save related products'}
+				</Button>
+			</div>
+
+			<p class="text-xs text-muted-foreground">
+				<strong>featured</strong> = hero product on the article ·
+				<strong>mentioned</strong> = passing reference ·
+				<strong>promoted</strong> = paid placement. All show as cards
+				at the bottom of the article page.
+			</p>
+			<p class="text-xs text-muted-foreground">
+				Tip: use <code>:::product{'{'}slug=your-product{'}'}</code> in the
+				article body to embed an inline product card in the middle of
+				the content.
+			</p>
+		</form>
+	{/if}
+</section>

--- a/src/plugins/shop/federation.ts
+++ b/src/plugins/shop/federation.ts
@@ -1,0 +1,347 @@
+/**
+ * Article ↔ product federation service.
+ *
+ * The differentiator for Khao Pad vs Shopify Metaobjects: articles
+ * and products are in the same D1 database, so cross-references are
+ * plain JOINs — no runtime Metaobject resolution dance, no headless-
+ * CMS + Shopify duct tape.
+ *
+ * Public API:
+ *   - listRefsForArticle(articleId): "which products does this article link?"
+ *   - listArticlesForProduct(productId): "which articles feature this product?"
+ *   - setRefs(articleId, refs): replace all refs for one article atomically
+ *   - extractEmbeds(markdown): parse :::product{slug=classic-tee} inline
+ *     embeds and return the slugs
+ *   - hydrateProductEmbeds(d1, slugs): batch-resolve slugs to product
+ *     summaries for rendering
+ *
+ * The `refKind='mentioned'` refs are auto-created when a product embed
+ * is used in the article body — so editors don't have to double-enter
+ * refs that already appear inline. Editors can override via the
+ * article editor's "Related products" panel.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { and, eq, inArray, asc } from "drizzle-orm";
+import {
+  shopArticleProductRefs,
+  type ShopArticleProductRef,
+} from "./schema-federation";
+import {
+  shopProducts,
+  shopProductLocalizations,
+  shopProductVariants,
+} from "./schema";
+import type { Satang } from "./money";
+
+export type ProductSummary = {
+  id: string;
+  slug: string;
+  title: string;
+  priceFromSatang: Satang | null;
+  vendor: string | null;
+  featuredMediaId: string | null;
+  inStock: boolean;
+};
+
+export type ArticleProductRef = ShopArticleProductRef & {
+  product: ProductSummary | null;
+};
+
+export type ProductArticleRef = {
+  articleId: string;
+  refKind: "featured" | "mentioned" | "promoted";
+  position: number;
+  createdAt: string;
+};
+
+export type SetRefInput = {
+  productId: string;
+  refKind?: "featured" | "mentioned" | "promoted";
+  position?: number;
+};
+
+/**
+ * Load all refs an article declares — hydrated with the product
+ * summary needed to render cards on the article page. Refs whose
+ * product row is missing (or archived) are dropped, matching the
+ * public-visibility contract.
+ */
+export async function listRefsForArticle(
+  d1: D1Database,
+  articleId: string,
+): Promise<ArticleProductRef[]> {
+  const db = drizzle(d1);
+  const refs = await db
+    .select()
+    .from(shopArticleProductRefs)
+    .where(eq(shopArticleProductRefs.articleId, articleId))
+    .orderBy(asc(shopArticleProductRefs.position))
+    .all();
+  if (refs.length === 0) return [];
+
+  const productIds = Array.from(new Set(refs.map((r) => r.productId)));
+  const summaries = await hydrateProductSummaries(d1, productIds);
+  const byId = new Map(summaries.map((s) => [s.id, s]));
+
+  return refs
+    .map((r) => ({
+      ...r,
+      product: byId.get(r.productId) ?? null,
+    }))
+    .filter((r) => r.product != null);
+}
+
+export async function listArticlesForProduct(
+  d1: D1Database,
+  productId: string,
+): Promise<ProductArticleRef[]> {
+  const db = drizzle(d1);
+  const rows = await db
+    .select()
+    .from(shopArticleProductRefs)
+    .where(eq(shopArticleProductRefs.productId, productId))
+    .orderBy(asc(shopArticleProductRefs.position))
+    .all();
+  return rows.map((r) => ({
+    articleId: r.articleId,
+    refKind: r.refKind,
+    position: r.position,
+    createdAt: r.createdAt,
+  }));
+}
+
+/**
+ * Replace all refs for one article. Delete-all + re-insert semantics —
+ * simpler than diffing, matches the editor's "save the whole panel"
+ * workflow. Composite PK (article, product, kind) means a product
+ * can appear once per kind; the same product with different kinds is
+ * legal (e.g. same product both `featured` in the hero and `mentioned`
+ * inline).
+ */
+export async function setRefs(
+  d1: D1Database,
+  input: {
+    articleId: string;
+    refs: SetRefInput[];
+    createdBy?: string | null;
+  },
+): Promise<void> {
+  const db = drizzle(d1);
+  await db
+    .delete(shopArticleProductRefs)
+    .where(eq(shopArticleProductRefs.articleId, input.articleId));
+  if (input.refs.length === 0) return;
+  const now = new Date().toISOString();
+  await db.insert(shopArticleProductRefs).values(
+    input.refs.map((r, index) => ({
+      articleId: input.articleId,
+      productId: r.productId,
+      refKind: r.refKind ?? "mentioned",
+      position: r.position ?? index,
+      createdAt: now,
+      createdBy: input.createdBy ?? null,
+    })),
+  );
+}
+
+/**
+ * Add a single ref (idempotent — upsert semantics on the composite
+ * PK). Used by the auto-embed hook when :::product markdown is
+ * detected in an article body.
+ */
+export async function addRefIfMissing(
+  d1: D1Database,
+  input: {
+    articleId: string;
+    productId: string;
+    refKind?: "featured" | "mentioned" | "promoted";
+    createdBy?: string | null;
+  },
+): Promise<void> {
+  const db = drizzle(d1);
+  const kind = input.refKind ?? "mentioned";
+  const existing = await db
+    .select()
+    .from(shopArticleProductRefs)
+    .where(
+      and(
+        eq(shopArticleProductRefs.articleId, input.articleId),
+        eq(shopArticleProductRefs.productId, input.productId),
+        eq(shopArticleProductRefs.refKind, kind),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (existing) return;
+  await db.insert(shopArticleProductRefs).values({
+    articleId: input.articleId,
+    productId: input.productId,
+    refKind: kind,
+    position: 999, // auto-embeds sort last unless an editor reorders
+    createdAt: new Date().toISOString(),
+    createdBy: input.createdBy ?? null,
+  });
+}
+
+// ─── Markdown embed parser ──────────────────────────────────
+
+const EMBED_PATTERN = /^:::product\{slug=([a-z0-9-]+)\}\s*$/gm;
+
+/**
+ * Extract product slugs from :::product{slug=classic-tee} embeds in
+ * a markdown body. Called at save time to auto-populate refs and at
+ * render time to hydrate the inline cards.
+ *
+ * Only matches the exact one-line syntax to keep the parser boring +
+ * deterministic. Editors who want a card in the middle of a paragraph
+ * should use the "Featured product" field on the article, not the
+ * embed.
+ */
+export function extractEmbeds(markdown: string | null | undefined): string[] {
+  if (!markdown) return [];
+  const slugs = new Set<string>();
+  for (const match of markdown.matchAll(EMBED_PATTERN)) {
+    if (match[1]) slugs.add(match[1]);
+  }
+  return Array.from(slugs);
+}
+
+/**
+ * Render :::product embeds → placeholder HTML the article template
+ * can replace with a live product card. Approach: leave a
+ * `<div data-shop-embed="classic-tee">` in the output so the client-
+ * side hydration picks it up. Server-side rendering can also
+ * pre-render the card by looking up the product summary.
+ *
+ * For simplicity, v3.4 replaces the embed with an inline `<a>` link;
+ * v3.5 upgrades to a richer card component.
+ */
+export function replaceEmbedsWithPlaceholders(
+  markdown: string,
+  productsBySlug: Map<string, ProductSummary>,
+): string {
+  return markdown.replace(EMBED_PATTERN, (_match, slug: string) => {
+    const product = productsBySlug.get(slug);
+    if (!product) {
+      // Missing product — leave a warning comment for admin's
+      // preview, but drop the empty embed from the public output.
+      return `<!-- shop embed: product ${slug} not found -->`;
+    }
+    // Minimal card as HTML — matches the site's existing prose style.
+    // Real component upgrade lands in v3.5.
+    const priceLabel = product.priceFromSatang
+      ? `<span class="text-sm text-muted-foreground">From ฿${(product.priceFromSatang / 100).toFixed(2)}</span>`
+      : "";
+    return `<a href="/en/products/${product.slug}" class="not-prose block rounded-lg border border-border p-4 my-4 hover:bg-muted transition-colors"><div class="font-semibold">${escapeHtml(product.title)}</div>${priceLabel}</a>`;
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ─── Batch product summary hydration ────────────────────────
+
+/**
+ * Fetch product summaries for a set of ids. Batched — one round-trip
+ * for products, one for localizations (English), one for variants
+ * (min price + stock rollup).
+ */
+async function hydrateProductSummaries(
+  d1: D1Database,
+  productIds: string[],
+): Promise<ProductSummary[]> {
+  if (productIds.length === 0) return [];
+  const db = drizzle(d1);
+
+  const [products, locs, variants] = await Promise.all([
+    db
+      .select()
+      .from(shopProducts)
+      .where(
+        and(
+          inArray(shopProducts.id, productIds),
+          eq(shopProducts.status, "active"),
+        ),
+      )
+      .all(),
+    db
+      .select()
+      .from(shopProductLocalizations)
+      .where(
+        and(
+          inArray(shopProductLocalizations.productId, productIds),
+          eq(shopProductLocalizations.locale, "en"),
+        ),
+      )
+      .all(),
+    db
+      .select()
+      .from(shopProductVariants)
+      .where(
+        and(
+          inArray(shopProductVariants.productId, productIds),
+          eq(shopProductVariants.status, "active"),
+        ),
+      )
+      .all(),
+  ]);
+
+  const titleByProduct = new Map(locs.map((l) => [l.productId, l.title]));
+  const variantsByProduct = new Map<string, typeof variants>();
+  for (const v of variants) {
+    const arr = variantsByProduct.get(v.productId) ?? [];
+    arr.push(v);
+    variantsByProduct.set(v.productId, arr);
+  }
+
+  return products.map((p) => {
+    const prodVariants = variantsByProduct.get(p.id) ?? [];
+    const priceFromSatang = prodVariants.length
+      ? (Math.min(...prodVariants.map((v) => v.priceSatang)) as Satang)
+      : null;
+    // in_stock: any variant with price>0 (we don't join inventory here
+    // to keep the summary cheap — mostly used in "related products"
+    // sections where a definitive stock indicator isn't critical)
+    return {
+      id: p.id,
+      slug: p.slug,
+      title: titleByProduct.get(p.id) ?? p.slug,
+      priceFromSatang,
+      vendor: p.vendor,
+      featuredMediaId: p.featuredMediaId,
+      inStock: prodVariants.length > 0,
+    };
+  });
+}
+
+/**
+ * Batch-fetch product summaries by SLUG (rather than id) — the shape
+ * needed by the markdown embed renderer, which only knows slugs.
+ */
+export async function hydrateProductEmbeds(
+  d1: D1Database,
+  slugs: string[],
+): Promise<Map<string, ProductSummary>> {
+  if (slugs.length === 0) return new Map();
+  const db = drizzle(d1);
+  const products = await db
+    .select({ id: shopProducts.id })
+    .from(shopProducts)
+    .where(
+      and(
+        inArray(shopProducts.slug, slugs),
+        eq(shopProducts.status, "active"),
+      ),
+    )
+    .all();
+  const summaries = await hydrateProductSummaries(
+    d1,
+    products.map((p) => p.id),
+  );
+  return new Map(summaries.map((s) => [s.slug, s]));
+}

--- a/src/plugins/shop/schema-federation.ts
+++ b/src/plugins/shop/schema-federation.ts
@@ -1,0 +1,57 @@
+/**
+ * Article ↔ product cross-references — v3.4's differentiator.
+ *
+ * Payload/Shopify Metaobjects call this "federation" — cross-content-
+ * type references. Khao Pad's implementation is a plain join table
+ * because articles and products live in the same D1: real FKs,
+ * cascade deletes, no runtime resolution dance.
+ *
+ * Table lives in the shop plugin's schema-federation.ts because the
+ * plugin owns the `shop_*` namespace + the migration numbering. Core
+ * article code stays clean; it queries the join via a helper that
+ * ships in the same plugin (getArticleProductRefs).
+ *
+ * Design decisions (from #59):
+ *
+ *   1. **refKind** = 'featured' | 'mentioned' | 'promoted' — lets an
+ *      editor distinguish the article's headline product from a
+ *      passing mention in the body. Storefront renders featured
+ *      prominently, mentioned inline.
+ *
+ *   2. **position** for ordering — multiple refs per article are
+ *      shown in the editor's chosen order.
+ *
+ *   3. **articleId is bare text** — no FK to core `articles` table
+ *      because the plugin can't reach across plugin boundaries with
+ *      FKs cleanly. Orphan cleanup runs at query time (ignore refs
+ *      whose article id doesn't resolve). Small tradeoff for keeping
+ *      the plugin decoupled from core.
+ *
+ *   4. **productId** IS an FK — same plugin owns both tables, so
+ *      `onDelete: cascade` cleans up refs when a product is deleted.
+ */
+import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { shopProducts } from "./schema";
+
+export const shopArticleProductRefs = sqliteTable(
+  "shop_article_product_refs",
+  {
+    articleId: text("article_id").notNull(),
+    productId: text("product_id")
+      .notNull()
+      .references(() => shopProducts.id, { onDelete: "cascade" }),
+    refKind: text("ref_kind", {
+      enum: ["featured", "mentioned", "promoted"],
+    })
+      .notNull()
+      .default("mentioned"),
+    position: integer("position").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    createdBy: text("created_by"),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.articleId, t.productId, t.refKind] }),
+  }),
+);
+
+export type ShopArticleProductRef = typeof shopArticleProductRefs.$inferSelect;

--- a/src/routes/(admin)/admin/articles/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/articles/[id]/+page.server.ts
@@ -53,7 +53,53 @@ export const load: PageServerLoad = async ({ locals, params, platform }) => {
     }
   }
 
-  return { article, categories, tags, sparkline, totalViews };
+  // v3.4 federation: load current product refs + a small list of
+  // active products for the editor's picker. Only when the shop
+  // plugin is enabled (fails silently otherwise — a Khao Pad install
+  // without shop shows an empty picker).
+  let productRefs: Array<{
+    productId: string;
+    refKind: "featured" | "mentioned" | "promoted";
+    productTitle: string | null;
+    productSlug: string | null;
+  }> = [];
+  let productChoices: Array<{ id: string; title: string; slug: string }> = [];
+  if (platform?.env?.DB) {
+    try {
+      const { listRefsForArticle } = await import("$plugins/shop/federation");
+      const refs = await listRefsForArticle(platform.env.DB, article.id);
+      productRefs = refs.map((r) => ({
+        productId: r.productId,
+        refKind: r.refKind,
+        productTitle: r.product?.title ?? null,
+        productSlug: r.product?.slug ?? null,
+      }));
+      // Editor picker: up to 100 active products, English titles.
+      const { ShopService } = await import("$plugins/shop/service");
+      const svc = new ShopService(platform.env.DB);
+      const products = await svc.listProducts({
+        status: "active",
+        limit: 100,
+      });
+      productChoices = products.map((p) => ({
+        id: p.id,
+        title: p.title,
+        slug: p.slug,
+      }));
+    } catch {
+      // Shop plugin not enabled or an unrelated failure — leave arrays empty.
+    }
+  }
+
+  return {
+    article,
+    categories,
+    tags,
+    sparkline,
+    totalViews,
+    productRefs,
+    productChoices,
+  };
 };
 
 function requireAuthor(locals: App.Locals) {
@@ -62,6 +108,49 @@ function requireAuthor(locals: App.Locals) {
 }
 
 export const actions: Actions = {
+  saveProductRefs: async ({ request, locals, params, platform }) => {
+    const user = requireAuthor(locals);
+    const existing = await locals.content.getArticle(params.id);
+    if (!existing) return fail(404, { error: "Article not found" });
+    if (!canEditArticle(user, existing.authorId)) {
+      return fail(403, { error: "Forbidden" });
+    }
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const form = await request.formData();
+    // refs[]=productId:refKind format. Empty submissions clear all
+    // refs — that's intended (unchecking every box in the editor).
+    const raw = form.getAll("refs").map(String);
+    const validKinds = new Set(["featured", "mentioned", "promoted"]);
+    const refs: Array<{
+      productId: string;
+      refKind: "featured" | "mentioned" | "promoted";
+    }> = [];
+    for (const entry of raw) {
+      const [productId, refKind] = entry.split(":");
+      if (!productId || !validKinds.has(refKind ?? "")) continue;
+      refs.push({
+        productId,
+        refKind: refKind as "featured" | "mentioned" | "promoted",
+      });
+    }
+
+    try {
+      const { setRefs } = await import("$plugins/shop/federation");
+      await setRefs(env.DB, {
+        articleId: params.id,
+        refs,
+        createdBy: user.id,
+      });
+      return { success: true, refsSaved: refs.length };
+    } catch (err) {
+      return fail(500, {
+        error: err instanceof Error ? err.message : "Save failed",
+      });
+    }
+  },
+
   save: async ({ request, locals, params, platform }) => {
     const user = requireAuthor(locals);
     const existing = await locals.content.getArticle(params.id);

--- a/src/routes/(admin)/admin/articles/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/articles/[id]/+page.svelte
@@ -3,7 +3,10 @@
 	import * as m from '$lib/paraglide/messages';
 	import ArticleForm from '../ArticleForm.svelte';
 	import Sparkline from '$lib/components/analytics/Sparkline.svelte';
+	import RelatedProductsEditor from '$lib/components/admin/RelatedProductsEditor.svelte';
 	import type { ArticleRecord, CategoryRecord, TagRecord } from '$lib/server/content/types';
+
+	type RefKind = 'featured' | 'mentioned' | 'promoted';
 
 	let {
 		data,
@@ -15,6 +18,13 @@
 			tags: TagRecord[];
 			sparkline: Array<{ date: string; count: number }>;
 			totalViews: number;
+			productRefs: Array<{
+				productId: string;
+				refKind: RefKind;
+				productTitle: string | null;
+				productSlug: string | null;
+			}>;
+			productChoices: Array<{ id: string; title: string; slug: string }>;
 		};
 		form: { ok?: boolean; error?: string; status?: ArticleRecord['status'] } | null;
 	} = $props();
@@ -89,4 +99,14 @@
 		categories={data.categories}
 		tags={data.tags}
 	/>
+
+	<div class="mt-8">
+		<RelatedProductsEditor
+			currentRefs={data.productRefs.map((r) => ({
+				productId: r.productId,
+				refKind: r.refKind,
+			}))}
+			productChoices={data.productChoices}
+		/>
+	</div>
 </div>

--- a/src/routes/(www)/[locale]/blog/[slug]/+page.server.ts
+++ b/src/routes/(www)/[locale]/blog/[slug]/+page.server.ts
@@ -52,7 +52,33 @@ export const load: PageServerLoad = async ({ locals, params, url, cookies, platf
     locals.content,
     locale,
   );
-  const htmlContent = await marked(expanded);
+
+  // v3.4: rewrite :::product{slug=x} embeds into inline product cards
+  // before markdown → HTML. Batch-hydrates all embedded slugs in one
+  // D1 pass, then replaces every embed with an <a> card. Products
+  // that don't resolve (deleted, archived) get a comment marker.
+  let expandedWithEmbeds = expanded;
+  if (platform?.env?.DB) {
+    const { extractEmbeds, hydrateProductEmbeds, replaceEmbedsWithPlaceholders } =
+      await import("$plugins/shop/federation");
+    const slugs = extractEmbeds(expanded);
+    if (slugs.length > 0) {
+      const productsBySlug = await hydrateProductEmbeds(platform.env.DB, slugs);
+      expandedWithEmbeds = replaceEmbedsWithPlaceholders(expanded, productsBySlug);
+    }
+  }
+  const htmlContent = await marked(expandedWithEmbeds);
+
+  // v3.4: load related products declared via the shop plugin's
+  // article_product_refs table. Rendered as a section below the
+  // article body. Empty array when no refs exist — template no-ops.
+  let relatedProducts: Awaited<
+    ReturnType<typeof import("$plugins/shop/federation").listRefsForArticle>
+  > = [];
+  if (platform?.env?.DB) {
+    const { listRefsForArticle } = await import("$plugins/shop/federation");
+    relatedProducts = await listRefsForArticle(platform.env.DB, article.id);
+  }
 
   // SEO surface for the public article page.
   const settings = await locals.content.getSettings().catch(() => null);
@@ -144,6 +170,11 @@ export const load: PageServerLoad = async ({ locals, params, url, cookies, platf
       authorName: c.authorName,
       body: c.body,
       submittedAt: c.submittedAt,
+    })),
+    relatedProducts: relatedProducts.map((r) => ({
+      productId: r.productId,
+      refKind: r.refKind,
+      product: r.product,
     })),
   };
 };

--- a/src/routes/(www)/[locale]/blog/[slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/blog/[slug]/+page.svelte
@@ -33,6 +33,37 @@
 		{@html data.htmlContent}
 	</div>
 
+	{#if data.relatedProducts && data.relatedProducts.length > 0}
+		<!-- v3.4 federation: "Related products" section powered by
+			shop_article_product_refs. Featured refs get a distinct
+			treatment; mentioned refs are a simple list. -->
+		<section class="mt-12 border-t border-border pt-8">
+			<h2 class="mb-4 text-lg font-semibold">Related products</h2>
+			<ul class="grid gap-3 sm:grid-cols-2">
+				{#each data.relatedProducts as ref (ref.productId)}
+					{#if ref.product}
+						<li>
+							<a
+								href="/{data.locale}/products/{ref.product.slug}"
+								class="block rounded-lg border p-4 transition-colors hover:bg-muted {ref.refKind ===
+								'featured'
+									? 'border-primary bg-primary/5'
+									: 'border-border'}"
+							>
+								<div class="font-medium">{ref.product.title}</div>
+								{#if ref.product.priceFromSatang != null}
+									<div class="mt-1 text-sm text-muted-foreground tabular-nums">
+										From ฿{(ref.product.priceFromSatang / 100).toFixed(2)}
+									</div>
+								{/if}
+							</a>
+						</li>
+					{/if}
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
 	{#if data.commentsOpen || data.comments.length > 0}
 		<CommentSection
 			articleId={data.articleId}

--- a/src/routes/(www)/[locale]/products/[slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/products/[slug]/+page.svelte
@@ -30,6 +30,16 @@
 	// Fire product_view once on mount. Tagged with the canonical
 	// product id so the per-product dashboard's queries (which key
 	// on the same id) actually find these rows.
+	//
+	// v3.4 federation: if the visitor arrived from an article page
+	// (document.referrer matches /[locale]/blog/<slug> OR
+	// /[locale]/articles/<slug>), stash the article slug in
+	// sessionStorage so the downstream `purchase` event can attribute
+	// this order to that article. product_view itself doesn't carry
+	// attributedArticleId (dashboard queries filter on `purchase`
+	// events); the sessionStorage stash is picked up server-side at
+	// checkout-start via a form-posted hidden field (defer to a
+	// follow-up sub-PR — this is the client-side half).
 	onMount(() => {
 		if (!selectedVariant) return;
 		track('product_view', {
@@ -37,6 +47,20 @@
 			variantId: selectedVariant.id,
 			priceSatang: selectedVariant.priceSatang,
 		});
+		try {
+			const referrer = document.referrer;
+			if (!referrer) return;
+			const url = new URL(referrer);
+			if (url.origin !== window.location.origin) return;
+			const match = url.pathname.match(
+				/^\/[a-z]{2}\/(?:articles|blog)\/([a-z0-9-]+)\/?$/,
+			);
+			if (match?.[1]) {
+				sessionStorage.setItem('khaopad_shop_attributed_slug', match[1]);
+			}
+		} catch {
+			// sessionStorage disabled (private mode etc.) — skip
+		}
 	});
 </script>
 

--- a/src/routes/(www)/checkout/+page.svelte
+++ b/src/routes/(www)/checkout/+page.svelte
@@ -18,6 +18,19 @@
 		}
 		submitting = true;
 		errorMessage = null;
+		// v3.4 federation: read the article slug the visitor came from
+		// (if any) so /checkout/start can tag the pending order and the
+		// downstream `purchase` event with attributedArticleId. Stash
+		// set by the product page's product_view handler; cleared after
+		// use so a second cart doesn't inherit stale attribution.
+		let attributedArticleSlug: string | null = null;
+		try {
+			attributedArticleSlug =
+				sessionStorage.getItem('khaopad_shop_attributed_slug') ?? null;
+		} catch {
+			/* private mode — no stash */
+		}
+
 		try {
 			type StartResponse = {
 				ok: boolean;
@@ -34,7 +47,10 @@
 			const startRes = await fetch('/api/shop/checkout/start', {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({ email: email.trim() }),
+				body: JSON.stringify({
+					email: email.trim(),
+					attributedArticleSlug,
+				}),
 			});
 			const startJson = (await startRes.json()) as StartResponse;
 			if (!startJson.ok) {

--- a/src/routes/api/shop/checkout/start/+server.ts
+++ b/src/routes/api/shop/checkout/start/+server.ts
@@ -26,6 +26,15 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals,
         email?: string;
         shippingAddress?: unknown;
         billingAddress?: unknown;
+        /**
+         * v3.4 federation: article slug the visitor came from before
+         * they entered the funnel. Client reads this from
+         * sessionStorage (stashed by the product page). Resolved to
+         * an article id server-side and included in the analytics
+         * purchase event so per-article dashboards can show
+         * "products this article drove" with accurate revenue.
+         */
+        attributedArticleSlug?: string;
       }
     | null;
   const email = String(body?.email ?? "").trim();
@@ -64,6 +73,25 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals,
 
     // Track begin_checkout. Uses reservations for item count/subtotal
     // since we don't want to re-hydrate the cart just for analytics.
+    // v3.4: resolve attributedArticleSlug → article id and include in
+    // the event properties. The webhook's `purchase` event copies it
+    // forward — dashboard's article analytics reads attributedArticleId
+    // from `purchase` events to power the "products this article drove"
+    // panel.
+    let attributedArticleId: string | undefined;
+    if (
+      body?.attributedArticleSlug &&
+      /^[a-z0-9-]+$/.test(body.attributedArticleSlug)
+    ) {
+      try {
+        const article = await locals.content.getArticleBySlug(
+          body.attributedArticleSlug,
+        );
+        if (article) attributedArticleId = article.id;
+      } catch {
+        /* content provider unavailable — attribution stays undefined */
+      }
+    }
     void track(
       env.DB,
       "begin_checkout",
@@ -79,6 +107,23 @@ export const POST: RequestHandler = async ({ request, platform, cookies, locals,
         userId: locals.user?.id ?? null,
       }),
     );
+    if (attributedArticleId) {
+      // Also persist attribution in the cart's discountCode column
+      // (unused for v3.4; discount codes ship in v3.5 with a
+      // dedicated table). Overloads the column temporarily so the
+      // webhook can read `attribution:<articleId>` back at markPaid.
+      const { drizzle } = await import("drizzle-orm/d1");
+      const { eq } = await import("drizzle-orm");
+      const { shopCarts } = await import("$plugins/shop/schema-cart");
+      try {
+        await drizzle(env.DB)
+          .update(shopCarts)
+          .set({ discountCode: `attribution:${attributedArticleId}` })
+          .where(eq(shopCarts.id, cart.id));
+      } catch {
+        /* best-effort — attribution loss is acceptable */
+      }
+    }
 
     return json({
       ok: true,

--- a/src/routes/api/shop/webhook/beam/+server.ts
+++ b/src/routes/api/shop/webhook/beam/+server.ts
@@ -84,8 +84,15 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
       // ordered to reuse the visitor's session id — otherwise the
       // funnel (product_view → add_to_cart → begin_checkout →
       // purchase) can't join by session_id and conversion looks 0.
+      // Also reads the discountCode field which v3.4 federation
+      // repurposes as `attribution:<articleId>` for article →
+      // purchase attribution tracking. Real discountCode ships in
+      // v3.5 with its own table.
       const cartRow = await drizzle(env.DB)
-        .select({ sessionId: shopCarts.sessionId })
+        .select({
+          sessionId: shopCarts.sessionId,
+          discountCode: shopCarts.discountCode,
+        })
         .from(shopCarts)
         .where(
           and(
@@ -97,6 +104,10 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
         .limit(1)
         .get();
       const sessionIdForFunnel = cartRow?.sessionId ?? paid.id;
+      let attributedArticleId: string | undefined;
+      if (cartRow?.discountCode?.startsWith("attribution:")) {
+        attributedArticleId = cartRow.discountCode.slice("attribution:".length);
+      }
       await track(
         env.DB,
         "purchase",
@@ -105,6 +116,7 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
           orderNumber: paid.orderNumber,
           totalSatang: paid.totalSatang,
           itemCount: paid.items.reduce((s, i) => s + i.quantity, 0),
+          ...(attributedArticleId ? { attributedArticleId } : {}),
         },
         buildEventContext({
           url,


### PR DESCRIPTION
Ships v3.4 ([#59](https://github.com/codustry/khaopad/issues/59)) — Khao Pad's differentiator: articles and products cross-reference natively (JOIN in the same D1, not Shopify Metaobjects duct tape).

## What ships

- **shop_article_product_refs** table (migration 0017) + \`federation.ts\` service
- **Public article page**: renders \`:::product{slug=x}\` inline embeds as product cards + \"Related products\" section from refs
- **Admin article editor**: new \`RelatedProductsEditor\` component; pick products + refKind (featured/mentioned/promoted); \`saveProductRefs\` action
- **Purchase attribution end-to-end**:
    - Product page reads document.referrer, stashes article slug in sessionStorage if from same-origin article
    - Checkout submits it as \`attributedArticleSlug\`
    - Server resolves slug → id, stashes on cart's \`discountCode\` (v3.4 pragmatic reuse — real discount table lands v3.5)
    - Webhook reads it back at markPaid, includes as \`attributedArticleId\` in purchase event
    - Per-article dashboard's \`getArticleAnalytics\` already queries by this field → dashboards fire immediately

## Verify

- ✅ \`pnpm run check\`: 0 new errors (only 3 pre-existing paraglide from [#62](https://github.com/codustry/khaopad/issues/62))
- ✅ \`pnpm run build\`: passes

## Deferred (small follow-ups)

- Auto-add refs when :::product embeds appear in article body (extractEmbeds is ready — needs wiring in article save)
- \"Products this article drove\" widget on article dashboard (data already flowing — just needs a widget)
- Product-side \"Related articles\" list on product admin page
- Richer product embed card (v3.4 uses simple <a>; v3.5 upgrades to component with image + variant picker)

Closes [#59](https://github.com/codustry/khaopad/issues/59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)