### PR TITLE
feat(v3.6-phase1): generic find()/populate query layer + N+1 fix

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -35,6 +35,17 @@ declare global {
     }
 
     interface Platform {
+      /**
+       * Worker execution context, supplied by
+       * @sveltejs/adapter-cloudflare. `waitUntil` keeps background work
+       * (e.g. cache invalidation after a write) alive past the
+       * response, which the isolate would otherwise be free to cancel.
+       * Optional because it is absent under `vite dev` without
+       * bindings.
+       */
+      context?: {
+        waitUntil(promise: Promise<unknown>): void;
+      };
       env: {
         DB: D1Database;
         MEDIA_BUCKET: R2Bucket;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,6 +9,7 @@ import {
   validatePlatformEnv,
 } from "$lib/server/config/platform-status";
 import { createContentProvider } from "$lib/server/content";
+import { QueryCache } from "$lib/server/content/query/cache";
 import { localeFromPathname } from "$lib/i18n";
 import { R2MediaService } from "$lib/server/media";
 import { initPlugins } from "$lib/plugins";
@@ -65,7 +66,12 @@ const bindingsHook: Handle = async ({ event, resolve }) => {
   }
 
   try {
-    event.locals.content = createContentProvider(env!);
+    // `platform.context` carries the Worker execution context; passing
+    // it lets cache invalidation outlive the response (Phase 1, #68).
+    event.locals.content = createContentProvider(
+      env!,
+      event.platform?.context,
+    );
 
     const mediaBaseUrl =
       event.locals.subdomain === "admin"
@@ -75,6 +81,20 @@ const bindingsHook: Handle = async ({ event, resolve }) => {
       env!.DB,
       env!.MEDIA_BUCKET,
       mediaBaseUrl,
+      // Media is a populate target (articles.coverMedia), so a media
+      // write has to drop cached article payloads that embedded it.
+      () => {
+        if (!env!.CONTENT_CACHE) return;
+        const pending = new QueryCache(env!.CONTENT_CACHE).invalidateMany([
+          "media",
+          "articles",
+        ]);
+        if (event.platform?.context?.waitUntil) {
+          event.platform.context.waitUntil(pending);
+        } else {
+          void pending;
+        }
+      },
     );
     event.locals.platformReady = true;
     event.locals.configurationError = null;

--- a/src/lib/server/content/index.ts
+++ b/src/lib/server/content/index.ts
@@ -11,6 +11,18 @@ import { D1ContentProvider } from "./providers/d1";
  */
 export function createContentProvider(
   env: App.Platform["env"],
+  ctx?: { waitUntil?: (p: Promise<unknown>) => void },
 ): ContentProvider {
-  return new D1ContentProvider(env.DB);
+  // CONTENT_CACHE is optional — passing it in lets the provider
+  // invalidate cached populate payloads on write (Phase 1, #68 §D).
+  // Without it the provider behaves exactly as it did before.
+  //
+  // `waitUntil` (from the Worker's execution context) keeps that
+  // invalidation alive past the response. Absent it, invalidation still
+  // runs, it just isn't guaranteed to finish.
+  return new D1ContentProvider(
+    env.DB,
+    env.CONTENT_CACHE,
+    ctx?.waitUntil ? ctx.waitUntil.bind(ctx) : undefined,
+  );
 }

--- a/src/lib/server/content/providers/d1.ts
+++ b/src/lib/server/content/providers/d1.ts
@@ -13,7 +13,11 @@ import {
 } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { generateSlugFromTitle, slugify } from "$lib/utils";
+import { QueryCache } from "../query/cache";
 import * as schema from "../schema";
+
+/** D1 binds at most 100 parameters per statement. See `loadChunked`. */
+const D1_MAX_BIND_PARAMS = 100;
 import type {
   ContentProvider,
   ArticleRecord,
@@ -62,9 +66,74 @@ import type {
 
 export class D1ContentProvider implements ContentProvider {
   private db: DrizzleD1Database<typeof schema>;
+  /**
+   * Populate-payload cache (Phase 1, #68 §D). Optional: when no KV
+   * binding is available (tests, local dev without bindings) the
+   * provider works exactly as before and every read goes to D1.
+   */
+  private cache: QueryCache | null;
+  /**
+   * Workers tears the isolate down once the response is returned, which
+   * can cancel a still-pending KV write. `waitUntil` keeps the
+   * invalidation alive past the response — without it a write can
+   * return 200 while its cache-invalidation never lands, pinning stale
+   * content for the full TTL.
+   */
+  private waitUntil: ((p: Promise<unknown>) => void) | null;
 
-  constructor(d1: D1Database) {
+  constructor(
+    d1: D1Database,
+    kv?: KVNamespace,
+    waitUntil?: (p: Promise<unknown>) => void,
+  ) {
     this.db = drizzle(d1, { schema });
+    this.cache = kv ? new QueryCache(kv) : null;
+    this.waitUntil = waitUntil ?? null;
+  }
+
+  /**
+   * Drop cached populate payloads that read these collections.
+   *
+   * Invalidation lives here, in the provider, rather than in each
+   * admin route: this is the one chokepoint every write already passes
+   * through, so a new write path can't forget to call it.
+   *
+   * Non-blocking but not abandoned — handed to `waitUntil` where it's
+   * available so it survives the response. A failed invalidation must
+   * never fail the write; the per-key TTL bounds the damage.
+   */
+  private invalidate(...collections: string[]): void {
+    if (!this.cache) return;
+    const pending = this.cache.invalidateMany(collections);
+    if (this.waitUntil) this.waitUntil(pending);
+    else void pending;
+  }
+
+  /**
+   * Run an `inArray` load in chunks that respect D1's 100-bound-
+   * parameter ceiling.
+   *
+   * Batching these loads is what makes them fast (see `hydrateArticles`),
+   * but it's also what introduces the limit: the per-row versions bound
+   * exactly one id and could never hit it. `listCategories`/`listTags`
+   * are the sharp edge — they bind every row in the table, so without
+   * chunking the public site starts 500ing once a site has ~100 tags.
+   *
+   * Sequential by design: D1 counts each statement against the
+   * per-invocation query budget, so fanning chunks out in parallel
+   * trades one limit for another.
+   */
+  private async loadChunked<T>(
+    ids: string[],
+    load: (chunk: string[]) => Promise<T[]>,
+  ): Promise<T[]> {
+    if (ids.length === 0) return [];
+    if (ids.length <= D1_MAX_BIND_PARAMS) return load(ids);
+    const out: T[] = [];
+    for (let i = 0; i < ids.length; i += D1_MAX_BIND_PARAMS) {
+      out.push(...(await load(ids.slice(i, i + D1_MAX_BIND_PARAMS))));
+    }
+    return out;
   }
 
   // ─── Articles ──────────────────────────────────────────
@@ -125,7 +194,15 @@ export class D1ContentProvider implements ContentProvider {
       );
     }
 
-    // Tag filter requires a subquery
+    // Tag filter requires a subquery.
+    //
+    // KNOWN LIMIT (pre-existing, not introduced by the Phase 1 batching):
+    // the id list below is bound as one parameter per id, so a tag
+    // applied to more than ~100 articles exceeds D1's bound-parameter
+    // ceiling. Unlike the batched *loads* elsewhere in this file, this
+    // is a WHERE condition and can't be chunked without either running
+    // the page query N times or rewriting it as a real SQL subquery /
+    // join. Left alone deliberately rather than half-fixed.
     let articleIdsWithTag: string[] | undefined;
     if (tagId) {
       const tagRows = await this.db
@@ -173,9 +250,11 @@ export class D1ContentProvider implements ContentProvider {
         .get(),
     ]);
 
-    const items = await Promise.all(
-      articles.map((a) => this.hydrateArticle(a)),
-    );
+    // Batched hydration — was `articles.map(a => this.hydrateArticle(a))`,
+    // which fired 2 queries per row (localizations + tags), making a
+    // 20-item list 1 + 40 queries (#68 §1.4). Now 2 queries total,
+    // flat in the number of rows.
+    const items = await this.hydrateArticles(articles);
 
     return {
       items,
@@ -183,6 +262,78 @@ export class D1ContentProvider implements ContentProvider {
       page,
       limit,
     };
+  }
+
+  /**
+   * Hydrate many articles with a fixed number of queries.
+   *
+   * Collects every article id up front and issues ONE localizations
+   * query and ONE tags query for the whole page, then stitches in
+   * memory. Same output as calling `hydrateArticle` per row — this is
+   * purely a query-count fix, not a behaviour change.
+   *
+   * Kept here (rather than routed through the new QueryEngine) so the
+   * fix applies to every existing caller of `listArticles` without any
+   * of them changing. The engine is the forward path; this is the
+   * back-compatible one.
+   */
+  private async hydrateArticles(
+    articles: (typeof schema.articles.$inferSelect)[],
+  ): Promise<ArticleRecord[]> {
+    if (articles.length === 0) return [];
+    const ids = articles.map((a) => a.id);
+
+    const [localizations, tagRows] = await Promise.all([
+      this.loadChunked(ids, (chunk) =>
+        this.db
+          .select()
+          .from(schema.articleLocalizations)
+          .where(inArray(schema.articleLocalizations.articleId, chunk))
+          .all(),
+      ),
+      this.loadChunked(ids, (chunk) =>
+        this.db
+          .select()
+          .from(schema.articleTags)
+          .where(inArray(schema.articleTags.articleId, chunk))
+          .all(),
+      ),
+    ]);
+
+    const locsByArticle = new Map<string, ArticleRecord["localizations"]>();
+    for (const loc of localizations) {
+      const bucket = locsByArticle.get(loc.articleId) ?? {};
+      bucket[loc.locale as Locale] = {
+        title: loc.title,
+        excerpt: loc.excerpt ?? "",
+        body: loc.body,
+        seoTitle: loc.seoTitle ?? undefined,
+        seoDescription: loc.seoDescription ?? undefined,
+      };
+      locsByArticle.set(loc.articleId, bucket);
+    }
+
+    const tagsByArticle = new Map<string, string[]>();
+    for (const row of tagRows) {
+      const list = tagsByArticle.get(row.articleId) ?? [];
+      list.push(row.tagId);
+      tagsByArticle.set(row.articleId, list);
+    }
+
+    return articles.map((article) => ({
+      id: article.id,
+      slug: article.slug,
+      coverMediaId: article.coverMediaId,
+      categoryId: article.categoryId,
+      status: article.status as ArticleRecord["status"],
+      authorId: article.authorId,
+      publishedAt: article.publishedAt,
+      commentsMode: article.commentsMode as ArticleRecord["commentsMode"],
+      createdAt: article.createdAt,
+      updatedAt: article.updatedAt,
+      tagIds: tagsByArticle.get(article.id) ?? [],
+      localizations: locsByArticle.get(article.id) ?? {},
+    }));
   }
 
   /**
@@ -397,6 +548,8 @@ export class D1ContentProvider implements ContentProvider {
       }
     }
 
+    this.invalidate("articles");
+
     return (await this.getArticle(id))!;
   }
 
@@ -525,11 +678,14 @@ export class D1ContentProvider implements ContentProvider {
       }
     }
 
+    this.invalidate("articles");
+
     return (await this.getArticle(id))!;
   }
 
   async deleteArticle(id: string): Promise<void> {
     await this.db.delete(schema.articles).where(eq(schema.articles.id, id));
+    this.invalidate("articles");
   }
 
   private async hydrateArticle(
@@ -589,8 +745,37 @@ export class D1ContentProvider implements ContentProvider {
   }
 
   async listCategories(): Promise<CategoryRecord[]> {
+    // 2 queries total, not 1 + N. This runs on every blog page render,
+    // so the per-row version cost one query per category site-wide.
     const cats = await this.db.select().from(schema.categories).all();
-    return Promise.all(cats.map((c) => this.hydrateCategory(c)));
+    if (cats.length === 0) return [];
+
+    const locs = await this.loadChunked(
+      cats.map((c) => c.id),
+      (chunk) =>
+        this.db
+          .select()
+          .from(schema.categoryLocalizations)
+          .where(inArray(schema.categoryLocalizations.categoryId, chunk))
+          .all(),
+    );
+
+    const byCategory = new Map<string, CategoryRecord["localizations"]>();
+    for (const loc of locs) {
+      const bucket = byCategory.get(loc.categoryId) ?? {};
+      bucket[loc.locale as Locale] = {
+        name: loc.name,
+        description: loc.description ?? undefined,
+      };
+      byCategory.set(loc.categoryId, bucket);
+    }
+
+    return cats.map((c) => ({
+      id: c.id,
+      slug: c.slug,
+      createdAt: c.createdAt,
+      localizations: byCategory.get(c.id) ?? {},
+    }));
   }
 
   async createCategory(data: {
@@ -613,6 +798,8 @@ export class D1ContentProvider implements ContentProvider {
         description: content.description,
       });
     }
+
+    this.invalidate("categories", "articles");
 
     return (await this.getCategory(id))!;
   }
@@ -659,11 +846,16 @@ export class D1ContentProvider implements ContentProvider {
       }
     }
 
+    this.invalidate("categories", "articles");
+
     return (await this.getCategory(id))!;
   }
 
   async deleteCategory(id: string): Promise<void> {
     await this.db.delete(schema.categories).where(eq(schema.categories.id, id));
+    // Articles embed their category when populated, so their cached
+    // payloads are stale too.
+    this.invalidate("categories", "articles");
   }
 
   private async hydrateCategory(
@@ -705,8 +897,34 @@ export class D1ContentProvider implements ContentProvider {
   }
 
   async listTags(): Promise<TagRecord[]> {
+    // 2 queries total, not 1 + N — same fix as listCategories, and the
+    // same hot path (tag chips render on every blog index).
     const allTags = await this.db.select().from(schema.tags).all();
-    return Promise.all(allTags.map((t) => this.hydrateTag(t)));
+    if (allTags.length === 0) return [];
+
+    const locs = await this.loadChunked(
+      allTags.map((t) => t.id),
+      (chunk) =>
+        this.db
+          .select()
+          .from(schema.tagLocalizations)
+          .where(inArray(schema.tagLocalizations.tagId, chunk))
+          .all(),
+    );
+
+    const byTag = new Map<string, TagRecord["localizations"]>();
+    for (const loc of locs) {
+      const bucket = byTag.get(loc.tagId) ?? {};
+      bucket[loc.locale as Locale] = { name: loc.name };
+      byTag.set(loc.tagId, bucket);
+    }
+
+    return allTags.map((t) => ({
+      id: t.id,
+      slug: t.slug,
+      createdAt: t.createdAt,
+      localizations: byTag.get(t.id) ?? {},
+    }));
   }
 
   async createTag(data: {
@@ -725,6 +943,8 @@ export class D1ContentProvider implements ContentProvider {
         name: content.name,
       });
     }
+
+    this.invalidate("tags", "articles");
 
     return (await this.getTag(id))!;
   }
@@ -770,11 +990,14 @@ export class D1ContentProvider implements ContentProvider {
       }
     }
 
+    this.invalidate("tags", "articles");
+
     return (await this.getTag(id))!;
   }
 
   async deleteTag(id: string): Promise<void> {
     await this.db.delete(schema.tags).where(eq(schema.tags.id, id));
+    this.invalidate("tags", "articles");
   }
 
   private async hydrateTag(
@@ -1083,6 +1306,7 @@ export class D1ContentProvider implements ContentProvider {
         seoDescription: content.seoDescription ?? null,
       });
     }
+    this.invalidate("pages");
     return (await this.getPage(id))!;
   }
 
@@ -1141,11 +1365,13 @@ export class D1ContentProvider implements ContentProvider {
         }
       }
     }
+    this.invalidate("pages");
     return (await this.getPage(id))!;
   }
 
   async deletePage(id: string): Promise<void> {
     await this.db.delete(schema.pages).where(eq(schema.pages.id, id));
+    this.invalidate("pages");
   }
 
   private async hydratePage(

--- a/src/lib/server/content/query/cache.ts
+++ b/src/lib/server/content/query/cache.ts
@@ -182,7 +182,10 @@ export class QueryCache {
 export function collectionsTouched(
   rootCollection: string,
   query: FindQuery,
-  resolveRelationTarget: (collection: string, relation: string) => string | null,
+  resolveRelationTarget: (
+    collection: string,
+    relation: string,
+  ) => string | null,
 ): string[] {
   const seen = new Set<string>([rootCollection]);
 

--- a/src/lib/server/content/query/cache.ts
+++ b/src/lib/server/content/query/cache.ts
@@ -1,0 +1,208 @@
+/**
+ * KV cache for assembled populate payloads — Phase 1 (#68 §D).
+ *
+ * `CONTENT_CACHE` has been bound since v1.0 but only ever
+ * health-probed (`api/health/+server.ts:41`). A deep populate is
+ * exactly what it's for: the result is expensive to assemble (several
+ * round trips), identical for every visitor, and changes only on
+ * write.
+ *
+ * ## Invalidation
+ *
+ * Per-key TTL plus a **generation counter per collection**. The
+ * generation is embedded in every cache key, so bumping it makes all
+ * existing keys for that collection unreachable in one write — no
+ * key enumeration, which KV does not do cheaply or atomically.
+ *
+ * Populate spans collections (an article payload embeds categories and
+ * tags), so a key's generation component is the concatenation of the
+ * generations of **every collection the query touched**. Editing a
+ * category therefore invalidates the article payloads that embedded
+ * it, without those payloads needing to know they existed.
+ *
+ * ## Deliberately not cached
+ *
+ * Only published, non-draft reads should reach this. Admin/preview
+ * traffic bypasses it entirely — a cache that can serve an unpublished
+ * draft to the public is a correctness bug, not a performance win.
+ * Callers opt in explicitly rather than the cache guessing.
+ */
+import type { FindQuery, FindResult } from "./types";
+
+/** Assembled payloads are cheap to rebuild; keep the TTL modest. */
+export const DEFAULT_TTL_SECONDS = 300;
+
+/** KV rejects TTLs under 60s. */
+const MIN_TTL_SECONDS = 60;
+
+const GENERATION_PREFIX = "gen:";
+const PAYLOAD_PREFIX = "q:";
+
+export interface CacheDeps {
+  kv: KVNamespace;
+}
+
+/**
+ * Stable stringify — key order must not change the hash, or two
+ * identical queries written in different orders would miss each other.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
+}
+
+/**
+ * FNV-1a. Not cryptographic — this only needs to distribute query
+ * shapes across key space, and a collision costs a wrong cache hit for
+ * one query shape, which the generation counter will clear anyway.
+ * Kept in-process because SubtleCrypto is async and this sits on the
+ * hot read path.
+ */
+function hash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(36);
+}
+
+export class QueryCache {
+  constructor(private readonly kv: KVNamespace) {}
+
+  /**
+   * Current generation for each collection, as one batched read.
+   * A missing counter reads as "0" — a cold cache is a miss, never an
+   * error.
+   */
+  private async generations(collections: string[]): Promise<string> {
+    const unique = Array.from(new Set(collections)).sort();
+    const values = await Promise.all(
+      unique.map((c) =>
+        this.kv.get(`${GENERATION_PREFIX}${c}`).catch(() => null),
+      ),
+    );
+    return unique.map((c, i) => `${c}=${values[i] ?? "0"}`).join("&");
+  }
+
+  /**
+   * Cache key for a query. `collections` must list every collection
+   * the query reads — root plus every populate target — so that
+   * editing any of them invalidates this entry.
+   */
+  private async key(
+    collection: string,
+    query: FindQuery,
+    collections: string[],
+  ): Promise<string> {
+    const gen = await this.generations(collections);
+    const shape = stableStringify({ collection, query });
+    return `${PAYLOAD_PREFIX}${collection}:${hash(gen)}:${hash(shape)}`;
+  }
+
+  async get(
+    collection: string,
+    query: FindQuery,
+    collections: string[],
+  ): Promise<FindResult | null> {
+    try {
+      const raw = await this.kv.get(
+        await this.key(collection, query, collections),
+        "json",
+      );
+      return (raw as FindResult | null) ?? null;
+    } catch {
+      // A cache read must never break a page render.
+      return null;
+    }
+  }
+
+  async set(
+    collection: string,
+    query: FindQuery,
+    collections: string[],
+    value: FindResult,
+    ttlSeconds = DEFAULT_TTL_SECONDS,
+  ): Promise<void> {
+    try {
+      await this.kv.put(
+        await this.key(collection, query, collections),
+        JSON.stringify(value),
+        {
+          expirationTtl: Math.max(MIN_TTL_SECONDS, Math.floor(ttlSeconds)),
+        },
+      );
+    } catch {
+      /* best-effort — a failed cache write is not a failed request */
+    }
+  }
+
+  /**
+   * Bump a collection's generation, orphaning every cached payload
+   * that read it. Call after any write to that collection.
+   *
+   * Not atomic (KV has no compare-and-swap): two concurrent bumps can
+   * land on the same number. That's harmless here — the only effect is
+   * that one of two simultaneous invalidations is redundant, and both
+   * still move the generation off the value cached before them.
+   */
+  async invalidate(collection: string): Promise<void> {
+    try {
+      const key = `${GENERATION_PREFIX}${collection}`;
+      const current = Number((await this.kv.get(key)) ?? "0");
+      const next = Number.isFinite(current) ? current + 1 : 1;
+      // No TTL: generation counters must outlive the payloads they
+      // guard, or an expired counter would silently resurrect stale
+      // entries cached under the old generation.
+      await this.kv.put(key, String(next));
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  /** Invalidate several collections — e.g. a write touching a join table. */
+  async invalidateMany(collections: string[]): Promise<void> {
+    await Promise.all(
+      Array.from(new Set(collections)).map((c) => this.invalidate(c)),
+    );
+  }
+}
+
+/**
+ * Every collection a query reads: the root, plus each populate target,
+ * resolved recursively. Used to build the generation component of the
+ * cache key.
+ */
+export function collectionsTouched(
+  rootCollection: string,
+  query: FindQuery,
+  resolveRelationTarget: (collection: string, relation: string) => string | null,
+): string[] {
+  const seen = new Set<string>([rootCollection]);
+
+  const walk = (
+    collection: string,
+    populate: FindQuery["populate"],
+    depth: number,
+  ): void => {
+    if (!populate || depth > 8) return;
+    for (const [name, spec] of Object.entries(populate)) {
+      if (spec === false) continue;
+      const target = resolveRelationTarget(collection, name);
+      if (!target) continue;
+      seen.add(target);
+      if (spec && typeof spec === "object" && spec.populate) {
+        walk(target, spec.populate, depth + 1);
+      }
+    }
+  };
+
+  walk(rootCollection, query.populate, 1);
+  return Array.from(seen);
+}

--- a/src/lib/server/content/query/engine.ts
+++ b/src/lib/server/content/query/engine.ts
@@ -1,0 +1,762 @@
+/**
+ * Generic query engine — Phase 1 (#68 §D).
+ *
+ * ## The problem this exists to fix
+ *
+ * `D1ContentProvider.listArticles` runs the base query, then calls
+ * `hydrateArticle` **per row**, and each of those fires 2 more queries
+ * (localizations + tags). A 20-item list is **1 + 40 queries**
+ * (d1.ts:176, :538). That doesn't survive nesting: adding a second
+ * level multiplies rather than adds.
+ *
+ * ## The fix: breadth-first, one query per relation per level
+ *
+ * Populate is resolved **level by level**, not row by row:
+ *
+ *   1. Load the root rows (1 query, + 1 count).
+ *   2. Collect every id needed for level-1 relations across ALL root
+ *      rows at once.
+ *   3. Issue ONE batched `inArray` query per relation.
+ *   4. Stitch results back onto the rows in memory.
+ *   5. Repeat for level 2 using the rows just loaded.
+ *
+ * Query count becomes a function of the *shape* of the populate tree,
+ * not the *number of rows*. 20 articles with `populate=category,tags`
+ * goes from 41 queries to 4, and stays 4 at 100 articles.
+ *
+ * This is the same `inArray` technique already used ad hoc at
+ * d1.ts:140 and in the shop's cart-service, applied systematically.
+ *
+ * Worth noting from the Phase 2 research: Payload — the closest
+ * architectural sibling — does NOT use real SQL joins for `hasMany`
+ * relations either; it excludes them from its join tree and populates
+ * with follow-up queries. Batched populate is the required approach on
+ * a relational store regardless of how schema is defined, which is why
+ * this layer is independent of the Phase 2 storage decision.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  like,
+  lt,
+  lte,
+  ne,
+  notInArray,
+  or,
+  getTableColumns,
+  sql,
+  type Column,
+  type SQL,
+} from "drizzle-orm";
+import { type SQLiteTable } from "drizzle-orm/sqlite-core";
+import {
+  getCollection,
+  type CollectionDef,
+  type RelationDef,
+} from "./registry";
+import {
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  MAX_POPULATE_DEPTH,
+  QueryError,
+  type EntryRow,
+  type Filters,
+  type FindQuery,
+  type FindResult,
+  type PopulateNode,
+  type PopulateSpec,
+} from "./types";
+
+/**
+ * D1 binds at most 100 parameters per statement. Every batched
+ * `inArray` load chunks to this size — see `loadChunked`.
+ */
+const MAX_BIND_PARAMS = 100;
+
+/** Column lookup that tolerates the drizzle table type being opaque. */
+function columnsOf(table: SQLiteTable): Record<string, unknown> {
+  return getTableColumns(table) as unknown as Record<string, unknown>;
+}
+
+function requireColumn(
+  table: SQLiteTable,
+  name: string,
+  ctx: string,
+): SQLiteColumnLike {
+  const col = columnsOf(table)[name];
+  if (!col) {
+    throw new QueryError(`Unknown field "${name}" on ${ctx}`, "UNKNOWN_FIELD");
+  }
+  return col as SQLiteColumnLike;
+}
+
+/**
+ * Stand-in for a drizzle column. The concrete type is generic over ~8
+ * params; we only ever hand these straight back to drizzle's own
+ * operators, so the loosest `Column` keeps call sites readable without
+ * `any` leaking into the public surface.
+ */
+type SQLiteColumnLike = Column;
+
+/** Normalizes a populate spec to its object form. */
+function toNode(spec: PopulateSpec): PopulateNode {
+  return spec === true ? {} : spec === false ? {} : spec;
+}
+
+export interface QueryEngineOptions {
+  /**
+   * Locales accepted by `locale` params. Comes from the runtime
+   * supported-locale list, NOT a compile-time enum — #68 §E calls for
+   * dropping the hardcoded `["th","en"]` assumption, and Phase 2
+   * requires an arbitrary locale set.
+   */
+  supportedLocales: readonly string[];
+  /** Canonical fallback when a row has no row for the asked locale. */
+  defaultLocale: string;
+}
+
+export class QueryEngine {
+  private db: ReturnType<typeof drizzle>;
+  /** Incremented per issued query so callers can assert on N+1. */
+  private queryCount = 0;
+
+  constructor(
+    d1: D1Database,
+    private readonly opts: QueryEngineOptions,
+  ) {
+    this.db = drizzle(d1);
+  }
+
+  /** Queries issued since construction. Used by tests and `meta`. */
+  get issuedQueries(): number {
+    return this.queryCount;
+  }
+
+  async findOne(
+    collectionId: string,
+    query: Omit<FindQuery, "page" | "limit"> = {},
+  ): Promise<EntryRow | null> {
+    const res = await this.find(collectionId, { ...query, page: 1, limit: 1 });
+    return res.data[0] ?? null;
+  }
+
+  async find(collectionId: string, query: FindQuery = {}): Promise<FindResult> {
+    const collection = getCollection(collectionId);
+    if (!collection) {
+      throw new QueryError(
+        `Unknown collection "${collectionId}"`,
+        "UNKNOWN_COLLECTION",
+      );
+    }
+
+    const locale = this.validateLocale(query.locale);
+    const limit = Math.min(
+      MAX_LIMIT,
+      Math.max(1, Math.floor(query.limit ?? DEFAULT_LIMIT)),
+    );
+    const page = Math.max(1, Math.floor(query.page ?? 1));
+    const offset = (page - 1) * limit;
+
+    this.assertDepth(query.populate, 1);
+
+    const where = this.buildWhere(
+      collection,
+      query.filters,
+      query.onlyPublished,
+    );
+    const orderBy = this.buildOrderBy(collection, query.sort);
+
+    const [rows, countRow] = await Promise.all([
+      this.tracked(() =>
+        this.db
+          .select()
+          .from(collection.table)
+          .where(where)
+          .orderBy(...orderBy)
+          .limit(limit)
+          .offset(offset)
+          .all(),
+      ),
+      this.tracked(() =>
+        this.db
+          .select({ count: sql<number>`count(*)` })
+          .from(collection.table)
+          .where(where)
+          .get(),
+      ),
+    ]);
+
+    const data = (rows as EntryRow[]).map((r) =>
+      this.projectScalars(collection, r, query.fields),
+    );
+
+    if (query.populate && data.length > 0) {
+      await this.populateLevel(
+        collection,
+        rows as EntryRow[],
+        data,
+        query.populate,
+        locale,
+        1,
+      );
+    }
+
+    const total = countRow?.count ?? 0;
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        pageCount: Math.ceil(total / limit),
+        queryCount: this.queryCount,
+      },
+    };
+  }
+
+  // ─── Populate ─────────────────────────────────────────────
+
+  /**
+   * Resolve one level of the populate tree for a set of already-loaded
+   * rows, then recurse. Exactly one query per relation at this level,
+   * regardless of how many rows there are.
+   *
+   * `sourceRows` are the raw DB rows (needed for FK values, which may
+   * have been projected away); `targetRows` are the caller-visible
+   * objects the results get attached to. They are index-aligned.
+   */
+  private async populateLevel(
+    collection: CollectionDef,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    populate: Record<string, PopulateSpec>,
+    inheritedLocale: string | undefined,
+    depth: number,
+  ): Promise<void> {
+    // `populate=*` — every relation of this collection, one level deep,
+    // with default fields. Expanded here rather than in the parser
+    // because only the registry knows what "every relation" means.
+    const expanded: Record<string, PopulateSpec> =
+      populate["*"] !== undefined && populate["*"] !== false
+        ? Object.fromEntries(
+            Object.keys(collection.relations).map((name) => [name, true]),
+          )
+        : populate;
+
+    for (const [relationName, spec] of Object.entries(expanded)) {
+      if (spec === false) continue;
+      const relation = collection.relations[relationName];
+      if (!relation) {
+        throw new QueryError(
+          `Unknown relation "${relationName}" on ${collection.apiId}`,
+          "UNKNOWN_RELATION",
+        );
+      }
+      const node = toNode(spec);
+      const locale = node.locale
+        ? this.validateLocale(node.locale)
+        : inheritedLocale;
+
+      await this.resolveRelation(
+        relation,
+        relationName,
+        sourceRows,
+        targetRows,
+        node,
+        locale,
+        depth,
+        collection,
+      );
+    }
+  }
+
+  private async resolveRelation(
+    relation: RelationDef,
+    relationName: string,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    node: PopulateNode,
+    locale: string | undefined,
+    depth: number,
+    parent: CollectionDef,
+  ): Promise<void> {
+    switch (relation.kind) {
+      case "localizations":
+        return this.resolveLocalizations(
+          relation,
+          relationName,
+          sourceRows,
+          targetRows,
+          locale,
+          parent,
+        );
+      case "manyToOne":
+        return this.resolveManyToOne(
+          relation,
+          relationName,
+          sourceRows,
+          targetRows,
+          node,
+          locale,
+          depth,
+        );
+      case "manyToMany":
+        return this.resolveManyToMany(
+          relation,
+          relationName,
+          sourceRows,
+          targetRows,
+          node,
+          locale,
+          depth,
+          parent,
+        );
+    }
+  }
+
+  /**
+   * Base-row + sibling `_localizations` — the repo's convention. ONE
+   * query for every parent row, grouped in memory into
+   * `{ en: {...}, th: {...} }`, matching the existing `ArticleRecord`
+   * shape so callers can swap onto this without reshaping.
+   */
+  private async resolveLocalizations(
+    relation: Extract<RelationDef, { kind: "localizations" }>,
+    relationName: string,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    locale: string | undefined,
+    parent: CollectionDef,
+  ): Promise<void> {
+    const ids = this.collectIds(sourceRows, parent.primaryKey);
+    if (ids.length === 0) return;
+
+    const fkCol = requireColumn(
+      relation.table,
+      relation.foreignKey,
+      "localizations",
+    );
+    // Extra conditions applied to every chunk alongside its id slice.
+    const extra: SQL[] = locale
+      ? [eq(requireColumn(relation.table, "locale", "locale"), locale)]
+      : [];
+
+    const locRows = (await this.loadChunked(ids, (chunk) =>
+      this.db
+        .select()
+        .from(relation.table)
+        .where(and(inArray(fkCol, chunk), ...extra))
+        .all(),
+    )) as EntryRow[];
+
+    const byParent = new Map<string, Record<string, unknown>>();
+    for (const row of locRows) {
+      const parentId = String(row[relation.foreignKey]);
+      const rowLocale = String(row.locale);
+      const bucket = byParent.get(parentId) ?? {};
+      const payload: Record<string, unknown> = {};
+      for (const f of relation.fields) payload[f] = row[f] ?? null;
+      bucket[rowLocale] = payload;
+      byParent.set(parentId, bucket);
+    }
+
+    for (let i = 0; i < targetRows.length; i++) {
+      const id = String(sourceRows[i][parent.primaryKey]);
+      targetRows[i][relationName] = byParent.get(id) ?? {};
+    }
+  }
+
+  /** FK column on this table → one batched load of the target. */
+  private async resolveManyToOne(
+    relation: Extract<RelationDef, { kind: "manyToOne" }>,
+    relationName: string,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    node: PopulateNode,
+    locale: string | undefined,
+    depth: number,
+  ): Promise<void> {
+    const target = getCollection(relation.target);
+    if (!target) {
+      throw new QueryError(
+        `Relation "${relationName}" targets unknown collection "${relation.target}"`,
+        "UNKNOWN_COLLECTION",
+      );
+    }
+
+    const localKey = relation.localKey;
+    const ids = this.collectIds(sourceRows, localKey);
+    if (ids.length === 0) {
+      // Every parent had a null FK — still set the key so the shape is
+      // stable for consumers rather than silently absent.
+      for (const row of targetRows) row[relationName] = null;
+      return;
+    }
+
+    const targetKey = relation.targetKey ?? target.primaryKey;
+    const targetCol = requireColumn(target.table, targetKey, target.apiId);
+
+    const rows = (await this.loadChunked(ids, (chunk) =>
+      this.db
+        .select()
+        .from(target.table)
+        .where(inArray(targetCol, chunk))
+        .all(),
+    )) as EntryRow[];
+
+    const projected = rows.map((r) =>
+      this.projectScalars(target, r, node.fields),
+    );
+    const byId = new Map<string, EntryRow>();
+    projected.forEach((p, i) => byId.set(String(rows[i][targetKey]), p));
+
+    for (let i = 0; i < targetRows.length; i++) {
+      const fk = sourceRows[i][localKey];
+      targetRows[i][relationName] = fk == null ? null : byId.get(String(fk)) ?? null;
+    }
+
+    if (node.populate && rows.length > 0) {
+      this.assertDepth(node.populate, depth + 1);
+      await this.populateLevel(
+        target,
+        rows,
+        projected,
+        node.populate,
+        locale,
+        depth + 1,
+      );
+    }
+  }
+
+  /**
+   * Join table → two batched queries total (edges, then targets),
+   * regardless of parent count. Order of the joined array follows the
+   * target load; the current join tables carry no explicit position
+   * column (Phase 2's `entry_relations` adds one).
+   */
+  private async resolveManyToMany(
+    relation: Extract<RelationDef, { kind: "manyToMany" }>,
+    relationName: string,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    node: PopulateNode,
+    locale: string | undefined,
+    depth: number,
+    parent: CollectionDef,
+  ): Promise<void> {
+    const target = getCollection(relation.target);
+    if (!target) {
+      throw new QueryError(
+        `Relation "${relationName}" targets unknown collection "${relation.target}"`,
+        "UNKNOWN_COLLECTION",
+      );
+    }
+
+    const parentIds = this.collectIds(sourceRows, parent.primaryKey);
+    if (parentIds.length === 0) return;
+
+    const throughLocal = requireColumn(
+      relation.through,
+      relation.throughLocalKey,
+      "join table",
+    );
+
+    const edges = (await this.loadChunked(parentIds, (chunk) =>
+      this.db
+        .select()
+        .from(relation.through)
+        .where(inArray(throughLocal, chunk))
+        .all(),
+    )) as EntryRow[];
+
+    if (edges.length === 0) {
+      for (const row of targetRows) row[relationName] = [];
+      return;
+    }
+
+    const targetIds = Array.from(
+      new Set(edges.map((e) => String(e[relation.throughTargetKey]))),
+    );
+
+    const rows = (await this.loadChunked(targetIds, (chunk) =>
+      this.db
+        .select()
+        .from(target.table)
+        .where(
+          inArray(
+            requireColumn(target.table, target.primaryKey, target.apiId),
+            chunk,
+          ),
+        )
+        .all(),
+    )) as EntryRow[];
+
+    const projected = rows.map((r) =>
+      this.projectScalars(target, r, node.fields),
+    );
+    const byId = new Map<string, EntryRow>();
+    projected.forEach((p, i) => byId.set(String(rows[i][target.primaryKey]), p));
+
+    const grouped = new Map<string, EntryRow[]>();
+    for (const edge of edges) {
+      const parentId = String(edge[relation.throughLocalKey]);
+      const hit = byId.get(String(edge[relation.throughTargetKey]));
+      if (!hit) continue;
+      const list = grouped.get(parentId) ?? [];
+      list.push(hit);
+      grouped.set(parentId, list);
+    }
+
+    for (let i = 0; i < targetRows.length; i++) {
+      const id = String(sourceRows[i][parent.primaryKey]);
+      targetRows[i][relationName] = grouped.get(id) ?? [];
+    }
+
+    if (node.populate && rows.length > 0) {
+      this.assertDepth(node.populate, depth + 1);
+      await this.populateLevel(
+        target,
+        rows,
+        projected,
+        node.populate,
+        locale,
+        depth + 1,
+      );
+    }
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────
+
+  /**
+   * Run an `inArray` load in chunks that respect D1's bound-parameter
+   * ceiling (100 per statement).
+   *
+   * Without this, `?limit=100&populate=tags` binds 100 parent ids in one
+   * statement and fails outright — and the failure is invisible until a
+   * site actually has that much content. The per-row hydration this
+   * layer replaces never hit the limit because it bound exactly one id
+   * at a time; batching is what introduces the constraint.
+   *
+   * Chunks run sequentially: D1 counts every subrequest against the
+   * per-invocation query budget, and firing an unbounded number in
+   * parallel is how you exhaust it.
+   */
+  private async loadChunked<T>(
+    ids: string[],
+    load: (chunk: string[]) => Promise<T[]>,
+  ): Promise<T[]> {
+    if (ids.length === 0) return [];
+    if (ids.length <= MAX_BIND_PARAMS) return this.tracked(() => load(ids));
+
+    const out: T[] = [];
+    for (let i = 0; i < ids.length; i += MAX_BIND_PARAMS) {
+      const chunk = ids.slice(i, i + MAX_BIND_PARAMS);
+      out.push(...(await this.tracked(() => load(chunk))));
+    }
+    return out;
+  }
+
+  /** Distinct, non-null values of `key` across rows. */
+  private collectIds(rows: EntryRow[], key: string): string[] {
+    const set = new Set<string>();
+    for (const row of rows) {
+      const v = row[key];
+      if (v != null) set.add(String(v));
+    }
+    return Array.from(set);
+  }
+
+  /**
+   * Restrict a row to the collection's `selectable` allowlist, then to
+   * the caller's `fields` if given. An unknown requested field is an
+   * error rather than a silent omission — a typo'd `fields` param
+   * should not quietly return less data.
+   */
+  private projectScalars(
+    collection: CollectionDef,
+    row: EntryRow,
+    fields?: string[],
+  ): EntryRow {
+    const allowed = fields
+      ? fields.map((f) => {
+          if (!collection.selectable.includes(f)) {
+            throw new QueryError(
+              `Unknown field "${f}" on ${collection.apiId}`,
+              "UNKNOWN_FIELD",
+            );
+          }
+          return f;
+        })
+      : collection.selectable;
+
+    const out: EntryRow = {};
+    for (const f of allowed) out[f] = row[f] ?? null;
+    // The primary key always rides along — populate stitching and any
+    // client-side cache keying need it, and omitting it makes results
+    // ambiguous.
+    if (!(collection.primaryKey in out)) {
+      out[collection.primaryKey] = row[collection.primaryKey];
+    }
+    return out;
+  }
+
+  private buildWhere(
+    collection: CollectionDef,
+    filters?: Filters,
+    onlyPublished?: boolean,
+  ): SQL | undefined {
+    const conditions: SQL[] = [];
+
+    // Scheduled-publishing guard. Applied before user filters so it
+    // can't be displaced by them, and expressed as a disjunction the
+    // `filters` grammar has no syntax for:
+    //   publishedAt IS NULL OR publishedAt <= now
+    if (onlyPublished && collection.filterable.includes("publishedAt")) {
+      const col = requireColumn(
+        collection.table,
+        "publishedAt",
+        collection.apiId,
+      );
+      conditions.push(
+        or(isNull(col), lte(col, new Date().toISOString()))!,
+      );
+    }
+
+    if (!filters) return conditions.length ? and(...conditions) : undefined;
+
+    for (const [field, condition] of Object.entries(filters)) {
+      if (!collection.filterable.includes(field)) {
+        throw new QueryError(
+          `Field "${field}" is not filterable on ${collection.apiId}`,
+          "UNKNOWN_FIELD",
+        );
+      }
+      const col = requireColumn(collection.table, field, collection.apiId);
+
+      // Bare value is sugar for $eq.
+      if (
+        condition === null ||
+        typeof condition !== "object" ||
+        Array.isArray(condition)
+      ) {
+        conditions.push(eq(col, condition as never));
+        continue;
+      }
+
+      for (const [op, raw] of Object.entries(condition)) {
+        conditions.push(this.buildCondition(col, op, raw));
+      }
+    }
+
+    return conditions.length ? and(...conditions) : undefined;
+  }
+
+  private buildCondition(
+    col: SQLiteColumnLike,
+    op: string,
+    raw: unknown,
+  ): SQL {
+    switch (op) {
+      case "$eq":
+        return eq(col, raw as never);
+      case "$ne":
+        return ne(col, raw as never);
+      case "$lt":
+        return lt(col, raw as never);
+      case "$lte":
+        return lte(col, raw as never);
+      case "$gt":
+        return gt(col, raw as never);
+      case "$gte":
+        return gte(col, raw as never);
+      case "$in":
+        return inArray(col, this.toArray(raw) as never[]);
+      case "$notIn":
+        return notInArray(col, this.toArray(raw) as never[]);
+      case "$contains":
+        // Escape LIKE wildcards in user input so a `%` in a search term
+        // is matched literally instead of turning into "match anything".
+        return like(col, `%${this.escapeLike(String(raw))}%`);
+      case "$null":
+        return raw === false ? isNotNull(col) : isNull(col);
+      case "$notNull":
+        return raw === false ? isNull(col) : isNotNull(col);
+      default:
+        throw new QueryError(`Unknown operator "${op}"`, "UNKNOWN_OPERATOR");
+    }
+  }
+
+  private escapeLike(value: string): string {
+    return value.replace(/[\\%_]/g, (c) => `\\${c}`);
+  }
+
+  private toArray(raw: unknown): unknown[] {
+    if (Array.isArray(raw)) return raw;
+    if (raw == null) return [];
+    return [raw];
+  }
+
+  private buildOrderBy(collection: CollectionDef, sort?: string | string[]) {
+    if (!sort) return [];
+    const specs = Array.isArray(sort) ? sort : [sort];
+    return specs.map((spec) => {
+      const descending = spec.startsWith("-");
+      const field = descending ? spec.slice(1) : spec;
+      if (!collection.filterable.includes(field)) {
+        throw new QueryError(
+          `Field "${field}" is not sortable on ${collection.apiId}`,
+          "INVALID_SORT",
+        );
+      }
+      const col = requireColumn(collection.table, field, collection.apiId);
+      return descending ? desc(col) : asc(col);
+    });
+  }
+
+  private validateLocale(locale?: string): string | undefined {
+    if (!locale) return undefined;
+    if (!this.opts.supportedLocales.includes(locale)) {
+      throw new QueryError(
+        `Unsupported locale "${locale}". Supported: ${this.opts.supportedLocales.join(", ")}`,
+        "INVALID_LOCALE",
+      );
+    }
+    return locale;
+  }
+
+  /**
+   * Depth is capped so a crafted `?populate=a.b.c.d.e…` can't fan out
+   * into an unbounded number of round trips. Contentful caps include
+   * at 10; Hygraph uses a complexity budget; #68 §D asks for 2–3.
+   */
+  private assertDepth(
+    populate: Record<string, PopulateSpec> | undefined,
+    depth: number,
+  ): void {
+    if (!populate) return;
+    if (depth > MAX_POPULATE_DEPTH) {
+      throw new QueryError(
+        `Populate depth exceeds maximum of ${MAX_POPULATE_DEPTH}`,
+        "DEPTH_EXCEEDED",
+      );
+    }
+    for (const spec of Object.values(populate)) {
+      if (spec && typeof spec === "object" && spec.populate) {
+        this.assertDepth(spec.populate, depth + 1);
+      }
+    }
+  }
+
+  private async tracked<T>(run: () => Promise<T>): Promise<T> {
+    this.queryCount++;
+    return run();
+  }
+}

--- a/src/lib/server/content/query/engine.ts
+++ b/src/lib/server/content/query/engine.ts
@@ -420,7 +420,8 @@ export class QueryEngine {
 
     for (let i = 0; i < targetRows.length; i++) {
       const fk = sourceRows[i][localKey];
-      targetRows[i][relationName] = fk == null ? null : byId.get(String(fk)) ?? null;
+      targetRows[i][relationName] =
+        fk == null ? null : (byId.get(String(fk)) ?? null);
     }
 
     if (node.populate && rows.length > 0) {
@@ -503,7 +504,9 @@ export class QueryEngine {
       this.projectScalars(target, r, node.fields),
     );
     const byId = new Map<string, EntryRow>();
-    projected.forEach((p, i) => byId.set(String(rows[i][target.primaryKey]), p));
+    projected.forEach((p, i) =>
+      byId.set(String(rows[i][target.primaryKey]), p),
+    );
 
     const grouped = new Map<string, EntryRow[]>();
     for (const edge of edges) {
@@ -625,9 +628,7 @@ export class QueryEngine {
         "publishedAt",
         collection.apiId,
       );
-      conditions.push(
-        or(isNull(col), lte(col, new Date().toISOString()))!,
-      );
+      conditions.push(or(isNull(col), lte(col, new Date().toISOString()))!);
     }
 
     if (!filters) return conditions.length ? and(...conditions) : undefined;
@@ -659,11 +660,7 @@ export class QueryEngine {
     return conditions.length ? and(...conditions) : undefined;
   }
 
-  private buildCondition(
-    col: SQLiteColumnLike,
-    op: string,
-    raw: unknown,
-  ): SQL {
+  private buildCondition(col: SQLiteColumnLike, op: string, raw: unknown): SQL {
     switch (op) {
       case "$eq":
         return eq(col, raw as never);

--- a/src/lib/server/content/query/index.ts
+++ b/src/lib/server/content/query/index.ts
@@ -1,0 +1,122 @@
+/**
+ * Query layer public surface — Phase 1 (#68).
+ *
+ * `createQueryEngine(env)` is what call sites use. The cached variant
+ * is opt-in per call rather than automatic: caching an admin/preview
+ * read that can contain unpublished drafts would be a correctness bug,
+ * so the caller has to say "this read is public and cacheable."
+ */
+import { QueryEngine, type QueryEngineOptions } from "./engine";
+import { QueryCache, collectionsTouched } from "./cache";
+import { getCollection } from "./registry";
+import type { EntryRow, FindQuery, FindResult } from "./types";
+
+export { QueryEngine } from "./engine";
+export { QueryCache } from "./cache";
+export {
+  COLLECTIONS,
+  getCollection,
+  listCollectionIds,
+  type CollectionDef,
+  type RelationDef,
+} from "./registry";
+export {
+  parseFindQuery,
+  parseFields,
+  parseFilters,
+  parsePopulate,
+  parseSort,
+} from "./params";
+export {
+  MAX_POPULATE_DEPTH,
+  MAX_LIMIT,
+  DEFAULT_LIMIT,
+  QueryError,
+  type EntryRow,
+  type Filters,
+  type FindQuery,
+  type FindResult,
+  type PopulateNode,
+  type PopulateSpec,
+} from "./types";
+
+/** Where a relation points, or null if it doesn't exist. */
+function resolveRelationTarget(
+  collection: string,
+  relation: string,
+): string | null {
+  const def = getCollection(collection);
+  if (!def) return null;
+  if (relation === "*") return null; // expanded by the engine, not a target
+  const rel = def.relations[relation];
+  if (!rel) return null;
+  // A localizations relation lives in a sibling table of the same
+  // collection — it has no separate target collection to invalidate.
+  return rel.kind === "localizations" ? collection : rel.target;
+}
+
+export interface ContentQuery {
+  find(collection: string, query?: FindQuery): Promise<FindResult>;
+  findOne(
+    collection: string,
+    query?: Omit<FindQuery, "page" | "limit">,
+  ): Promise<EntryRow | null>;
+  /**
+   * Cached read. Only for public, published-only queries — see the
+   * note in cache.ts about never caching draft-visible reads.
+   */
+  findCached(
+    collection: string,
+    query?: FindQuery,
+    ttlSeconds?: number,
+  ): Promise<FindResult>;
+  /** Bump the generation for these collections after a write. */
+  invalidate(collections: string[]): Promise<void>;
+  /** Queries issued by the underlying engine (for tests / meta). */
+  readonly issuedQueries: number;
+}
+
+export function createQueryEngine(
+  env: App.Platform["env"],
+  opts?: Partial<QueryEngineOptions>,
+): ContentQuery {
+  const supportedLocales =
+    opts?.supportedLocales ??
+    (env.SUPPORTED_LOCALES ?? "en,th")
+      .split(",")
+      .map((l) => l.trim())
+      .filter(Boolean);
+  const defaultLocale =
+    opts?.defaultLocale ?? env.DEFAULT_LOCALE ?? supportedLocales[0] ?? "en";
+
+  const engine = new QueryEngine(env.DB, { supportedLocales, defaultLocale });
+  const cache = env.CONTENT_CACHE ? new QueryCache(env.CONTENT_CACHE) : null;
+
+  return {
+    find: (collection, query) => engine.find(collection, query ?? {}),
+    findOne: (collection, query) => engine.findOne(collection, query ?? {}),
+
+    async findCached(collection, query = {}, ttlSeconds) {
+      if (!cache) return engine.find(collection, query);
+      const touched = collectionsTouched(
+        collection,
+        query,
+        resolveRelationTarget,
+      );
+      const hit = await cache.get(collection, query, touched);
+      if (hit) return hit;
+      const fresh = await engine.find(collection, query);
+      await cache.set(collection, query, touched, fresh, ttlSeconds);
+      return fresh;
+    },
+
+    async invalidate(collections) {
+      if (!cache) return;
+      await cache.invalidateMany(collections);
+    },
+
+    get issuedQueries() {
+      return engine.issuedQueries;
+    },
+  };
+}

--- a/src/lib/server/content/query/params.ts
+++ b/src/lib/server/content/query/params.ts
@@ -64,10 +64,7 @@ export function parsePopulate(
 
   const tree: Record<string, PopulateSpec> = {};
   for (const path of trimmed.split(",")) {
-    const segments = path
-      .trim()
-      .split(".")
-      .filter(Boolean);
+    const segments = path.trim().split(".").filter(Boolean);
     if (segments.length === 0) continue;
     if (segments.length > MAX_PATH_SEGMENTS) {
       throw new QueryError(

--- a/src/lib/server/content/query/params.ts
+++ b/src/lib/server/content/query/params.ts
@@ -1,0 +1,228 @@
+/**
+ * Strapi-compatible query-param parsing — Phase 1 (#68 §D).
+ *
+ * Translates URL params into a `FindQuery`. The vocabulary is
+ * deliberately Strapi's, because that's what headless consumers and
+ * their client libraries already speak:
+ *
+ *   ?populate=category,tags
+ *   ?populate=category.parent          → nested via dot path
+ *   ?fields=slug,status
+ *   ?filters[status][$eq]=published
+ *   ?filters[publishedAt][$lte]=2026-01-01
+ *   ?sort=-publishedAt,slug
+ *   ?page=2&limit=50
+ *   ?locale=th
+ *
+ * Everything here is untrusted input, so parsing is strict: unknown
+ * shapes raise `QueryError` (→ HTTP 400) rather than being ignored.
+ * Silently dropping a malformed filter is the dangerous failure —
+ * a caller asking for `status=published` and getting drafts because
+ * their bracket syntax was wrong is worse than an error.
+ */
+import {
+  QueryError,
+  type Filters,
+  type FilterOperator,
+  type FindQuery,
+  type PopulateNode,
+  type PopulateSpec,
+} from "./types";
+
+const OPERATORS = new Set<string>([
+  "$eq",
+  "$ne",
+  "$lt",
+  "$lte",
+  "$gt",
+  "$gte",
+  "$in",
+  "$notIn",
+  "$contains",
+  "$null",
+  "$notNull",
+]);
+
+/** Guards against a pathological `?populate=a.b.c.d.e.f…` blowing the parser. */
+const MAX_PATH_SEGMENTS = 8;
+
+/**
+ * `category,tags` or `category.parent,tags` → nested populate tree.
+ *
+ * Depth is enforced later by the engine (which knows MAX_POPULATE_DEPTH);
+ * here we only bound the raw string so parsing itself stays cheap.
+ */
+export function parsePopulate(
+  raw: string | null,
+): Record<string, PopulateSpec> | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  // `populate=*` — every relation, one level. Matches Strapi.
+  if (trimmed === "*") return { "*": true };
+
+  const tree: Record<string, PopulateSpec> = {};
+  for (const path of trimmed.split(",")) {
+    const segments = path
+      .trim()
+      .split(".")
+      .filter(Boolean);
+    if (segments.length === 0) continue;
+    if (segments.length > MAX_PATH_SEGMENTS) {
+      throw new QueryError(
+        `Populate path "${path}" has too many segments`,
+        "DEPTH_EXCEEDED",
+      );
+    }
+
+    let cursor = tree;
+    segments.forEach((segment, i) => {
+      const last = i === segments.length - 1;
+      if (last) {
+        // Don't clobber a branch already created by a sibling path.
+        if (cursor[segment] === undefined) cursor[segment] = true;
+        return;
+      }
+      const existing = cursor[segment];
+      const node: PopulateNode =
+        existing && typeof existing === "object" ? existing : {};
+      if (!node.populate) node.populate = {};
+      cursor[segment] = node;
+      cursor = node.populate;
+    });
+  }
+  return Object.keys(tree).length ? tree : undefined;
+}
+
+/** `slug,status` → ["slug","status"] */
+export function parseFields(raw: string | null): string[] | undefined {
+  if (!raw) return undefined;
+  const fields = raw
+    .split(",")
+    .map((f) => f.trim())
+    .filter(Boolean);
+  return fields.length ? fields : undefined;
+}
+
+/** `-publishedAt,slug` → ["-publishedAt","slug"] */
+export function parseSort(raw: string | null): string[] | undefined {
+  if (!raw) return undefined;
+  const specs = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return specs.length ? specs : undefined;
+}
+
+/**
+ * Collects `filters[field][$op]=value` across all search params.
+ *
+ * Also accepts the shorthand `filters[field]=value` (implicit `$eq`).
+ * Repeated keys accumulate into an array, so
+ * `filters[id][$in]=a&filters[id][$in]=b` works as expected.
+ */
+export function parseFilters(params: URLSearchParams): Filters | undefined {
+  const filters: Filters = {};
+  let found = false;
+
+  for (const [key, value] of params.entries()) {
+    if (!key.startsWith("filters[")) continue;
+
+    const path = parseBracketPath(key);
+    if (!path || path.length === 0 || path.length > 2) {
+      throw new QueryError(
+        `Malformed filter parameter "${key}"`,
+        "UNKNOWN_OPERATOR",
+      );
+    }
+
+    const [field, op] = path;
+    found = true;
+
+    if (op === undefined) {
+      filters[field] = coerce(value);
+      continue;
+    }
+    if (!OPERATORS.has(op)) {
+      throw new QueryError(`Unknown operator "${op}"`, "UNKNOWN_OPERATOR");
+    }
+
+    const existing = filters[field];
+    const bucket: Partial<Record<FilterOperator, unknown>> =
+      existing && typeof existing === "object" && !Array.isArray(existing)
+        ? (existing as Partial<Record<FilterOperator, unknown>>)
+        : {};
+
+    const operator = op as FilterOperator;
+    const prior = bucket[operator];
+    if (prior === undefined) {
+      bucket[operator] = coerce(value);
+    } else if (Array.isArray(prior)) {
+      prior.push(coerce(value));
+    } else {
+      bucket[operator] = [prior, coerce(value)];
+    }
+    filters[field] = bucket as Filters[string];
+  }
+
+  return found ? filters : undefined;
+}
+
+/** `filters[status][$eq]` → ["status","$eq"] */
+function parseBracketPath(key: string): string[] | null {
+  const inner = key.slice("filters".length);
+  const parts: string[] = [];
+  const re = /\[([^\]]*)\]/g;
+  let match: RegExpExecArray | null;
+  let consumed = 0;
+  while ((match = re.exec(inner)) !== null) {
+    if (match.index !== consumed) return null; // gap → malformed
+    if (!match[1]) return null; // empty bracket
+    parts.push(match[1]);
+    consumed = re.lastIndex;
+  }
+  if (consumed !== inner.length) return null; // trailing junk
+  return parts;
+}
+
+/**
+ * URL params are strings; filters are compared against typed columns.
+ * Coerce the unambiguous cases so `?filters[size][$gt]=100` compares
+ * numerically rather than lexicographically ("9" > "100" as text).
+ *
+ * Deliberately conservative: only exact `true`/`false`/`null` and
+ * finite numbers convert. Anything else stays a string, so an id like
+ * `0123` isn't silently mangled into 123.
+ */
+function coerce(value: string): string | number | boolean | null {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (value === "null") return null;
+  if (value !== "" && /^-?\d+(\.\d+)?$/.test(value)) {
+    const n = Number(value);
+    // Reject anything that wouldn't round-trip (leading zeros, overflow).
+    if (Number.isFinite(n) && String(n) === value) return n;
+  }
+  return value;
+}
+
+/** Parse a full `FindQuery` off a request URL. */
+export function parseFindQuery(
+  url: URL,
+  defaults: { limit?: number } = {},
+): FindQuery {
+  const p = url.searchParams;
+  const limitRaw = p.get("limit") ?? p.get("pageSize");
+  const pageRaw = p.get("page");
+
+  return {
+    fields: parseFields(p.get("fields")),
+    filters: parseFilters(p),
+    sort: parseSort(p.get("sort")),
+    populate: parsePopulate(p.get("populate")),
+    locale: p.get("locale") ?? undefined,
+    limit: limitRaw ? Number(limitRaw) || defaults.limit : defaults.limit,
+    page: pageRaw ? Number(pageRaw) || 1 : 1,
+  };
+}

--- a/src/lib/server/content/query/registry.ts
+++ b/src/lib/server/content/query/registry.ts
@@ -1,0 +1,251 @@
+/**
+ * Query-layer collection registry — Phase 1 (#68).
+ *
+ * Describes the CURRENT hand-written schema to the generic query
+ * engine, so `find()`/`populate` work over today's tables with **no
+ * migration and no data movement**. This is deliberately a code-level
+ * registry, not a DB-stored one: Phase 1's whole premise is "generic
+ * query layer over the existing schema."
+ *
+ * When Phase 2's DB-stored collection registry lands, it produces the
+ * same `CollectionDef` shape at runtime and the engine below is reused
+ * unchanged. That is the point of splitting the phases — the query
+ * engine never learns whether its collections came from code or rows.
+ *
+ * ## What a relation is here
+ *
+ * Three kinds, matching what the current schema actually uses:
+ *
+ * - `manyToOne`  — an FK column on this table (articles.category_id)
+ * - `manyToMany` — a join table (article_tags)
+ * - `localizations` — the repo's base-row + sibling-`_localizations`
+ *   convention. Modelled as a relation rather than special-cased so
+ *   `populate` and `fields` treat it uniformly.
+ *
+ * Every one resolves by **batched `inArray` over collected parent
+ * ids**, never per row. See engine.ts.
+ */
+import * as schema from "../schema";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+
+/** How a relation is physically stored in the current schema. */
+export type RelationDef =
+  | {
+      kind: "manyToOne";
+      /** Column on THIS table holding the target id. */
+      localKey: string;
+      /** Collection apiId being pointed at. */
+      target: string;
+      /** Column on the target table the localKey matches (default "id"). */
+      targetKey?: string;
+    }
+  | {
+      kind: "manyToMany";
+      /** Join table, e.g. article_tags. */
+      through: SQLiteTable;
+      /** Join-table column pointing back at this collection. */
+      throughLocalKey: string;
+      /** Join-table column pointing at the target collection. */
+      throughTargetKey: string;
+      target: string;
+    }
+  | {
+      kind: "localizations";
+      /** The sibling `_localizations` table. */
+      table: SQLiteTable;
+      /** Column on that table pointing back at the base row. */
+      foreignKey: string;
+      /**
+       * Columns that carry translated text. Everything else on the
+       * localization row (id, the FK, locale) is structural.
+       */
+      fields: readonly string[];
+    };
+
+export interface CollectionDef {
+  /** Stable public name used in API params: `?populate=category`. */
+  apiId: string;
+  table: SQLiteTable;
+  /** Primary key column name. Every current table uses "id". */
+  primaryKey: string;
+  /**
+   * Columns safe to expose through the public API. Anything absent is
+   * unreachable via `fields` or a populate leaf — an allowlist, so a
+   * column added later is private until someone opts it in.
+   */
+  selectable: readonly string[];
+  /** Columns permitted in `filters` / `sort`. Subset of selectable. */
+  filterable: readonly string[];
+  relations: Record<string, RelationDef>;
+}
+
+/**
+ * The registry itself. Only content collections are listed — users,
+ * sessions, accounts, api_keys and the rest of the auth/ops tables are
+ * intentionally absent so no populate path can ever reach them.
+ */
+export const COLLECTIONS: Record<string, CollectionDef> = {
+  articles: {
+    apiId: "articles",
+    table: schema.articles,
+    primaryKey: "id",
+    selectable: [
+      "id",
+      "slug",
+      "coverMediaId",
+      "categoryId",
+      "authorId",
+      "status",
+      "publishedAt",
+      "commentsMode",
+      "createdAt",
+      "updatedAt",
+    ],
+    filterable: [
+      "id",
+      "slug",
+      "categoryId",
+      "authorId",
+      "status",
+      "publishedAt",
+      "createdAt",
+      "updatedAt",
+    ],
+    relations: {
+      category: {
+        kind: "manyToOne",
+        localKey: "categoryId",
+        target: "categories",
+      },
+      coverMedia: {
+        kind: "manyToOne",
+        localKey: "coverMediaId",
+        target: "media",
+      },
+      tags: {
+        kind: "manyToMany",
+        through: schema.articleTags,
+        throughLocalKey: "articleId",
+        throughTargetKey: "tagId",
+        target: "tags",
+      },
+      localizations: {
+        kind: "localizations",
+        table: schema.articleLocalizations,
+        foreignKey: "articleId",
+        fields: ["title", "excerpt", "body", "seoTitle", "seoDescription"],
+      },
+    },
+  },
+
+  categories: {
+    apiId: "categories",
+    table: schema.categories,
+    primaryKey: "id",
+    selectable: ["id", "slug", "createdAt"],
+    filterable: ["id", "slug", "createdAt"],
+    relations: {
+      localizations: {
+        kind: "localizations",
+        table: schema.categoryLocalizations,
+        foreignKey: "categoryId",
+        fields: ["name", "description"],
+      },
+    },
+  },
+
+  tags: {
+    apiId: "tags",
+    table: schema.tags,
+    primaryKey: "id",
+    selectable: ["id", "slug", "createdAt"],
+    filterable: ["id", "slug", "createdAt"],
+    relations: {
+      localizations: {
+        kind: "localizations",
+        table: schema.tagLocalizations,
+        foreignKey: "tagId",
+        fields: ["name"],
+      },
+    },
+  },
+
+  pages: {
+    apiId: "pages",
+    table: schema.pages,
+    primaryKey: "id",
+    selectable: [
+      "id",
+      "slug",
+      "parentId",
+      "template",
+      "status",
+      "publishedAt",
+      "createdAt",
+      "updatedAt",
+    ],
+    filterable: [
+      "id",
+      "slug",
+      "parentId",
+      "template",
+      "status",
+      "publishedAt",
+      "createdAt",
+      "updatedAt",
+    ],
+    relations: {
+      // Self-referential. `pages.parent_id` is plain text with no
+      // .references() in the current schema (#68 §1.1 flags this) —
+      // populate still resolves it, it just isn't FK-enforced at the
+      // DB level.
+      parent: {
+        kind: "manyToOne",
+        localKey: "parentId",
+        target: "pages",
+      },
+      localizations: {
+        kind: "localizations",
+        table: schema.pageLocalizations,
+        foreignKey: "pageId",
+        fields: ["title", "body", "seoTitle", "seoDescription"],
+      },
+    },
+  },
+
+  media: {
+    apiId: "media",
+    table: schema.media,
+    primaryKey: "id",
+    // No `localizations` relation: media alt text is a plain column in
+    // the current schema, not a sibling table.
+    // NOTE: the column is `altText`, not `alt` — `r2Key` and
+    // `uploadedBy` are deliberately excluded. r2Key is an internal
+    // storage path (media is served through /api/media/[id]) and
+    // uploadedBy is a user id that public consumers have no business
+    // seeing.
+    selectable: [
+      "id",
+      "filename",
+      "mimeType",
+      "size",
+      "width",
+      "height",
+      "altText",
+      "folderId",
+      "createdAt",
+    ],
+    filterable: ["id", "filename", "mimeType", "folderId", "createdAt"],
+    relations: {},
+  },
+};
+
+export function getCollection(apiId: string): CollectionDef | null {
+  return Object.prototype.hasOwnProperty.call(COLLECTIONS, apiId)
+    ? COLLECTIONS[apiId]
+    : null;
+}
+
+export function listCollectionIds(): string[] {
+  return Object.keys(COLLECTIONS);
+}

--- a/src/lib/server/content/query/types.ts
+++ b/src/lib/server/content/query/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Generic query contract — Phase 1 (#68 §D).
+ *
+ * One primitive, `find(collection, query)`, replacing the need for a
+ * new pair of provider methods per entity. The 85-method
+ * `ContentProvider` stays exactly as it is; this is additive, and the
+ * existing methods keep working untouched.
+ *
+ * Params are deliberately Strapi-shaped (`populate` / `fields` /
+ * `filters` / `sort` / pagination) because that is the vocabulary
+ * every headless-CMS consumer already knows, and #68 §D calls for
+ * Strapi-compatible query params on the public API.
+ */
+
+/** Operators supported in `filters`. Deliberately small. */
+export type FilterOperator =
+  | "$eq"
+  | "$ne"
+  | "$lt"
+  | "$lte"
+  | "$gt"
+  | "$gte"
+  | "$in"
+  | "$notIn"
+  | "$contains"
+  | "$null"
+  | "$notNull";
+
+export type FilterValue = string | number | boolean | null;
+
+/**
+ * `{ status: { $eq: "published" }, publishedAt: { $lte: "2026-01-01" } }`
+ *
+ * Conditions across different fields AND together. A bare value is
+ * sugar for `$eq`.
+ */
+export type Filters = Record<
+  string,
+  FilterValue | Partial<Record<FilterOperator, FilterValue | FilterValue[]>>
+>;
+
+/**
+ * Nested populate spec.
+ *
+ * `true` populates the relation with its default field set.
+ * An object narrows it and/or recurses:
+ *   { category: true, tags: { fields: ["slug"] } }
+ */
+export type PopulateSpec = boolean | PopulateNode;
+
+export interface PopulateNode {
+  /** Scalar allowlist for the populated rows. */
+  fields?: string[];
+  /** Recurse into the target collection's own relations. */
+  populate?: Record<string, PopulateSpec>;
+  /**
+   * For `localizations` relations: restrict to one locale. Ignored by
+   * other relation kinds.
+   */
+  locale?: string;
+}
+
+export interface FindQuery {
+  /** Scalar allowlist on the root rows. Omit for all selectable. */
+  fields?: string[];
+  filters?: Filters;
+  /** `"publishedAt"` asc, `"-publishedAt"` desc. Multiple allowed. */
+  sort?: string | string[];
+  page?: number;
+  /** Rows per page. Clamped to MAX_LIMIT. */
+  limit?: number;
+  populate?: Record<string, PopulateSpec>;
+  /**
+   * Restricts every `localizations` relation in the tree, unless a
+   * node overrides it. Validated against the runtime supported-locale
+   * list, not a compile-time enum (#68 §E).
+   */
+  locale?: string;
+  /**
+   * Scheduled-publishing guard: hide rows whose `publishedAt` is in the
+   * future. A null `publishedAt` passes (treated as "publish
+   * immediately when status is published"), matching
+   * `listArticles({onlyPublished})`.
+   *
+   * This is a flag rather than a filter because it needs
+   * `publishedAt IS NULL OR publishedAt <= now` — a disjunction the
+   * AND-only `filters` grammar can't express. Public endpoints must
+   * set it; without it, an embargoed post is readable early.
+   */
+  onlyPublished?: boolean;
+}
+
+/** A returned row: scalars, plus whatever populate attached. */
+export type EntryRow = Record<string, unknown>;
+
+export interface FindResult {
+  data: EntryRow[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    pageCount: number;
+    /** Queries actually issued. Surfaced so N+1 regressions are visible. */
+    queryCount?: number;
+  };
+}
+
+/**
+ * Depth cap. #68 §D calls for 2–3; Contentful caps include at 10 and
+ * Hygraph uses a complexity budget. 3 is enough for
+ * `brand → productLines → variants` while bounding fan-out.
+ */
+export const MAX_POPULATE_DEPTH = 3;
+
+/** Page-size ceiling, matching the existing public API's cap. */
+export const MAX_LIMIT = 100;
+
+export const DEFAULT_LIMIT = 20;
+
+/** Raised for malformed queries — mapped to HTTP 400 by callers. */
+export class QueryError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "UNKNOWN_COLLECTION"
+      | "UNKNOWN_FIELD"
+      | "UNKNOWN_RELATION"
+      | "UNKNOWN_OPERATOR"
+      | "DEPTH_EXCEEDED"
+      | "INVALID_LOCALE"
+      | "INVALID_SORT",
+  ) {
+    super(message);
+    this.name = "QueryError";
+  }
+}

--- a/src/lib/server/media/index.ts
+++ b/src/lib/server/media/index.ts
@@ -17,6 +17,14 @@ export class R2MediaService implements MediaService {
     d1: D1Database,
     private bucket: R2Bucket,
     private publicBaseUrl: string, // e.g. https://cdn.example.com or /api/media
+    /**
+     * Called after any write that changes a media row. Media is a
+     * populate target (`articles.coverMedia`), so cached article
+     * payloads embed its filename and alt text — without this,
+     * replacing an image or fixing alt text would not reach an
+     * already-warm cache entry until its TTL expired.
+     */
+    private onMediaChanged?: () => void,
   ) {
     this.db = drizzle(d1, { schema });
   }
@@ -70,6 +78,7 @@ export class R2MediaService implements MediaService {
       uploadedBy: input.uploadedBy ?? null,
     });
 
+    this.onMediaChanged?.();
     return (await this.get(id))!;
   }
 
@@ -82,6 +91,7 @@ export class R2MediaService implements MediaService {
 
     // Delete from D1
     await this.db.delete(schema.media).where(eq(schema.media.id, id));
+    this.onMediaChanged?.();
   }
 
   async move(id: string, folderId: string | null): Promise<MediaRecord> {
@@ -89,6 +99,7 @@ export class R2MediaService implements MediaService {
       .update(schema.media)
       .set({ folderId })
       .where(eq(schema.media.id, id));
+    this.onMediaChanged?.();
     return (await this.get(id))!;
   }
 
@@ -157,6 +168,9 @@ export class R2MediaService implements MediaService {
     await this.db
       .delete(schema.mediaFolders)
       .where(eq(schema.mediaFolders.id, id));
+    // Detaching the folder rewrote media rows, so cached payloads that
+    // embedded them are stale.
+    this.onMediaChanged?.();
   }
 
   private toRecord(row: typeof schema.media.$inferSelect): MediaRecord {

--- a/src/routes/api/public/content/[collection]/+server.ts
+++ b/src/routes/api/public/content/[collection]/+server.ts
@@ -1,0 +1,133 @@
+/**
+ * GET /api/public/content/[collection] — generic relational read.
+ *
+ * The Phase 1 (#68) answer to "the API returns bare FK ids." One
+ * request returns a fully-populated nested graph:
+ *
+ *   /api/public/content/articles
+ *     ?populate=category,tags,localizations
+ *     &filters[status][$eq]=published
+ *     &sort=-publishedAt
+ *     &locale=th
+ *     &limit=20
+ *
+ * Params are Strapi-shaped (see query/params.ts). Auth reuses the
+ * existing bearer-token + scope machinery — this endpoint requires the
+ * same `<collection>:read` scope the per-entity endpoints do, so it
+ * grants nothing a key couldn't already reach.
+ *
+ * The existing `/api/public/articles` etc. are untouched and still
+ * work; this is additive.
+ */
+import { json } from "@sveltejs/kit";
+import { authenticate, hasScope } from "$lib/server/api-auth";
+import {
+  createQueryEngine,
+  getCollection,
+  parseFindQuery,
+  QueryError,
+} from "$lib/server/content/query";
+import type { ApiKeyScope } from "$lib/server/content/types";
+import type { RequestHandler } from "./$types";
+
+/**
+ * Collections reachable through this endpoint, each mapped to the
+ * scope that unlocks it. Written as an explicit record rather than
+ * templating `${collection}:read` so the scope strings stay typed —
+ * a new collection can't silently become reachable without someone
+ * adding a scope for it.
+ *
+ * The query registry also describes `media`, which is deliberately
+ * absent here: media is served through its own route with its own
+ * access rules. It stays reachable as a *populate target*, which only
+ * ever exposes the columns in its `selectable` allowlist.
+ */
+const PUBLIC_ROOTS: Record<string, ApiKeyScope> = {
+  articles: "articles:read",
+  categories: "categories:read",
+  tags: "tags:read",
+  pages: "pages:read",
+};
+
+export const GET: RequestHandler = async ({
+  params,
+  url,
+  request,
+  locals,
+  platform,
+}) => {
+  const env = platform?.env;
+  if (!env) {
+    return json({ error: "Platform not ready" }, { status: 503 });
+  }
+
+  const collection = params.collection;
+  const scope = Object.prototype.hasOwnProperty.call(PUBLIC_ROOTS, collection)
+    ? PUBLIC_ROOTS[collection]
+    : undefined;
+  if (!scope || !getCollection(collection)) {
+    return json(
+      { error: `Unknown collection "${collection}"` },
+      { status: 404 },
+    );
+  }
+
+  const auth = await authenticate(request, locals.content);
+  if (!auth.ok || !auth.key) {
+    return json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth.key, scope)) {
+    return json({ error: `Forbidden — ${scope} scope required` }, { status: 403 });
+  }
+
+  let query;
+  try {
+    query = parseFindQuery(url);
+  } catch (err) {
+    if (err instanceof QueryError) {
+      return json({ error: err.message, code: err.code }, { status: 400 });
+    }
+    throw err;
+  }
+
+  // Public reads are published-only. Applied AFTER parsing so a caller
+  // cannot widen it via their own `filters[status]` — this overwrites
+  // whatever they sent.
+  //
+  // `status` alone is NOT sufficient: scheduled publishing sets
+  // status='published' with a future publishedAt, and the row must stay
+  // hidden until that moment. Every other public read path applies this
+  // same guard (d1.ts listArticles' `onlyPublished`, searchArticles);
+  // omitting it here would make this endpoint the one way to read an
+  // embargoed post early.
+  //
+  // A null publishedAt means "publish immediately when status flips",
+  // matching listArticles' behaviour, so it passes the guard. That
+  // `publishedAt IS NULL OR publishedAt <= now` disjunction can't be
+  // expressed in the AND-only filter grammar, so it rides as a separate
+  // `onlyPublished` flag the engine applies itself.
+  const filters = { ...(query.filters ?? {}) };
+  const schedulable = collection === "articles" || collection === "pages";
+  if (schedulable) {
+    filters.status = { $eq: "published" };
+  }
+
+  const engine = createQueryEngine(env);
+  try {
+    // Cacheable: published-only, no per-user variation.
+    const result = await engine.findCached(collection, {
+      ...query,
+      filters,
+      onlyPublished: schedulable,
+    });
+    return json(
+      { data: result.data, meta: result.meta },
+      { headers: { "cache-control": "public, max-age=60" } },
+    );
+  } catch (err) {
+    if (err instanceof QueryError) {
+      return json({ error: err.message, code: err.code }, { status: 400 });
+    }
+    throw err;
+  }
+};

--- a/src/routes/api/public/content/[collection]/+server.ts
+++ b/src/routes/api/public/content/[collection]/+server.ts
@@ -77,7 +77,10 @@ export const GET: RequestHandler = async ({
     return json({ error: "Unauthorized" }, { status: 401 });
   }
   if (!hasScope(auth.key, scope)) {
-    return json({ error: `Forbidden — ${scope} scope required` }, { status: 403 });
+    return json(
+      { error: `Forbidden — ${scope} scope required` },
+      { status: 403 },
+    );
   }
 
   let query;


### PR DESCRIPTION
Phase 1 of #68 — a generic query primitive over the **current** schema. No migration, no data movement, and every existing `ContentProvider` method keeps working untouched.

## What lands

`find(collection, query)` / `findOne` with `populate` / `fields` / `filters` / `sort` / pagination, exposed at `GET /api/public/content/[collection]`:

```
/api/public/content/articles
  ?populate=category,tags,localizations
  &filters[status][$eq]=published
  &sort=-publishedAt&locale=th&limit=20
```

Params are Strapi-shaped because that's the vocabulary headless consumers already speak, and #68 §D asks for it.

**Populate resolves breadth-first with batched `inArray` loads** — one query per relation per *level*, never per row. 20 articles with `populate=category,tags` is 4 queries, and stays 4 at 100 articles.

A code-level registry describes today's tables to the engine. When Phase 2's registry lands it emits the same `CollectionDef` shape and this engine is reused unchanged — the engine never learns whether its collections came from code or from rows.

## The N+1 fix (the concrete payoff)

`listArticles` called `hydrateArticle` per row, each firing 2 queries — a 20-item list was **1 + 40 queries** (#68 §1.4). Now **2, flat**.

`listCategories` / `listTags` were worse: **1 + N over every row in the table**, on every blog page render. Both now 2.

Done in the provider rather than routed through the engine, so every existing caller benefits without changing a line.

## KV cache

`CONTENT_CACHE` has been bound since v1.0 but only health-probed (#68 §1.6). Assembled payloads are now cached, keyed by a **per-collection generation counter** — one write invalidates every payload that read that collection, with no key enumeration (which KV doesn't do cheaply). Invalidation lives in the provider: the one chokepoint every write already passes through, so a future write path can't forget it.

Only published-only reads are cacheable. Admin/preview bypasses it — a cache that can serve a draft publicly is a correctness bug, not a performance win.

## Bug hunt — 4 defects found and fixed before commit

1. **Scheduled posts leaked publicly.** The endpoint filtered `status` but not `publishedAt`, so an embargoed post dated next week was readable *today*. Every other public read path applies this guard; this endpoint would have been the one way around it. The fix needs `publishedAt IS NULL OR publishedAt <= now` — a disjunction the AND-only filter grammar can't express — so it rides as an `onlyPublished` flag the engine applies itself, ahead of user filters and not overridable from the URL.
2. **D1's 100-bound-parameter ceiling.** Batching is what *introduces* this — the per-row versions bound exactly one id and could never hit it. All batched loads now chunk. `listCategories`/`listTags` were the sharp edge: they bind every row in the table, so the public site would have begun 500ing at ~100 tags.
3. **Media writes never invalidated.** `media` is a populate target (`articles.coverMedia`), so replacing an image or correcting alt text wouldn't reach a warm cache entry for its full TTL.
4. **Invalidation could be cancelled.** Workers may tear the isolate down once the response returns, so a write could return 200 while its KV invalidation never landed — pinning stale content. Now handed to `waitUntil`.

Also: the media registry entry named a column `alt`; the schema column is `altText`. `r2Key` and `uploadedBy` are deliberately not `selectable`.

## Security posture

Populate cannot reach `users` / `sessions` / `api_keys` — they aren't in the registry, and `articles.authorId` is selectable but has no relation entry, so it returns a bare id and can't be traversed. Field names go through `selectable` / `filterable` allowlists then `getTableColumns`, so only real drizzle `Column` objects reach the operators; values are always bound parameters. `hasOwnProperty` guards reject `?populate=__proto__`. LIKE wildcards in `$contains` are escaped.

## Known limits (deliberately not fixed here)

- The **tag-filter and search paths** in `listArticles` bind one parameter per matched id. Pre-existing, and a `WHERE` condition rather than a load, so chunking doesn't apply — it needs a real SQL subquery or join. Marked in place rather than half-fixed.
- Cache generation bumps are read-modify-write with **no CAS**. Benign: concurrent bumps still move the counter off the pre-write value.
- `pages.parent` is self-referential and `parentId` has no `.references()` in the current schema, so a data cycle produces duplicated nesting up to the depth cap. Bounded, not a hang.

## Verification

`pnpm check` clean apart from the 3 pre-existing paraglide errors; `pnpm build` passes.

## Note on #68

The 2026-07-28 verdict on #68 was re-researched before this work — see [the correction comment](https://github.com/codustry/khaopad/issues/68#issuecomment-5120307316). **Phase 1 is unaffected either way**: the research found that Payload excludes `hasMany` relations from its SQL join tree and populates them with follow-up queries, so batched populate is the required approach on a relational store regardless of how schema is defined. Phases 2–4 are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
