### PR TITLE
feat(v3.6-phase2): collection registry — user-definable content types

### DIFF
--- a/drizzle/0020_collection_registry.sql
+++ b/drizzle/0020_collection_registry.sql
@@ -1,0 +1,145 @@
+-- Phase 2 of #68 — collection registry: user-definable content types.
+--
+-- These are ENGINE tables and ship as an ordinary migration. What they
+-- make dynamic is *user* collections: adding a content type after this
+-- lands is an INSERT into `collections` + `collection_fields`, with no
+-- migration and no deploy.
+--
+-- Storage shape: one row per entry with its non-localized scalars in a
+-- single `data_json` document, per-locale scalars in
+-- `entry_localizations.data_json`, and ALL relations (1:1 / 1:n / n:m,
+-- ordered) in the single `entry_relations` table.
+--
+-- Note `locale` is plain TEXT, deliberately not a CHECK-constrained
+-- enum: the existing content tables bake ("th","en") into ~8 schemas so
+-- adding a locale means a migration everywhere. Here it is validated
+-- against the runtime supported-locale list instead.
+
+CREATE TABLE `collections` (
+  `id` text PRIMARY KEY NOT NULL,
+  `api_id` text NOT NULL,
+  `kind` text DEFAULT 'collection' NOT NULL,
+  `labels_json` text,
+  `draft_publish` integer DEFAULT true NOT NULL,
+  `localized` integer DEFAULT true NOT NULL,
+  `system` integer DEFAULT false NOT NULL,
+  `description` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `collections_api_id_unique` ON `collections` (`api_id`);--> statement-breakpoint
+CREATE INDEX `collections_kind_idx` ON `collections` (`kind`);--> statement-breakpoint
+
+CREATE TABLE `collection_fields` (
+  `id` text PRIMARY KEY NOT NULL,
+  `collection_id` text NOT NULL,
+  `api_id` text NOT NULL,
+  `type` text NOT NULL,
+  `labels_json` text,
+  `required` integer DEFAULT false NOT NULL,
+  `localized` integer DEFAULT false NOT NULL,
+  `unique` integer DEFAULT false NOT NULL,
+  `promoted` integer DEFAULT false NOT NULL,
+  `config_json` text,
+  `position` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `collections`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- Two fields writing the same document key would silently overwrite.
+CREATE UNIQUE INDEX `collection_fields_collection_api_idx` ON `collection_fields` (`collection_id`,`api_id`);--> statement-breakpoint
+CREATE INDEX `collection_fields_position_idx` ON `collection_fields` (`collection_id`,`position`);--> statement-breakpoint
+
+CREATE TABLE `entries` (
+  `id` text PRIMARY KEY NOT NULL,
+  `collection_id` text NOT NULL,
+  `slug` text,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `published_at` text,
+  `data_json` text DEFAULT '{}' NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `collections`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- Slug uniqueness is scoped to the collection: two types may both
+-- legitimately have an "about" entry.
+CREATE UNIQUE INDEX `entries_collection_slug_idx` ON `entries` (`collection_id`,`slug`);--> statement-breakpoint
+CREATE INDEX `entries_collection_status_idx` ON `entries` (`collection_id`,`status`,`updated_at`);--> statement-breakpoint
+CREATE INDEX `entries_published_idx` ON `entries` (`collection_id`,`published_at`);--> statement-breakpoint
+
+CREATE TABLE `entry_localizations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `entry_id` text NOT NULL,
+  `locale` text NOT NULL,
+  `data_json` text DEFAULT '{}' NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `entry_localizations_entry_locale_idx` ON `entry_localizations` (`entry_id`,`locale`);--> statement-breakpoint
+
+-- ONE join table for every entry→entry relation. `position` gives
+-- ordered relations, which the existing `article_tags` cannot express —
+-- a catalog needs it, and for a dynamic zone the order of nested
+-- component entries IS the page layout.
+CREATE TABLE `entry_relations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `entry_id` text NOT NULL,
+  `field_api_id` text NOT NULL,
+  `target_entry_id` text NOT NULL,
+  `position` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`target_entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- Forward: "this entry's `variants`, in order" — issued on every read.
+CREATE INDEX `entry_relations_forward_idx` ON `entry_relations` (`entry_id`,`field_api_id`,`position`);--> statement-breakpoint
+-- Reverse: "what points at this entry?" — reverse/join fields, and
+-- cache invalidation when a target is edited.
+CREATE INDEX `entry_relations_reverse_idx` ON `entry_relations` (`target_entry_id`,`field_api_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `entry_relations_unique_edge_idx` ON `entry_relations` (`entry_id`,`field_api_id`,`target_entry_id`);--> statement-breakpoint
+
+-- Sparse inverted index over filterable, non-promoted field values.
+--
+-- This is what makes the design NOT wp_postmeta: rows exist only for
+-- fields explicitly marked filterable, and reading an entry never
+-- touches this table — `entries.data_json` is the source of truth. It's
+-- a lookup structure, not the storage.
+--
+-- Values are split by type because SQLite would otherwise compare
+-- "9" > "100" as text, the exact failure that makes an untyped
+-- `meta_value` column useless for faceting.
+CREATE TABLE `entry_field_index` (
+  `entry_id` text NOT NULL,
+  `field_api_id` text NOT NULL,
+  `locale` text,
+  `value_text` text,
+  `value_number` integer,
+  `value_bool` integer,
+  PRIMARY KEY (`entry_id`, `field_api_id`, `locale`),
+  FOREIGN KEY (`entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `entry_field_index_text_idx` ON `entry_field_index` (`field_api_id`,`value_text`);--> statement-breakpoint
+CREATE INDEX `entry_field_index_number_idx` ON `entry_field_index` (`field_api_id`,`value_number`);--> statement-breakpoint
+
+-- Generalizes `article_versions` (#68 §F) to every content type.
+-- Snapshots document + localizations + relation edges so a restore is
+-- exact rather than best-effort.
+CREATE TABLE `entry_versions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `entry_id` text NOT NULL,
+  `snapshot_json` text NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `entry_versions_entry_idx` ON `entry_versions` (`entry_id`,`created_at`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1785340500000,
       "tag": "0019_plugin_shop_recovery_email",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1785426900000,
+      "tag": "0020_collection_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "db:seed": "tsx scripts/seed.ts",
     "setup": "tsx scripts/setup.ts",
     "wrangler:dev": "wrangler dev",
-    "deploy": "pnpm build && wrangler deploy"
+    "deploy": "pnpm build && wrangler deploy",
+    "db:seed:registry": "tsx scripts/seed-registry-demo.ts"
   },
   "dependencies": {
     "@inlang/paraglide-js": "^2.0.0",

--- a/scripts/fixtures/registry-demo.json
+++ b/scripts/fixtures/registry-demo.json
@@ -1,0 +1,180 @@
+{
+  "_readme": [
+    "Demo fixture for the Phase 2 collection registry (#68).",
+    "",
+    "A three-level relational catalog (brand -> productLine -> variant)",
+    "plus an ordered component (a spec row), in EN and TH. Nothing here is",
+    "engine knowledge: these are ordinary USER collections, defined by",
+    "inserting registry rows. Swap this file for a Strapi export or a CSV",
+    "reader and the same importer loads it.",
+    "",
+    "Shape:",
+    "  collections[].fields[]  -> collection_fields rows",
+    "  entries[].key           -> local handle used to wire relations",
+    "  entries[].data          -> non-localized values (entries.data_json)",
+    "  entries[].localizations -> per-locale values (entry_localizations)",
+    "  entries[].relations     -> ordered edges (entry_relations)",
+    "",
+    "`promoted: true` asks for a VIRTUAL generated column + index, making",
+    "the field efficiently filterable/sortable. It spends part of D1's",
+    "100-column-per-table budget, so it is opt-in per field."
+  ],
+
+  "collections": [
+    {
+      "apiId": "brand",
+      "kind": "collection",
+      "localized": true,
+      "fields": [
+        {
+          "apiId": "name",
+          "type": "text",
+          "required": true,
+          "localized": true
+        },
+        { "apiId": "code", "type": "text", "unique": true, "promoted": true },
+        { "apiId": "country", "type": "text" },
+        { "apiId": "summary", "type": "richtext", "localized": true }
+      ]
+    },
+    {
+      "apiId": "product_line",
+      "kind": "collection",
+      "localized": true,
+      "fields": [
+        {
+          "apiId": "name",
+          "type": "text",
+          "required": true,
+          "localized": true
+        },
+        { "apiId": "excerpt", "type": "text", "localized": true },
+        { "apiId": "featured", "type": "boolean", "promoted": true },
+        {
+          "apiId": "brand",
+          "type": "relation",
+          "config": { "target": "brand", "cardinality": "one" }
+        },
+        {
+          "apiId": "variants",
+          "type": "relation",
+          "config": { "target": "variant", "cardinality": "many" }
+        }
+      ]
+    },
+    {
+      "apiId": "variant",
+      "kind": "collection",
+      "localized": true,
+      "fields": [
+        {
+          "apiId": "name",
+          "type": "text",
+          "required": true,
+          "localized": true
+        },
+        { "apiId": "sku", "type": "text", "unique": true, "promoted": true },
+        { "apiId": "weight_kg", "type": "number", "promoted": true },
+        {
+          "apiId": "specs",
+          "type": "component",
+          "config": { "allowed": ["spec_row"], "cardinality": "many" }
+        }
+      ]
+    },
+    {
+      "apiId": "spec_row",
+      "kind": "component",
+      "localized": true,
+      "fields": [
+        {
+          "apiId": "label",
+          "type": "text",
+          "required": true,
+          "localized": true
+        },
+        { "apiId": "value", "type": "text", "required": true },
+        { "apiId": "unit", "type": "text" }
+      ]
+    }
+  ],
+
+  "entries": [
+    {
+      "key": "brand_northwind",
+      "collection": "brand",
+      "slug": "northwind",
+      "data": { "code": "NW", "country": "TH" },
+      "localizations": {
+        "en": { "name": "Northwind", "summary": "A demo brand." },
+        "th": { "name": "นอร์ทวินด์", "summary": "แบรนด์ตัวอย่าง" }
+      }
+    },
+
+    {
+      "key": "line_alpha",
+      "collection": "product_line",
+      "slug": "alpha-series",
+      "data": { "featured": true },
+      "localizations": {
+        "en": { "name": "Alpha Series", "excerpt": "Entry-level range." },
+        "th": { "name": "ซีรีส์อัลฟา", "excerpt": "รุ่นเริ่มต้น" }
+      },
+      "relations": {
+        "brand": ["brand_northwind"],
+        "variants": ["variant_a100", "variant_a200"]
+      }
+    },
+
+    {
+      "key": "variant_a100",
+      "collection": "variant",
+      "slug": "a100",
+      "data": { "sku": "NW-A100", "weight_kg": 12.5 },
+      "localizations": {
+        "en": { "name": "A100" },
+        "th": { "name": "เอ100" }
+      },
+      "relations": { "specs": ["spec_a100_flow", "spec_a100_power"] }
+    },
+    {
+      "key": "variant_a200",
+      "collection": "variant",
+      "slug": "a200",
+      "data": { "sku": "NW-A200", "weight_kg": 18.0 },
+      "localizations": {
+        "en": { "name": "A200" },
+        "th": { "name": "เอ200" }
+      },
+      "relations": { "specs": ["spec_a200_flow"] }
+    },
+
+    {
+      "key": "spec_a100_flow",
+      "collection": "spec_row",
+      "data": { "value": "63", "unit": "m3/h" },
+      "localizations": {
+        "en": { "label": "Flow rate" },
+        "th": { "label": "อัตราการไหล" }
+      }
+    },
+    {
+      "key": "spec_a100_power",
+      "collection": "spec_row",
+      "data": { "value": "1.5", "unit": "kW" },
+      "localizations": {
+        "en": { "label": "Motor power" },
+        "th": { "label": "กำลังมอเตอร์" }
+      }
+    },
+    {
+      "key": "spec_a200_flow",
+      "collection": "spec_row",
+      "data": { "value": "100", "unit": "m3/h" },
+      "localizations": {
+        "en": { "label": "Flow rate" },
+        "th": { "label": "อัตราการไหล" }
+      }
+    }
+  ]
+}

--- a/scripts/seed-registry-demo.ts
+++ b/scripts/seed-registry-demo.ts
@@ -1,0 +1,262 @@
+/**
+ * Registry demo seed — Phase 2 proof, and the source-agnostic import
+ * path (#68 / task "portability requirement").
+ *
+ * Loads a small relational catalog **from an external JSON file** into
+ * the collection registry, using only the public `RegistryService` API.
+ * That is the point: the importer is a thin, swappable script, not part
+ * of the engine. A Strapi export, a CSV, or another CMS's dump can be
+ * scripted the same way — write a different reader, call the same
+ * methods.
+ *
+ * There is nothing client-specific in the engine. `brand`, `productLine`
+ * and `variant` below are just example USER collections defined through
+ * the registry, exactly as any other site would define its own.
+ *
+ * Usage:
+ *   pnpm tsx scripts/seed-registry-demo.ts                 # local D1
+ *   pnpm tsx scripts/seed-registry-demo.ts --remote
+ *   pnpm tsx scripts/seed-registry-demo.ts --file ./my.json
+ *
+ * The JSON shape is documented in `fixtures/registry-demo.json`.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface FixtureField {
+  apiId: string;
+  type: string;
+  required?: boolean;
+  localized?: boolean;
+  unique?: boolean;
+  promoted?: boolean;
+  config?: unknown;
+}
+
+interface FixtureCollection {
+  apiId: string;
+  kind?: "collection" | "single" | "component";
+  localized?: boolean;
+  fields: FixtureField[];
+}
+
+interface FixtureEntry {
+  /** Local key used to wire relations within the fixture. */
+  key: string;
+  collection: string;
+  slug?: string;
+  status?: "draft" | "published";
+  data?: Record<string, unknown>;
+  localizations?: Record<string, Record<string, unknown>>;
+  /** Values are fixture `key`s, resolved to real entry ids on insert. */
+  relations?: Record<string, string[]>;
+}
+
+interface Fixture {
+  collections: FixtureCollection[];
+  entries: FixtureEntry[];
+}
+
+const args = process.argv.slice(2);
+const remote = args.includes("--remote");
+const fileArg = args.indexOf("--file");
+const fixturePath = resolve(
+  fileArg >= 0 && args[fileArg + 1]
+    ? args[fileArg + 1]
+    : "scripts/fixtures/registry-demo.json",
+);
+const dbName = process.env.D1_DB_NAME ?? "khaopad-db";
+
+const fixture: Fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+/**
+ * Run SQL through wrangler.
+ *
+ * This script talks SQL rather than importing RegistryService because it
+ * runs in Node, outside the Worker — there is no D1 binding here. It
+ * mirrors what the service does; the HTTP admin API (Phase 4) is the
+ * path that uses the service directly.
+ *
+ * Uses execFileSync with an argument array, never a shell string, so
+ * fixture content cannot be interpreted as shell syntax.
+ */
+function exec(sql: string): void {
+  execFileSync(
+    "npx",
+    [
+      "wrangler",
+      "d1",
+      "execute",
+      dbName,
+      remote ? "--remote" : "--local",
+      "--command",
+      sql,
+    ],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+}
+
+/** SQLite string literal — doubles embedded single quotes. */
+function lit(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "1" : "0";
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/** Deterministic ids so re-running the seed is idempotent. */
+function idFor(kind: string, key: string): string {
+  return `seed_${kind}_${key}`.replace(/[^a-zA-Z0-9_]/g, "_").slice(0, 60);
+}
+
+const NOW = "2026-07-30T00:00:00.000Z";
+
+console.log(`Seeding registry demo from ${fixturePath} → ${dbName}`);
+
+// ── Collections + fields
+for (const collection of fixture.collections) {
+  const cid = idFor("col", collection.apiId);
+  exec(
+    `INSERT OR REPLACE INTO collections
+       (id, api_id, kind, labels_json, draft_publish, localized, system, description, created_by, created_at, updated_at)
+     VALUES (${lit(cid)}, ${lit(collection.apiId)}, ${lit(collection.kind ?? "collection")},
+             NULL, 1, ${collection.localized === false ? 0 : 1}, 0, NULL, NULL,
+             ${lit(NOW)}, ${lit(NOW)})`,
+  );
+
+  collection.fields.forEach((field, position) => {
+    const fid = idFor("fld", `${collection.apiId}_${field.apiId}`);
+    exec(
+      `INSERT OR REPLACE INTO collection_fields
+         (id, collection_id, api_id, type, labels_json, required, localized,
+          "unique", promoted, config_json, position, created_at, updated_at)
+       VALUES (${lit(fid)}, ${lit(cid)}, ${lit(field.apiId)}, ${lit(field.type)},
+               NULL, ${field.required ? 1 : 0}, ${field.localized ? 1 : 0},
+               ${field.unique ? 1 : 0}, ${field.promoted ? 1 : 0},
+               ${lit(JSON.stringify(field.config ?? {}))}, ${position},
+               ${lit(NOW)}, ${lit(NOW)})`,
+    );
+  });
+  console.log(
+    `  collection ${collection.apiId} (${collection.fields.length} fields)`,
+  );
+}
+
+// ── Entries. Two passes: rows first, then edges, so a relation can
+// point at an entry defined later in the fixture.
+const entryIds = new Map<string, string>();
+for (const entry of fixture.entries) {
+  entryIds.set(entry.key, idFor("ent", entry.key));
+}
+
+for (const entry of fixture.entries) {
+  const id = entryIds.get(entry.key)!;
+  const cid = idFor("col", entry.collection);
+  const status = entry.status ?? "published";
+  exec(
+    `INSERT OR REPLACE INTO entries
+       (id, collection_id, slug, status, published_at, data_json, created_by, created_at, updated_at)
+     VALUES (${lit(id)}, ${lit(cid)}, ${lit(entry.slug ?? null)}, ${lit(status)},
+             ${status === "published" ? lit(NOW) : "NULL"},
+             ${lit(JSON.stringify(entry.data ?? {}))}, NULL, ${lit(NOW)}, ${lit(NOW)})`,
+  );
+
+  for (const [locale, values] of Object.entries(entry.localizations ?? {})) {
+    exec(
+      `INSERT OR REPLACE INTO entry_localizations
+         (id, entry_id, locale, data_json, created_at, updated_at)
+       VALUES (${lit(`${id}_${locale}`)}, ${lit(id)}, ${lit(locale)},
+               ${lit(JSON.stringify(values))}, ${lit(NOW)}, ${lit(NOW)})`,
+    );
+  }
+}
+
+let edgeCount = 0;
+for (const entry of fixture.entries) {
+  const id = entryIds.get(entry.key)!;
+  for (const [fieldApiId, targetKeys] of Object.entries(
+    entry.relations ?? {},
+  )) {
+    targetKeys.forEach((targetKey, position) => {
+      const targetId = entryIds.get(targetKey);
+      if (!targetId) {
+        throw new Error(
+          `Entry "${entry.key}" relation "${fieldApiId}" references unknown key "${targetKey}"`,
+        );
+      }
+      exec(
+        `INSERT OR REPLACE INTO entry_relations
+           (id, entry_id, field_api_id, target_entry_id, position, created_at)
+         VALUES (${lit(`${id}_${fieldApiId}_${position}`)}, ${lit(id)},
+                 ${lit(fieldApiId)}, ${lit(targetId)}, ${position}, ${lit(NOW)})`,
+      );
+      edgeCount++;
+    });
+  }
+}
+
+// ── Promotions
+//
+// A `promoted` registry row on its own does nothing: the VIRTUAL
+// generated column and its index are real DDL. In the Worker that
+// happens through PromotionService; here we issue the equivalent SQL so
+// a seeded database is actually queryable on those fields rather than
+// merely claiming to be.
+//
+// Mirrors PromotionService.promote(): VIRTUAL (the only kind SQLite can
+// add to an existing table), and the index paired with collection_id so
+// it serves "filter within one collection".
+let promotedCount = 0;
+for (const collection of fixture.collections) {
+  for (const field of collection.fields) {
+    if (!field.promoted) continue;
+    if (field.localized) {
+      // Localized promotions live on entry_localizations; the demo has
+      // none, and silently promoting to the wrong table would be worse
+      // than skipping with a warning.
+      console.warn(
+        `  ! skipping promotion of localized ${collection.apiId}.${field.apiId} (not needed by this fixture)`,
+      );
+      continue;
+    }
+    // Must match PromotionService.promotedColumnName exactly, including
+    // the DOUBLE-underscore separator — a single one would be ambiguous
+    // between `a_b`+`c` and `a`+`b_c`. Both halves are validated with the
+    // same no-consecutive-underscore rule as assertValidApiId before any
+    // interpolation into DDL.
+    const safe = /^[a-z](?:_?[a-z0-9])*$/;
+    if (!safe.test(collection.apiId) || !safe.test(field.apiId)) {
+      throw new Error(
+        `Unsafe identifier for promotion: ${collection.apiId}.${field.apiId}`,
+      );
+    }
+    const column = `q_${collection.apiId}__${field.apiId}`;
+    const sqlType =
+      field.type === "number"
+        ? "REAL"
+        : field.type === "boolean"
+          ? "INTEGER"
+          : "TEXT";
+    try {
+      exec(
+        `ALTER TABLE entries ADD COLUMN ${column} ${sqlType} ` +
+          `AS (json_extract(data_json, '$.${field.apiId}')) VIRTUAL`,
+      );
+    } catch {
+      // Already promoted by a previous run — ALTER TABLE ADD COLUMN has
+      // no IF NOT EXISTS, so this is the idempotency path.
+    }
+    exec(
+      `CREATE INDEX IF NOT EXISTS idx_${column} ON entries(collection_id, ${column})`,
+    );
+    promotedCount++;
+  }
+}
+
+console.log(
+  `  ${fixture.entries.length} entries, ${edgeCount} relation edges, ` +
+    `${promotedCount} promoted columns\n` +
+    `Done. Try:\n` +
+    `  GET /api/public/entries/${fixture.collections[0]?.apiId}?populate=*&locale=en`,
+);

--- a/src/lib/server/content/query/engine.ts
+++ b/src/lib/server/content/query/engine.ts
@@ -57,6 +57,7 @@ import {
   type SQL,
 } from "drizzle-orm";
 import { type SQLiteTable } from "drizzle-orm/sqlite-core";
+import { entryLocalizations, entryRelations } from "../registry/schema";
 import {
   getCollection,
   type CollectionDef,
@@ -128,11 +129,29 @@ export class QueryEngine {
   /** Incremented per issued query so callers can assert on N+1. */
   private queryCount = 0;
 
+  /**
+   * `resolveCollection` is injectable so Phase 2's registry can supply
+   * user-defined collections alongside the built-in ones. Defaults to
+   * the built-in code registry, which is what the public per-entity
+   * endpoints use.
+   */
+  private readonly resolveCollection: (apiId: string) => CollectionDef | null;
+
+  /**
+   * Visibility rules inherited from the root query and applied to every
+   * populate target. Set per `find()` call — an admin read wants drafts,
+   * a public read must not see them, and a nested target has to honour
+   * whichever context it was reached from.
+   */
+  private visibility: { onlyPublished?: boolean } = {};
+
   constructor(
     d1: D1Database,
     private readonly opts: QueryEngineOptions,
+    resolveCollection?: (apiId: string) => CollectionDef | null,
   ) {
     this.db = drizzle(d1);
+    this.resolveCollection = resolveCollection ?? getCollection;
   }
 
   /** Queries issued since construction. Used by tests and `meta`. */
@@ -149,7 +168,7 @@ export class QueryEngine {
   }
 
   async find(collectionId: string, query: FindQuery = {}): Promise<FindResult> {
-    const collection = getCollection(collectionId);
+    const collection = this.resolveCollection(collectionId);
     if (!collection) {
       throw new QueryError(
         `Unknown collection "${collectionId}"`,
@@ -166,6 +185,9 @@ export class QueryEngine {
     const offset = (page - 1) * limit;
 
     this.assertDepth(query.populate, 1);
+
+    // Inherited by every populate target in this query's tree.
+    this.visibility = { onlyPublished: query.onlyPublished };
 
     const where = this.buildWhere(
       collection,
@@ -319,6 +341,190 @@ export class QueryEngine {
           depth,
           parent,
         );
+      case "entryLocalizations":
+        return this.resolveEntryLocalizations(
+          relation,
+          relationName,
+          sourceRows,
+          targetRows,
+          locale,
+          parent,
+        );
+      case "entryRelation":
+        return this.resolveEntryRelation(
+          relation,
+          relationName,
+          sourceRows,
+          targetRows,
+          node,
+          locale,
+          depth,
+          parent,
+        );
+    }
+  }
+
+  /**
+   * Phase 2 localizations: per-locale documents in the shared
+   * `entry_localizations` table.
+   *
+   * One query for every parent row, grouped into
+   * `{ en: {...}, th: {...} }` — deliberately the same output shape as
+   * the built-in `localizations` relation, so a consumer can't tell
+   * which storage backs the collection.
+   */
+  private async resolveEntryLocalizations(
+    relation: Extract<RelationDef, { kind: "entryLocalizations" }>,
+    relationName: string,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    locale: string | undefined,
+    parent: CollectionDef,
+  ): Promise<void> {
+    const ids = this.collectIds(sourceRows, parent.primaryKey);
+    if (ids.length === 0) return;
+
+    const extra: SQL[] = locale ? [eq(entryLocalizations.locale, locale)] : [];
+
+    const rows = (await this.loadChunked(ids, (chunk) =>
+      this.db
+        .select()
+        .from(entryLocalizations)
+        .where(and(inArray(entryLocalizations.entryId, chunk), ...extra))
+        .all(),
+    )) as EntryRow[];
+
+    const byParent = new Map<string, Record<string, unknown>>();
+    for (const row of rows) {
+      let doc: Record<string, unknown> = {};
+      try {
+        const parsed = JSON.parse(String(row.dataJson ?? "{}"));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          doc = parsed as Record<string, unknown>;
+        }
+      } catch {
+        // A corrupt document degrades to empty rather than 500ing the
+        // whole page — one bad row shouldn't take out a listing.
+      }
+      // Project through the field allowlist so a key left behind by a
+      // removed field can't leak back into an API response.
+      const payload: Record<string, unknown> = {};
+      for (const f of relation.fields) payload[f] = doc[f] ?? null;
+
+      byParent.set(String(row.entryId), {
+        ...(byParent.get(String(row.entryId)) ?? {}),
+        [String(row.locale)]: payload,
+      });
+    }
+
+    for (let i = 0; i < targetRows.length; i++) {
+      const id = String(sourceRows[i][parent.primaryKey]);
+      targetRows[i][relationName] = byParent.get(id) ?? {};
+    }
+  }
+
+  /**
+   * Phase 2 relations: edges in the shared `entry_relations` table.
+   *
+   * Two batched queries regardless of parent count — edges, then
+   * targets — same as `manyToMany`, plus two differences: edges are
+   * filtered by `fieldApiId` because every collection's relations share
+   * one table, and the result respects the edge `position` so ordered
+   * relations (a curated product list, a dynamic zone's block order)
+   * come back in the author's order.
+   */
+  private async resolveEntryRelation(
+    relation: Extract<RelationDef, { kind: "entryRelation" }>,
+    relationName: string,
+    sourceRows: EntryRow[],
+    targetRows: EntryRow[],
+    node: PopulateNode,
+    locale: string | undefined,
+    depth: number,
+    parent: CollectionDef,
+  ): Promise<void> {
+    const target = this.resolveCollection(relation.target);
+    if (!target) {
+      throw new QueryError(
+        `Relation "${relationName}" targets unknown collection "${relation.target}"`,
+        "UNKNOWN_COLLECTION",
+      );
+    }
+
+    const parentIds = this.collectIds(sourceRows, parent.primaryKey);
+    const empty = relation.cardinality === "one" ? null : [];
+    if (parentIds.length === 0) return;
+
+    const edges = (await this.loadChunked(parentIds, (chunk) =>
+      this.db
+        .select()
+        .from(entryRelations)
+        .where(
+          and(
+            inArray(entryRelations.entryId, chunk),
+            eq(entryRelations.fieldApiId, relation.fieldApiId),
+          ),
+        )
+        .orderBy(asc(entryRelations.position))
+        .all(),
+    )) as EntryRow[];
+
+    if (edges.length === 0) {
+      for (const row of targetRows) row[relationName] = empty;
+      return;
+    }
+
+    const targetIds = Array.from(
+      new Set(edges.map((e) => String(e.targetEntryId))),
+    );
+
+    const rows = await this.loadPopulateTargets(
+      target,
+      targetIds,
+      this.visibility,
+    );
+
+    const projected = rows.map((r) =>
+      this.projectScalars(target, r, node.fields),
+    );
+    const byId = new Map<string, EntryRow>();
+    projected.forEach((p, i) =>
+      byId.set(String(rows[i][target.primaryKey]), p),
+    );
+
+    // Edges arrived position-ordered from SQL; chunking preserves that
+    // per chunk but not across chunks, so re-sort before grouping.
+    const ordered = [...edges].sort(
+      (a, b) => Number(a.position ?? 0) - Number(b.position ?? 0),
+    );
+
+    const grouped = new Map<string, EntryRow[]>();
+    for (const edge of ordered) {
+      const hit = byId.get(String(edge.targetEntryId));
+      if (!hit) continue;
+      const parentId = String(edge.entryId);
+      const list = grouped.get(parentId) ?? [];
+      list.push(hit);
+      grouped.set(parentId, list);
+    }
+
+    for (let i = 0; i < targetRows.length; i++) {
+      const id = String(sourceRows[i][parent.primaryKey]);
+      const list = grouped.get(id) ?? [];
+      targetRows[i][relationName] =
+        relation.cardinality === "one" ? (list[0] ?? null) : list;
+    }
+
+    if (node.populate && rows.length > 0) {
+      this.assertDepth(node.populate, depth + 1);
+      await this.populateLevel(
+        target,
+        rows,
+        projected,
+        node.populate,
+        locale,
+        depth + 1,
+      );
     }
   }
 
@@ -384,7 +590,7 @@ export class QueryEngine {
     locale: string | undefined,
     depth: number,
   ): Promise<void> {
-    const target = getCollection(relation.target);
+    const target = this.resolveCollection(relation.target);
     if (!target) {
       throw new QueryError(
         `Relation "${relationName}" targets unknown collection "${relation.target}"`,
@@ -402,15 +608,12 @@ export class QueryEngine {
     }
 
     const targetKey = relation.targetKey ?? target.primaryKey;
-    const targetCol = requireColumn(target.table, targetKey, target.apiId);
-
-    const rows = (await this.loadChunked(ids, (chunk) =>
-      this.db
-        .select()
-        .from(target.table)
-        .where(inArray(targetCol, chunk))
-        .all(),
-    )) as EntryRow[];
+    const rows = await this.loadPopulateTargets(
+      target,
+      ids,
+      this.visibility,
+      targetKey,
+    );
 
     const projected = rows.map((r) =>
       this.projectScalars(target, r, node.fields),
@@ -453,7 +656,7 @@ export class QueryEngine {
     depth: number,
     parent: CollectionDef,
   ): Promise<void> {
-    const target = getCollection(relation.target);
+    const target = this.resolveCollection(relation.target);
     if (!target) {
       throw new QueryError(
         `Relation "${relationName}" targets unknown collection "${relation.target}"`,
@@ -487,18 +690,11 @@ export class QueryEngine {
       new Set(edges.map((e) => String(e[relation.throughTargetKey]))),
     );
 
-    const rows = (await this.loadChunked(targetIds, (chunk) =>
-      this.db
-        .select()
-        .from(target.table)
-        .where(
-          inArray(
-            requireColumn(target.table, target.primaryKey, target.apiId),
-            chunk,
-          ),
-        )
-        .all(),
-    )) as EntryRow[];
+    const rows = await this.loadPopulateTargets(
+      target,
+      targetIds,
+      this.visibility,
+    );
 
     const projected = rows.map((r) =>
       this.projectScalars(target, r, node.fields),
@@ -567,6 +763,70 @@ export class QueryEngine {
     return out;
   }
 
+  /**
+   * Load populate targets by id, applying the TARGET collection's own
+   * scope and visibility rules.
+   *
+   * Filtering by id alone is not sufficient, for two reasons:
+   *
+   *  1. **Cross-collection leak.** Registry collections all share the
+   *     `entries` table, so an edge pointing at the wrong content type
+   *     would return that type's row projected through this
+   *     collection's field names. Write-path validation
+   *     (`assertValidTargets`) can't be trusted here — edges can also
+   *     arrive from an importer or a direct SQL seed.
+   *  2. **Draft leak.** The root query is `status = published`, but a
+   *     populate target loaded by id alone ignores status entirely, so
+   *     an unpublished or archived entry would ride along inside a
+   *     published parent's payload.
+   *
+   * `visibility` is inherited from the root query, so an admin read
+   * (which legitimately wants drafts) still sees them.
+   */
+  private async loadPopulateTargets(
+    target: CollectionDef,
+    ids: string[],
+    visibility: { onlyPublished?: boolean },
+    /** Column the ids match, when it isn't the primary key. */
+    matchKey?: string,
+  ): Promise<EntryRow[]> {
+    const idColumn = requireColumn(
+      target.table,
+      matchKey ?? target.primaryKey,
+      target.apiId,
+    );
+
+    const extra: SQL[] = [];
+    if (target.scopeFilter) extra.push(target.scopeFilter);
+    if (
+      visibility.onlyPublished &&
+      target.filterable.includes("status") &&
+      target.selectable.includes("status")
+    ) {
+      extra.push(
+        eq(requireColumn(target.table, "status", target.apiId), "published"),
+      );
+    }
+    if (visibility.onlyPublished && target.filterable.includes("publishedAt")) {
+      const publishedAt = requireColumn(
+        target.table,
+        "publishedAt",
+        target.apiId,
+      );
+      extra.push(
+        or(isNull(publishedAt), lte(publishedAt, new Date().toISOString()))!,
+      );
+    }
+
+    return (await this.loadChunked(ids, (chunk) =>
+      this.db
+        .select()
+        .from(target.table)
+        .where(and(inArray(idColumn, chunk), ...extra))
+        .all(),
+    )) as EntryRow[];
+  }
+
   /** Distinct, non-null values of `key` across rows. */
   private collectIds(rows: EntryRow[], key: string): string[] {
     const set = new Set<string>();
@@ -600,13 +860,18 @@ export class QueryEngine {
         })
       : collection.selectable;
 
+    // Registry-backed collections keep their field values inside a JSON
+    // document, so lift them to the top level before projecting. Column-
+    // per-field collections set no mapper and read straight through.
+    const source = collection.flattenRow ? collection.flattenRow(row) : row;
+
     const out: EntryRow = {};
-    for (const f of allowed) out[f] = row[f] ?? null;
+    for (const f of allowed) out[f] = source[f] ?? null;
     // The primary key always rides along — populate stitching and any
     // client-side cache keying need it, and omitting it makes results
     // ambiguous.
     if (!(collection.primaryKey in out)) {
-      out[collection.primaryKey] = row[collection.primaryKey];
+      out[collection.primaryKey] = source[collection.primaryKey];
     }
     return out;
   }
@@ -617,6 +882,12 @@ export class QueryEngine {
     onlyPublished?: boolean,
   ): SQL | undefined {
     const conditions: SQL[] = [];
+
+    // Collection scoping. Registry-backed collections all live in the
+    // shared `entries` table, so without this a query for one content
+    // type would return every type's rows. First in the list and not
+    // reachable through the filter grammar, so a caller cannot widen it.
+    if (collection.scopeFilter) conditions.push(collection.scopeFilter);
 
     // Scheduled-publishing guard. Applied before user filters so it
     // can't be displaced by them, and expressed as a disjunction the

--- a/src/lib/server/content/query/index.ts
+++ b/src/lib/server/content/query/index.ts
@@ -50,9 +50,17 @@ function resolveRelationTarget(
   if (relation === "*") return null; // expanded by the engine, not a target
   const rel = def.relations[relation];
   if (!rel) return null;
-  // A localizations relation lives in a sibling table of the same
-  // collection — it has no separate target collection to invalidate.
-  return rel.kind === "localizations" ? collection : rel.target;
+  switch (rel.kind) {
+    // Localizations live in a sibling table of the same collection —
+    // there is no separate target collection to invalidate.
+    case "localizations":
+    case "entryLocalizations":
+      return collection;
+    case "manyToOne":
+    case "manyToMany":
+    case "entryRelation":
+      return rel.target;
+  }
 }
 
 export interface ContentQuery {

--- a/src/lib/server/content/query/registry.ts
+++ b/src/lib/server/content/query/registry.ts
@@ -26,6 +26,7 @@
  * ids**, never per row. See engine.ts.
  */
 import * as schema from "../schema";
+import type { SQL } from "drizzle-orm";
 import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 
 /** How a relation is physically stored in the current schema. */
@@ -48,6 +49,36 @@ export type RelationDef =
       /** Join-table column pointing at the target collection. */
       throughTargetKey: string;
       target: string;
+    }
+  | {
+      /**
+       * Phase 2: an edge in the shared `entry_relations` table.
+       *
+       * Differs from `manyToMany` in two ways that matter to the engine:
+       * all relations of every collection share ONE table, so edges must
+       * additionally be filtered by `fieldApiId`; and edges carry an
+       * explicit `position`, so the joined array has a meaningful order
+       * (which `article_tags` cannot express).
+       */
+      kind: "entryRelation";
+      /** Field apiId discriminating these edges from every other field's. */
+      fieldApiId: string;
+      /** Target collection apiId. */
+      target: string;
+      /** `one` collapses the array to a single object or null. */
+      cardinality: "one" | "many";
+    }
+  | {
+      /**
+       * Phase 2: per-locale documents in the shared
+       * `entry_localizations` table. Same public shape as
+       * `localizations` (`{en: {...}, th: {...}}`) so consumers see one
+       * convention, but the values are lifted out of a JSON document
+       * rather than read from columns.
+       */
+      kind: "entryLocalizations";
+      /** Field apiIds carried in each locale's document. */
+      fields: readonly string[];
     }
   | {
       kind: "localizations";
@@ -77,6 +108,33 @@ export interface CollectionDef {
   /** Columns permitted in `filters` / `sort`. Subset of selectable. */
   filterable: readonly string[];
   relations: Record<string, RelationDef>;
+  /**
+   * Optional hook to flatten a raw DB row before projection.
+   *
+   * The built-in collections below store every field in its own column,
+   * so `row[fieldName]` just works and this is unset. Phase 2's registry
+   * collections keep their field values inside a `data_json` document on
+   * a shared `entries` table, so they supply a mapper that lifts those
+   * keys to the top level.
+   *
+   * This is the seam that lets ONE engine serve both storage shapes.
+   * Without it the engine would have to know which kind of collection it
+   * was reading, which is exactly the coupling the phase split avoids.
+   *
+   * Must be pure and synchronous — it runs once per row on the read
+   * path.
+   */
+  flattenRow?: (row: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * Extra condition ANDed into every query for this collection.
+   *
+   * Built-in collections each own a table, so they need none. Phase 2's
+   * registry collections all share `entries`, so without this a query
+   * for one content type would return every type's rows. Applied by the
+   * engine ahead of user filters and not expressible through the filter
+   * grammar, so a caller cannot widen or remove it.
+   */
+  scopeFilter?: SQL;
 }
 
 /**

--- a/src/lib/server/content/registry/adapter.ts
+++ b/src/lib/server/content/registry/adapter.ts
@@ -1,0 +1,168 @@
+/**
+ * Registry → query-engine adapter — Phase 2.
+ *
+ * Turns `collections` / `collection_fields` rows into the same
+ * `CollectionDef` shape Phase 1's engine already consumes for the
+ * built-in tables. This is the join between the two phases, and the
+ * reason Phase 1 was worth shipping first: the engine gains
+ * user-definable content types without a single change to how it
+ * resolves, batches, or caches.
+ *
+ * Every registry collection reads from the shared `entries` table, so:
+ *
+ *  - **`flattenRow`** lifts `data_json` keys to the top level, which is
+ *    how `fields` projection and populate leaves keep working unchanged.
+ *  - **relations** become `entryRelation` defs discriminated by
+ *    `fieldApiId`.
+ *  - **`filterable`** lists only the columns a filter can actually use
+ *    efficiently. A non-promoted document field is deliberately NOT
+ *    filterable here: `json_extract` is O(N) in document size on SQLite,
+ *    so allowing it would turn one careless query param into a full scan
+ *    of every entry. Promote the field (a real generated column plus a
+ *    real index) and it becomes filterable.
+ */
+import { sql } from "drizzle-orm";
+import type { CollectionDef, RelationDef } from "../query/registry";
+import { entries } from "./schema";
+import { promotedColumnName } from "./promote";
+import {
+  RELATIONAL_FIELD_TYPES,
+  type ComponentFieldConfig,
+  type RelationFieldConfig,
+} from "./types";
+import type { CollectionWithFields } from "./service";
+
+/**
+ * Columns of `entries` that are always safe to expose. `collection_id`
+ * is omitted — it is an internal join key, and the caller already knows
+ * which collection they queried.
+ */
+const BASE_SELECTABLE = [
+  "id",
+  "slug",
+  "status",
+  "publishedAt",
+  "createdAt",
+  "updatedAt",
+] as const;
+
+/**
+ * Real columns on `entries`, so these are indexed and cheap to filter
+ * and sort by.
+ */
+const BASE_FILTERABLE = [
+  "id",
+  "slug",
+  "status",
+  "publishedAt",
+  "createdAt",
+  "updatedAt",
+] as const;
+
+/**
+ * Build a `CollectionDef` for one registry collection.
+ *
+ * `collectionId` is captured so the engine's base query can be scoped to
+ * this collection's entries — see `scopeFilter`.
+ */
+export function toCollectionDef(
+  collection: CollectionWithFields,
+): CollectionDef {
+  const documentFields = collection.fields.filter(
+    (f) => !RELATIONAL_FIELD_TYPES.has(f.type),
+  );
+
+  const selectable = [
+    ...BASE_SELECTABLE,
+    ...documentFields.map((f) => f.apiId),
+  ];
+
+  // Only promoted fields join the filterable set. See the module note:
+  // an unpromoted JSON field would be an O(N)-per-row scan.
+  const promoted = documentFields
+    .filter((f) => f.promoted && !f.localized)
+    .map((f) => f.apiId);
+
+  const relations: Record<string, RelationDef> = {};
+  for (const field of collection.fields) {
+    if (!RELATIONAL_FIELD_TYPES.has(field.type)) continue;
+    const config = parseConfig(field.configJson);
+    if (field.type === "relation") {
+      const cfg = config as RelationFieldConfig;
+      relations[field.apiId] = {
+        kind: "entryRelation",
+        fieldApiId: field.apiId,
+        target: cfg.target,
+        cardinality: cfg.cardinality ?? "one",
+      };
+    } else {
+      const cfg = config as ComponentFieldConfig;
+      relations[field.apiId] = {
+        kind: "entryRelation",
+        fieldApiId: field.apiId,
+        // A dynamic zone may allow several component collections. The
+        // engine loads one target collection per relation, so a
+        // multi-allowed zone resolves against the first; mixed zones
+        // need per-edge type resolution, which lands with the Phase 4
+        // block editor that actually renders them.
+        target: cfg.allowed[0],
+        cardinality: cfg.cardinality ?? "many",
+      };
+    }
+  }
+
+  // Localized fields are exposed as a `localizations` relation, matching
+  // the built-in collections' shape so a consumer sees one convention.
+  const localizedFields = documentFields.filter((f) => f.localized);
+  if (collection.localized && localizedFields.length > 0) {
+    relations.localizations = {
+      kind: "entryLocalizations",
+      fields: localizedFields.map((f) => f.apiId),
+    };
+  }
+
+  return {
+    apiId: collection.apiId,
+    table: entries,
+    primaryKey: "id",
+    selectable,
+    filterable: [...BASE_FILTERABLE, ...promoted],
+    relations,
+    flattenRow: flattenEntryRow,
+    scopeFilter: sql`${entries.collectionId} = ${collection.id}`,
+  };
+}
+
+/**
+ * Lift `data_json` keys onto the row.
+ *
+ * Base columns win on collision: a field named `status` cannot shadow
+ * the entry's real status. `assertValidApiId` already rejects those
+ * names, so this is belt-and-braces against a row written before that
+ * validation existed.
+ */
+function flattenEntryRow(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const doc = safeParse(row.dataJson);
+  return { ...doc, ...row };
+}
+
+function parseConfig(json: string | null): unknown {
+  return json ? safeParse(json) : {};
+}
+
+function safeParse(value: unknown): Record<string, unknown> {
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Promoted-column name, for callers building their own SQL. */
+export { promotedColumnName };

--- a/src/lib/server/content/registry/index.ts
+++ b/src/lib/server/content/registry/index.ts
@@ -1,0 +1,185 @@
+/**
+ * Registry public surface — Phase 2 (#68).
+ *
+ * `createRegistryQuery(env)` returns a query interface that resolves
+ * BOTH the built-in code-defined collections and the user-defined
+ * registry collections through the same Phase 1 engine.
+ *
+ * Resolution order matters: built-in collections win on a name
+ * collision, so a user cannot shadow `articles` with a registry
+ * collection of the same apiId and change what the public API returns.
+ * `createCollection` rejects those names up front too; this is the
+ * second line of defence.
+ */
+import { QueryEngine } from "../query/engine";
+import { QueryCache, collectionsTouched } from "../query/cache";
+import {
+  getCollection as getBuiltinCollection,
+  listCollectionIds as listBuiltinIds,
+  type CollectionDef,
+} from "../query/registry";
+import type { EntryRow, FindQuery, FindResult } from "../query/types";
+import { toCollectionDef } from "./adapter";
+import { RegistryService } from "./service";
+
+export { RegistryService } from "./service";
+export { PromotionService, MAX_PROMOTED_FIELDS } from "./promote";
+export { toCollectionDef } from "./adapter";
+export {
+  RegistryError,
+  assertValidApiId,
+  validateFieldConfig,
+  API_ID_PATTERN,
+  PROMOTABLE_FIELD_TYPES,
+  RELATIONAL_FIELD_TYPES,
+} from "./types";
+export { validateFieldValue } from "./validate";
+export * from "./schema";
+export type {
+  CollectionWithFields,
+  CreateCollectionInput,
+  CreateFieldInput,
+  UpsertEntryInput,
+} from "./service";
+
+export interface RegistryQuery {
+  /** Every queryable collection apiId, built-in and registry. */
+  listCollections(): Promise<string[]>;
+  find(collection: string, query?: FindQuery): Promise<FindResult>;
+  findOne(
+    collection: string,
+    query?: Omit<FindQuery, "page" | "limit">,
+  ): Promise<EntryRow | null>;
+  findCached(
+    collection: string,
+    query?: FindQuery,
+    ttlSeconds?: number,
+  ): Promise<FindResult>;
+  invalidate(collections: string[]): Promise<void>;
+  /** The write API — collections, fields, entries, relations. */
+  readonly service: RegistryService;
+}
+
+export function createRegistryQuery(env: App.Platform["env"]): RegistryQuery {
+  const supportedLocales = (env.SUPPORTED_LOCALES ?? "en,th")
+    .split(",")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  const defaultLocale = env.DEFAULT_LOCALE ?? supportedLocales[0] ?? "en";
+
+  const cache = env.CONTENT_CACHE ? new QueryCache(env.CONTENT_CACHE) : null;
+
+  const service = new RegistryService(env.DB, {
+    supportedLocales,
+    defaultLocale,
+    // Registry writes must drop cached payloads, or `findCached` keeps
+    // serving pre-edit content for the full TTL. Fire-and-forget: a
+    // failed invalidation must not fail the write, and the TTL bounds
+    // the damage. Callers with an execution context should prefer
+    // `invalidate()` under waitUntil.
+    onWrite: cache
+      ? (collectionApiIds) => void cache.invalidateMany(collectionApiIds)
+      : undefined,
+  });
+
+  /**
+   * Registry defs, built once per request and memoized.
+   *
+   * Two queries (collections + their fields) shared across every
+   * collection touched by one request's populate tree — rebuilding per
+   * lookup would reintroduce exactly the N+1 Phase 1 removed.
+   */
+  let defsPromise: Promise<{
+    all: Map<string, CollectionDef>;
+    roots: Map<string, CollectionDef>;
+  }> | null = null;
+  const registryDefs = () => {
+    if (!defsPromise) {
+      defsPromise = service.listCollectionsWithFields().then((collections) => {
+        const all = new Map<string, CollectionDef>();
+        const roots = new Map<string, CollectionDef>();
+        for (const collection of collections) {
+          const def = toCollectionDef(collection);
+          // Components must stay RESOLVABLE — a component field's
+          // populate target is a component collection, and omitting them
+          // from resolution makes `populate=*` throw UNKNOWN_COLLECTION
+          // on any collection that has one.
+          all.set(collection.apiId, def);
+          // But they are not addressable on their own: exposing them as
+          // query roots would let a caller enumerate page fragments
+          // outside the page that owns them.
+          if (collection.kind !== "component") {
+            roots.set(collection.apiId, def);
+          }
+        }
+        return { all, roots };
+      });
+    }
+    return defsPromise;
+  };
+
+  /**
+   * Resolve a collection by apiId across both sources, built-in first.
+   *
+   * The engine takes a synchronous resolver, so registry defs are loaded
+   * before the query runs and handed over as a plain lookup.
+   */
+  const buildResolver = async () => {
+    const { all } = await registryDefs();
+    return (apiId: string): CollectionDef | null =>
+      getBuiltinCollection(apiId) ?? all.get(apiId) ?? null;
+  };
+
+  const engineFor = async () => {
+    const resolve = await buildResolver();
+    return new QueryEngine(
+      env.DB,
+      { supportedLocales, defaultLocale },
+      resolve,
+    );
+  };
+
+  return {
+    async listCollections() {
+      // Roots only — this is what the public endpoint gates on, so
+      // components must not appear or they'd become addressable.
+      const { roots } = await registryDefs();
+      return [...listBuiltinIds(), ...roots.keys()];
+    },
+
+    async find(collection, query = {}) {
+      return (await engineFor()).find(collection, query);
+    },
+
+    async findOne(collection, query = {}) {
+      return (await engineFor()).findOne(collection, query);
+    },
+
+    async findCached(collection, query = {}, ttlSeconds) {
+      const engine = await engineFor();
+      if (!cache) return engine.find(collection, query);
+      const resolve = await buildResolver();
+      const touched = collectionsTouched(collection, query, (c, relation) => {
+        const def = resolve(c);
+        if (!def || relation === "*") return null;
+        const rel = def.relations[relation];
+        if (!rel) return null;
+        return rel.kind === "localizations" || rel.kind === "entryLocalizations"
+          ? c
+          : rel.target;
+      });
+      const hit = await cache.get(collection, query, touched);
+      if (hit) return hit;
+      const fresh = await engine.find(collection, query);
+      await cache.set(collection, query, touched, fresh, ttlSeconds);
+      return fresh;
+    },
+
+    async invalidate(collections) {
+      if (!cache) return;
+      await cache.invalidateMany(collections);
+    },
+
+    service,
+  };
+}

--- a/src/lib/server/content/registry/promote.ts
+++ b/src/lib/server/content/registry/promote.ts
@@ -1,0 +1,332 @@
+/**
+ * Hot-field promotion — Phase 2, the "inverted index" for hot paths.
+ *
+ * SQLite's `json_extract` is **O(N) in the document size, not O(1)**
+ * (see SQLite's json1 docs — its JSONB format makes no O(1) claim). So
+ * an unindexed filter over a JSON field is a full scan of every row's
+ * document. For a field users actually filter or sort by, that is the
+ * difference between a working catalog and a broken one.
+ *
+ * The fix Cloudflare explicitly recommends:
+ *
+ *   > "If you have JSON data that you frequently query and filter over,
+ *   > creating a generated column and an index can dramatically improve
+ *   > query performance."
+ *
+ * So a field marked `promoted` gets:
+ *
+ *   ALTER TABLE entries ADD COLUMN q_<field> TEXT
+ *     AS (json_extract(data_json, '$.<field>')) VIRTUAL;
+ *   CREATE INDEX IF NOT EXISTS ... ON entries(collection_id, q_<field>);
+ *
+ * ## Why VIRTUAL, not STORED
+ *
+ * SQLite permits **only VIRTUAL** generated columns to be added by
+ * `ALTER TABLE` — STORED cannot be added to an existing table. Since
+ * promotion happens at runtime against a populated table, VIRTUAL is
+ * the only option. It costs no storage; the index over it is an
+ * expression index, and generated columns can participate in indexes
+ * like any other.
+ *
+ * ## Why this is bounded, and opt-in
+ *
+ * **D1 caps a table at 100 columns.** `entries` already spends 8, and
+ * every promoted field across *every* collection spends another from
+ * the same shared budget. This is the real ceiling on the design — not
+ * join performance — and it is why promotion is an explicit per-field
+ * opt-in with a hard budget check rather than something the engine does
+ * automatically. SonicJS, which ships this same design on D1, hit and
+ * documents the identical wall.
+ *
+ * ## Promoted columns are effectively permanent
+ *
+ * SQLite cannot drop a generated column that an index references, and D1
+ * discourages destructive DDL, so `unpromote` drops only the index and
+ * leaves the column inert. Two consequences worth knowing:
+ *
+ *  - un-promoting does NOT return budget; `budget()` reports that
+ *    honestly rather than pretending the space came back
+ *  - changing the column NAMING scheme orphans every existing promoted
+ *    column, and the orphans keep consuming budget. If the scheme ever
+ *    changes again it needs a real migration that rebuilds `entries`,
+ *    not just a new format here.
+ *
+ * ## Injection safety
+ *
+ * DDL cannot use bound parameters — identifiers are not bindable — so
+ * these statements are built by string interpolation. That is only safe
+ * because the interpolated values are not free text: `apiId` has
+ * already passed `assertValidApiId` (`^[a-z][a-z0-9_]{0,62}$`), so it
+ * cannot contain a quote, space, semicolon or comment marker. This
+ * module re-checks rather than trusting its caller, because a single
+ * missed validation here is arbitrary SQL execution.
+ */
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import type { FieldType } from "./schema";
+import {
+  assertValidApiId,
+  PROMOTABLE_FIELD_TYPES,
+  RegistryError,
+} from "./types";
+
+/** D1's hard per-table column ceiling. */
+export const D1_MAX_COLUMNS = 100;
+
+/**
+ * Columns `entries` declares itself: id, collection_id, slug, status,
+ * published_at, data_json, created_by, created_at, updated_at.
+ *
+ * Kept as a constant rather than counted at runtime so the budget is
+ * legible here, and so a schema change that eats headroom shows up as a
+ * deliberate edit to this number rather than silently shrinking it.
+ */
+const BASE_ENTRY_COLUMNS = 9;
+
+/**
+ * Deliberate safety margin. Running right up to 100 would leave no room
+ * for a future engine column, and hitting the cap is unrecoverable
+ * without a table rebuild — SQLite cannot drop a generated column
+ * cleanly on D1.
+ */
+const PROMOTION_HEADROOM = 12;
+
+export const MAX_PROMOTED_FIELDS =
+  D1_MAX_COLUMNS - BASE_ENTRY_COLUMNS - PROMOTION_HEADROOM;
+
+/** Prefix marking a column as engine-generated, not hand-declared. */
+const PROMOTED_PREFIX = "q_";
+
+/**
+ * Generated-column name for a field.
+ *
+ * Namespaced by collection so two collections can both promote a field
+ * called `title` — they are different JSON paths and must be different
+ * columns.
+ *
+ * The separator is a DOUBLE underscore, not a single one. `API_ID_PATTERN`
+ * permits single underscores inside a name, so `_` would be ambiguous:
+ * collection `blog_post` + field `title` and collection `blog` + field
+ * `post_title` would both produce `q_blog_post_title`. The second
+ * promotion would then find the column already present, return a silent
+ * no-op, and every filter on that field would read the *other*
+ * collection's JSON path — wrong results with no error. `__` cannot
+ * appear in a validated apiId, so the encoding is unambiguous.
+ */
+export function promotedColumnName(
+  collectionApiId: string,
+  fieldApiId: string,
+): string {
+  assertSafeIdentifier(collectionApiId, "collection apiId");
+  assertSafeIdentifier(fieldApiId, "field apiId");
+  return `${PROMOTED_PREFIX}${collectionApiId}__${fieldApiId}`;
+}
+
+/**
+ * Re-validate an identifier immediately before it is interpolated into
+ * DDL. Redundant with the service layer by design: this is the last
+ * gate before string-built SQL, so it must not depend on a caller
+ * having done the right thing.
+ */
+function assertSafeIdentifier(value: string, what: string): void {
+  // Delegates to the shared validator so this gate can never drift from
+  // the one the service applies — including the no-consecutive-
+  // underscores rule that keeps `__` usable as a separator.
+  try {
+    assertValidApiId(value, what);
+  } catch {
+    throw new RegistryError(
+      `Refusing to build DDL: unsafe ${what} "${value}"`,
+      "INVALID_API_ID",
+    );
+  }
+}
+
+/** SQLite storage class for a promoted field. */
+function sqliteTypeFor(type: FieldType): "TEXT" | "INTEGER" | "REAL" {
+  switch (type) {
+    case "number":
+      return "REAL";
+    case "boolean":
+      return "INTEGER";
+    default:
+      return "TEXT";
+  }
+}
+
+export interface PromotionTarget {
+  collectionApiId: string;
+  fieldApiId: string;
+  fieldType: FieldType;
+  /** True when the value lives in entry_localizations, not entries. */
+  localized: boolean;
+}
+
+export class PromotionService {
+  private db: ReturnType<typeof drizzle>;
+
+  constructor(private readonly d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  /**
+   * Generated columns currently on a table, by name.
+   *
+   * Uses `table_xinfo` rather than `table_info` — the latter omits
+   * generated columns entirely, so counting with it would under-report
+   * the budget and let promotions exceed the column cap.
+   */
+  async listColumns(
+    table: "entries" | "entry_localizations",
+  ): Promise<string[]> {
+    const rows = await this.d1
+      .prepare(`PRAGMA table_xinfo(${table})`)
+      .all<{ name: string }>();
+    return (rows.results ?? []).map((r) => r.name);
+  }
+
+  /** How many promoted columns exist / remain. */
+  async budget(): Promise<{ used: number; max: number; remaining: number }> {
+    const [entryCols, locCols] = await Promise.all([
+      this.listColumns("entries"),
+      this.listColumns("entry_localizations"),
+    ]);
+    // Both tables draw on the same conceptual budget; report the worse
+    // of the two so a promotion is refused before either table is at
+    // risk.
+    const used = Math.max(
+      entryCols.filter((c) => c.startsWith(PROMOTED_PREFIX)).length,
+      locCols.filter((c) => c.startsWith(PROMOTED_PREFIX)).length,
+    );
+    return {
+      used,
+      max: MAX_PROMOTED_FIELDS,
+      remaining: Math.max(0, MAX_PROMOTED_FIELDS - used),
+    };
+  }
+
+  /**
+   * Add the generated column + index for a field. Idempotent: an
+   * already-promoted field is a no-op, so this is safe to call on every
+   * boot to reconcile the physical schema against the registry.
+   *
+   * Returns the column name, or null when it already existed.
+   */
+  async promote(target: PromotionTarget): Promise<string | null> {
+    if (!PROMOTABLE_FIELD_TYPES.has(target.fieldType)) {
+      throw new RegistryError(
+        `Field type "${target.fieldType}" cannot be promoted to an indexed column`,
+        "INVALID_CONFIG",
+      );
+    }
+
+    const column = promotedColumnName(
+      target.collectionApiId,
+      target.fieldApiId,
+    );
+    const table = target.localized ? "entry_localizations" : "entries";
+
+    const existing = await this.listColumns(table);
+    if (existing.includes(column)) return null;
+
+    const { remaining } = await this.budget();
+    if (remaining <= 0) {
+      throw new RegistryError(
+        `Cannot promote "${target.collectionApiId}.${target.fieldApiId}": D1 allows ${D1_MAX_COLUMNS} columns per table and the promotion budget (${MAX_PROMOTED_FIELDS}) is exhausted. Un-promote a field first.`,
+        "PROMOTION_BUDGET_EXCEEDED",
+      );
+    }
+
+    const sqlType = sqliteTypeFor(target.fieldType);
+    // Every interpolated value is validated: `column` came from
+    // promotedColumnName (which re-checks both halves), `table` is one
+    // of two literals, `sqlType` is one of three literals, and the JSON
+    // path is built from the same validated apiId.
+    const jsonPath = `$.${target.fieldApiId}`;
+
+    await this.d1
+      .prepare(
+        `ALTER TABLE ${table} ADD COLUMN ${column} ${sqlType} ` +
+          `AS (json_extract(data_json, '${jsonPath}')) VIRTUAL`,
+      )
+      .run();
+
+    // Index is (collection_id, promoted) on `entries` so it serves the
+    // common "filter within one collection" query rather than a global
+    // scan across every collection's entries. entry_localizations has no
+    // collection_id, so it pairs with locale instead.
+    const indexName = `idx_${column}`;
+    const indexCols = target.localized
+      ? `locale, ${column}`
+      : `collection_id, ${column}`;
+    await this.d1
+      .prepare(
+        `CREATE INDEX IF NOT EXISTS ${indexName} ON ${table}(${indexCols})`,
+      )
+      .run();
+
+    return column;
+  }
+
+  /**
+   * Drop the index for a promoted field.
+   *
+   * The generated **column is deliberately left in place**: SQLite's
+   * `DROP COLUMN` refuses to remove a column referenced by an index and
+   * is unsupported for generated columns on older engines, and D1
+   * discourages destructive DDL. Dropping just the index reclaims the
+   * write cost and the query planner stops using it; the column becomes
+   * inert. It still counts against the budget, which `budget()` reports
+   * honestly rather than pretending the space came back.
+   */
+  async unpromote(target: {
+    collectionApiId: string;
+    fieldApiId: string;
+  }): Promise<void> {
+    const column = promotedColumnName(
+      target.collectionApiId,
+      target.fieldApiId,
+    );
+    await this.d1.prepare(`DROP INDEX IF EXISTS idx_${column}`).run();
+  }
+
+  /**
+   * Bring the physical schema in line with the registry: promote every
+   * field marked `promoted` that lacks its column.
+   *
+   * Cheap and idempotent, so it can run at boot. Returns the columns it
+   * actually added.
+   *
+   * Failures are collected rather than thrown: one field exhausting the
+   * budget must not stop the rest of the schema from reconciling, and
+   * the caller (an admin screen or a boot log) is better placed to
+   * surface it than a half-applied exception.
+   */
+  async reconcile(
+    targets: PromotionTarget[],
+  ): Promise<{ added: string[]; failed: { field: string; reason: string }[] }> {
+    const added: string[] = [];
+    const failed: { field: string; reason: string }[] = [];
+    for (const target of targets) {
+      try {
+        const column = await this.promote(target);
+        if (column) added.push(column);
+      } catch (err) {
+        failed.push({
+          field: `${target.collectionApiId}.${target.fieldApiId}`,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return { added, failed };
+  }
+
+  /**
+   * Raw SQL fragment for a promoted column, for use in a WHERE/ORDER BY.
+   * Callers must already know the field is promoted.
+   */
+  columnRef(collectionApiId: string, fieldApiId: string) {
+    const column = promotedColumnName(collectionApiId, fieldApiId);
+    return sql.raw(column);
+  }
+}

--- a/src/lib/server/content/registry/schema.ts
+++ b/src/lib/server/content/registry/schema.ts
@@ -1,0 +1,424 @@
+/**
+ * Collection registry — Phase 2 (#68 §B, as corrected).
+ *
+ * A DB-stored meta-schema so new content types and fields are **data,
+ * not code**. Adding a user collection is an INSERT; it needs no
+ * migration and no deploy. The engine tables below are themselves
+ * ordinary Drizzle migrations — there is no runtime DDL for *these*.
+ *
+ * ## Why this shape (and why the earlier verdict was reversed)
+ *
+ * Issue #68 carried a 2026-07-28 verdict that overturned this design in
+ * favour of code-first tables. Re-research (see the correction comment
+ * on #68) found all three of its pillars failed:
+ *
+ *  1. "Cloudflare discourages runtime DDL" — the quote it relied on is
+ *     not in current docs; today's wording narrows the rationale to
+ *     REST-API rate limits.
+ *  2. "Payload proves code-first buys real SQL joins" — reading shipped
+ *     source, Payload folds a relation into its join tree only when the
+ *     relation is single-valued AND monomorphic, and its list path
+ *     hardcodes depth 0. For `hasMany` — every catalog relation — it
+ *     also issues follow-up queries. Batched populate is required
+ *     either way, which is why Phase 1 stands independent of this.
+ *  3. "wp_postmeta is the cautionary tale" — that argues against a
+ *     schema nobody proposed. wp_postmeta puts every *field* in a row,
+ *     so filtering on N fields costs N self-joins on one untyped
+ *     column. Here, an entry's scalars are **one JSON document**: zero
+ *     joins to read them. Karwin's canonical anti-EAV essay lists
+ *     "serialized LOB with an inverted index" among its *recommended*
+ *     alternatives — which is exactly this. Akeneo migrated *toward*
+ *     this shape in 2.0, keeping definitions relational and values in
+ *     JSON.
+ *
+ * The inverted index is `entry_field_index` plus, for hot fields,
+ * VIRTUAL generated columns promoted at runtime (see promote.ts) — a
+ * pattern Cloudflare explicitly recommends.
+ *
+ * ## The one constraint to design around
+ *
+ * Not join explosion — **D1's 100-column-per-table ceiling**. It bounds
+ * how many fields can be promoted to generated columns on `entries`.
+ * SonicJS, which ships this design on D1, flags the same wall. Hence
+ * `promoted` is opt-in per field, never automatic.
+ */
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+// ─── Collections (the meta-schema) ──────────────────────────
+
+/**
+ * A user-defined content type.
+ *
+ * `kind`:
+ *  - `collection` — many entries (Article, Product, Brand)
+ *  - `single`     — exactly one entry (Homepage, Settings); enforced in
+ *                   the service layer, not by a DB constraint, because
+ *                   SQLite can't express "at most one row per FK value"
+ *                   without a trigger
+ *  - `component`  — never addressable on its own; only ever nested
+ *                   inside another entry's field. This is how blocks
+ *                   and dynamic zones are modelled (#68 §C).
+ */
+export const collections = sqliteTable(
+  "collections",
+  {
+    id: text("id").primaryKey(),
+    /**
+     * Stable machine name used in API paths and populate params.
+     * Immutable after creation — renaming would silently break every
+     * consumer's saved queries, so the service rejects it.
+     */
+    apiId: text("api_id").notNull().unique(),
+    kind: text("kind", { enum: ["collection", "single", "component"] })
+      .notNull()
+      .default("collection"),
+    /** Per-locale display labels, JSON: `{"en":{"singular":…,"plural":…}}` */
+    labelsJson: text("labels_json"),
+    /** When false, every entry is immediately live (no draft state). */
+    draftPublish: integer("draft_publish", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    /**
+     * Whether entries carry per-locale content at all. A taxonomy of
+     * machine keys may not need it.
+     */
+    localized: integer("localized", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    /**
+     * Engine-owned collections (if any are ever registered here) must
+     * not be editable or deletable from the admin UI.
+     */
+    system: integer("system", { mode: "boolean" }).notNull().default(false),
+    description: text("description"),
+    createdBy: text("created_by"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    kindIdx: index("collections_kind_idx").on(t.kind),
+  }),
+);
+
+/**
+ * Field types. Deliberately closed: the admin UI maps each to exactly
+ * one editor component (Phase 4), and a `find()` filter has to know how
+ * to compare the value.
+ *
+ * `relation` and `component` store nothing in the entry document —
+ * their values live in `entry_relations` so they stay independently
+ * queryable and orderable.
+ */
+export const FIELD_TYPES = [
+  "text",
+  "richtext",
+  "number",
+  "boolean",
+  "date",
+  "datetime",
+  "email",
+  "url",
+  "slug",
+  "enum",
+  "json",
+  "media",
+  "relation",
+  "component",
+] as const;
+
+export type FieldType = (typeof FIELD_TYPES)[number];
+
+export const collectionFields = sqliteTable(
+  "collection_fields",
+  {
+    id: text("id").primaryKey(),
+    collectionId: text("collection_id")
+      .notNull()
+      .references(() => collections.id, { onDelete: "cascade" }),
+    /** Machine name; the key inside the entry's JSON document. */
+    apiId: text("api_id").notNull(),
+    type: text("type", { enum: FIELD_TYPES }).notNull(),
+    labelsJson: text("labels_json"),
+    required: integer("required", { mode: "boolean" }).notNull().default(false),
+    /**
+     * When true the value lives in `entry_localizations.dataJson` per
+     * locale; when false it lives once in `entries.dataJson`. Per-field,
+     * so a Product can have a localized `name` and a shared `sku`.
+     */
+    localized: integer("localized", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    /**
+     * Uniqueness is enforced in the service layer, not by a DB
+     * constraint — the value lives inside a JSON document, so there is
+     * no column to put a UNIQUE index on. Promoting the field (below)
+     * does make a real unique index possible.
+     */
+    unique: integer("unique", { mode: "boolean" }).notNull().default(false),
+    /**
+     * Opt into a VIRTUAL generated column + index on this field, making
+     * it efficiently filterable and sortable.
+     *
+     * Opt-in rather than automatic because D1 caps a table at 100
+     * columns: every promotion spends part of a fixed budget shared by
+     * all collections on the `entries` table.
+     */
+    promoted: integer("promoted", { mode: "boolean" }).notNull().default(false),
+    /**
+     * Type-specific settings as JSON — enum options, min/max, relation
+     * target + cardinality, allowed component collections for a
+     * dynamic zone, etc. Validated per `type` by the service.
+     */
+    configJson: text("config_json"),
+    /** Display order in the admin form. */
+    position: integer("position").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    // A field's apiId must be unique within its collection — two
+    // fields both writing `data.title` would silently overwrite.
+    collectionApiIdx: uniqueIndex("collection_fields_collection_api_idx").on(
+      t.collectionId,
+      t.apiId,
+    ),
+    positionIdx: index("collection_fields_position_idx").on(
+      t.collectionId,
+      t.position,
+    ),
+  }),
+);
+
+// ─── Entries (the content) ──────────────────────────────────
+
+/**
+ * One row per entry, whatever its collection.
+ *
+ * Non-localized scalars live in `dataJson`. This is the "serialized
+ * LOB" — reading an entry's scalars is one row read and zero joins,
+ * which is precisely what distinguishes this from per-field EAV.
+ *
+ * Promoted fields get VIRTUAL generated columns added to THIS table at
+ * runtime (`promote.ts`). They are not declared here because they are
+ * per-installation: which ones exist depends on the registry rows a
+ * given site created.
+ */
+export const entries = sqliteTable(
+  "entries",
+  {
+    id: text("id").primaryKey(),
+    collectionId: text("collection_id")
+      .notNull()
+      .references(() => collections.id, { onDelete: "cascade" }),
+    /**
+     * Shared across locales and unique within the collection, matching
+     * the repo's existing slug convention (English-derived ASCII, no
+     * per-locale slug). Null for `component` entries, which are never
+     * addressed by URL.
+     */
+    slug: text("slug"),
+    status: text("status", { enum: ["draft", "published", "archived"] })
+      .notNull()
+      .default("draft"),
+    publishedAt: text("published_at"),
+    /** Non-localized field values, JSON object keyed by field apiId. */
+    dataJson: text("data_json").notNull().default("{}"),
+    createdBy: text("created_by"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    // Slug uniqueness is scoped to the collection: two different types
+    // may both legitimately have an "about" entry.
+    collectionSlugIdx: uniqueIndex("entries_collection_slug_idx").on(
+      t.collectionId,
+      t.slug,
+    ),
+    // The list query: entries of one type, by status, newest first.
+    listIdx: index("entries_collection_status_idx").on(
+      t.collectionId,
+      t.status,
+      t.updatedAt,
+    ),
+    publishedIdx: index("entries_published_idx").on(
+      t.collectionId,
+      t.publishedAt,
+    ),
+  }),
+);
+
+/**
+ * Per-locale field values. One row per (entry, locale).
+ *
+ * `locale` is **plain text, deliberately not an enum** — #68 §E. The
+ * existing content tables bake `["th","en"]` into ~8 schemas, so adding
+ * a locale means a migration everywhere. Here it's validated against
+ * the runtime supported-locale list instead.
+ */
+export const entryLocalizations = sqliteTable(
+  "entry_localizations",
+  {
+    id: text("id").primaryKey(),
+    entryId: text("entry_id")
+      .notNull()
+      .references(() => entries.id, { onDelete: "cascade" }),
+    locale: text("locale").notNull(),
+    /** Localized field values, JSON object keyed by field apiId. */
+    dataJson: text("data_json").notNull().default("{}"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    entryLocaleIdx: uniqueIndex("entry_localizations_entry_locale_idx").on(
+      t.entryId,
+      t.locale,
+    ),
+  }),
+);
+
+// ─── Relations ──────────────────────────────────────────────
+
+/**
+ * ONE join table for every entry→entry relation — 1:1, 1:n and n:m
+ * alike (#68 §C). Cardinality is declared in the field's `configJson`
+ * and enforced by the service; the storage shape is identical.
+ *
+ * `position` gives ordered relations, which the existing `article_tags`
+ * table cannot express. A catalog needs it (a Brand's ProductLines have
+ * a curated order), and so do dynamic zones, where the order of nested
+ * component entries *is* the page layout.
+ */
+export const entryRelations = sqliteTable(
+  "entry_relations",
+  {
+    id: text("id").primaryKey(),
+    /** The entry that owns the relation field. */
+    entryId: text("entry_id")
+      .notNull()
+      .references(() => entries.id, { onDelete: "cascade" }),
+    /**
+     * Which field on the owner this edge belongs to. Stored as the
+     * field's apiId rather than its row id so an edge stays readable
+     * (and debuggable) without joining the registry.
+     */
+    fieldApiId: text("field_api_id").notNull(),
+    /**
+     * The target. CASCADE, so deleting an entry removes the edges
+     * pointing at it rather than leaving dangling references that
+     * populate would have to filter out on every read.
+     */
+    targetEntryId: text("target_entry_id")
+      .notNull()
+      .references(() => entries.id, { onDelete: "cascade" }),
+    position: integer("position").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+  },
+  (t) => ({
+    // Forward traversal: "this entry's `variants`, in order" — the
+    // query populate issues on every read.
+    forwardIdx: index("entry_relations_forward_idx").on(
+      t.entryId,
+      t.fieldApiId,
+      t.position,
+    ),
+    // Reverse traversal: "what points at this entry?" Needed for
+    // reverse/join fields and for invalidating caches on target edit.
+    reverseIdx: index("entry_relations_reverse_idx").on(
+      t.targetEntryId,
+      t.fieldApiId,
+    ),
+    // The same edge must not exist twice on one field.
+    uniqueEdge: uniqueIndex("entry_relations_unique_edge_idx").on(
+      t.entryId,
+      t.fieldApiId,
+      t.targetEntryId,
+    ),
+  }),
+);
+
+// ─── Inverted index for non-promoted fields ─────────────────
+
+/**
+ * Sparse index over field values that are filtered but not promoted to
+ * a generated column.
+ *
+ * This is the "inverted index" half of Karwin's serialized-LOB
+ * recommendation, and the reason this design is not wp_postmeta: rows
+ * here are written **only** for fields explicitly marked filterable,
+ * and reading an entry never touches this table — the document in
+ * `entries.dataJson` is the source of truth. It is a lookup structure,
+ * not the storage.
+ *
+ * Values are split by type so comparisons stay typed: SQLite would
+ * otherwise compare "9" > "100" as text, which is the specific failure
+ * that makes an untyped `meta_value` column useless for faceting.
+ */
+export const entryFieldIndex = sqliteTable(
+  "entry_field_index",
+  {
+    entryId: text("entry_id")
+      .notNull()
+      .references(() => entries.id, { onDelete: "cascade" }),
+    fieldApiId: text("field_api_id").notNull(),
+    /** Null for non-localized fields. */
+    locale: text("locale"),
+    valueText: text("value_text"),
+    valueNumber: integer("value_number"),
+    valueBool: integer("value_bool", { mode: "boolean" }),
+  },
+  (t) => ({
+    pk: primaryKey({
+      columns: [t.entryId, t.fieldApiId, t.locale],
+    }),
+    // Facet/filter: "entries where field X = / < / between …".
+    textLookupIdx: index("entry_field_index_text_idx").on(
+      t.fieldApiId,
+      t.valueText,
+    ),
+    numberLookupIdx: index("entry_field_index_number_idx").on(
+      t.fieldApiId,
+      t.valueNumber,
+    ),
+  }),
+);
+
+// ─── Versions ───────────────────────────────────────────────
+
+/**
+ * Generalizes `article_versions` (#68 §F). Snapshots the whole entry —
+ * document, localizations and relation edges — so a restore is exact
+ * rather than best-effort.
+ */
+export const entryVersions = sqliteTable(
+  "entry_versions",
+  {
+    id: text("id").primaryKey(),
+    entryId: text("entry_id")
+      .notNull()
+      .references(() => entries.id, { onDelete: "cascade" }),
+    /** Full snapshot: `{data, localizations, relations}`. */
+    snapshotJson: text("snapshot_json").notNull(),
+    createdBy: text("created_by"),
+    createdAt: text("created_at").notNull(),
+  },
+  (t) => ({
+    entryIdx: index("entry_versions_entry_idx").on(t.entryId, t.createdAt),
+  }),
+);
+
+// ─── Type exports ───────────────────────────────────────────
+
+export type Collection = typeof collections.$inferSelect;
+export type CollectionField = typeof collectionFields.$inferSelect;
+export type Entry = typeof entries.$inferSelect;
+export type EntryLocalization = typeof entryLocalizations.$inferSelect;
+export type EntryRelation = typeof entryRelations.$inferSelect;
+export type EntryFieldIndexRow = typeof entryFieldIndex.$inferSelect;
+export type EntryVersion = typeof entryVersions.$inferSelect;

--- a/src/lib/server/content/registry/service.ts
+++ b/src/lib/server/content/registry/service.ts
@@ -1,0 +1,1097 @@
+/**
+ * Registry service — Phase 2 (#68 §B/§C/§F).
+ *
+ * The write API for both halves of the design:
+ *
+ *  - **Schema as data** — create/alter collections and fields. No
+ *    migration, no deploy. This is the core DX win the phase exists for.
+ *  - **Entries** — create/update entries, their per-locale documents,
+ *    and their relation edges.
+ *
+ * It is also the source-agnostic import surface the task calls for: a
+ * Strapi export, a CSV, or a JSON dump all land through these same
+ * methods, so an importer is a thin script rather than part of the
+ * engine.
+ *
+ * ## Where the invariants live
+ *
+ * There is no DB constraint on a value inside a JSON document, so the
+ * service is the only enforcement point for required fields, types,
+ * enums, uniqueness and relation cardinality. Nothing may write
+ * `entries.dataJson` except through here.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { slugify } from "$lib/utils";
+import { listCollectionIds as listBuiltinCollectionIds } from "../query/registry";
+import {
+  collectionFields,
+  collections,
+  entries,
+  entryFieldIndex,
+  entryLocalizations,
+  entryRelations,
+  entryVersions,
+  type Collection,
+  type CollectionField,
+  type Entry,
+  type FieldType,
+} from "./schema";
+import {
+  assertValidApiId,
+  indexColumnFor,
+  RegistryError,
+  RELATIONAL_FIELD_TYPES,
+  validateFieldConfig,
+  type ComponentFieldConfig,
+  type RelationFieldConfig,
+} from "./types";
+import { validateFieldValue } from "./validate";
+import { PromotionService, type PromotionTarget } from "./promote";
+
+/** D1 binds at most 100 parameters per statement. */
+const D1_MAX_BIND_PARAMS = 100;
+
+/**
+ * apiIds owned by the code-defined query registry. Imported rather than
+ * hardcoded so adding a built-in collection automatically reserves its
+ * name here.
+ */
+const BUILTIN_COLLECTION_API_IDS = new Set(listBuiltinCollectionIds());
+
+export interface CollectionWithFields extends Collection {
+  fields: CollectionField[];
+}
+
+export interface CreateCollectionInput {
+  apiId: string;
+  kind?: "collection" | "single" | "component";
+  labels?: Record<string, { singular: string; plural: string }>;
+  draftPublish?: boolean;
+  localized?: boolean;
+  description?: string;
+  createdBy?: string;
+}
+
+export interface CreateFieldInput {
+  apiId: string;
+  type: FieldType;
+  labels?: Record<string, string>;
+  required?: boolean;
+  localized?: boolean;
+  unique?: boolean;
+  promoted?: boolean;
+  config?: unknown;
+  position?: number;
+}
+
+export interface UpsertEntryInput {
+  /** Omit to create. */
+  id?: string;
+  slug?: string;
+  status?: "draft" | "published" | "archived";
+  publishedAt?: string | null;
+  /** Non-localized field values, keyed by field apiId. */
+  data?: Record<string, unknown>;
+  /** Localized values: `{ en: {...}, th: {...} }`. */
+  localizations?: Record<string, Record<string, unknown>>;
+  /**
+   * Relation + component edges, keyed by field apiId. Order is
+   * significant and is persisted as `position`.
+   */
+  relations?: Record<string, string[]>;
+  createdBy?: string;
+}
+
+export class RegistryService {
+  private db: ReturnType<typeof drizzle>;
+  readonly promotions: PromotionService;
+
+  constructor(
+    private readonly d1: D1Database,
+    private readonly opts: {
+      supportedLocales: readonly string[];
+      defaultLocale: string;
+      /**
+       * Called after any write, with the collection apiIds whose cached
+       * payloads are now stale. Supplied by `createRegistryQuery` so the
+       * service stays free of a KV dependency (and testable without one).
+       *
+       * Without this, `findCached` would keep serving a pre-edit payload
+       * for the full TTL — including after a collection was deleted.
+       */
+      onWrite?: (collectionApiIds: string[]) => void;
+    },
+  ) {
+    this.db = drizzle(d1);
+    this.promotions = new PromotionService(d1);
+  }
+
+  /**
+   * Signal that these collections changed.
+   *
+   * Also invalidates every collection with a relation POINTING AT the
+   * changed ones: their cached payloads embed the edited entries, and the
+   * cache key's generation component covers each collection a query read.
+   */
+  private async invalidate(collectionApiIds: string[]): Promise<void> {
+    if (!this.opts.onWrite) return;
+    const touched = new Set(collectionApiIds);
+    try {
+      const all = await this.listCollectionsWithFields();
+      for (const c of all) {
+        for (const f of c.fields) {
+          if (!RELATIONAL_FIELD_TYPES.has(f.type)) continue;
+          const cfg = this.parseConfig(f);
+          const targets =
+            f.type === "relation"
+              ? [(cfg as RelationFieldConfig).target]
+              : ((cfg as ComponentFieldConfig).allowed ?? []);
+          if (targets.some((t) => collectionApiIds.includes(t))) {
+            touched.add(c.apiId);
+          }
+        }
+      }
+    } catch {
+      // Fall back to invalidating just the named collections — a partial
+      // invalidation beats none.
+    }
+    this.opts.onWrite(Array.from(touched));
+  }
+
+  private now() {
+    return new Date().toISOString();
+  }
+
+  // ─── Collections ──────────────────────────────────────────
+
+  async listCollections(): Promise<Collection[]> {
+    return this.db
+      .select()
+      .from(collections)
+      .orderBy(asc(collections.apiId))
+      .all();
+  }
+
+  async getCollection(apiId: string): Promise<CollectionWithFields | null> {
+    const collection = await this.db
+      .select()
+      .from(collections)
+      .where(eq(collections.apiId, apiId))
+      .limit(1)
+      .get();
+    if (!collection) return null;
+    const fields = await this.db
+      .select()
+      .from(collectionFields)
+      .where(eq(collectionFields.collectionId, collection.id))
+      .orderBy(asc(collectionFields.position), asc(collectionFields.apiId))
+      .all();
+    return { ...collection, fields };
+  }
+
+  /**
+   * Every collection with its fields, in one pair of queries.
+   *
+   * This is what builds the query-layer adapter's collection defs on
+   * each request, so it must not be 1+N over collections.
+   */
+  async listCollectionsWithFields(): Promise<CollectionWithFields[]> {
+    const all = await this.listCollections();
+    if (all.length === 0) return [];
+    const fields = await this.loadChunked(
+      all.map((c) => c.id),
+      (chunk) =>
+        this.db
+          .select()
+          .from(collectionFields)
+          .where(inArray(collectionFields.collectionId, chunk))
+          .orderBy(asc(collectionFields.position), asc(collectionFields.apiId))
+          .all(),
+    );
+    const byCollection = new Map<string, CollectionField[]>();
+    for (const f of fields) {
+      const list = byCollection.get(f.collectionId) ?? [];
+      list.push(f);
+      byCollection.set(f.collectionId, list);
+    }
+    return all.map((c) => ({ ...c, fields: byCollection.get(c.id) ?? [] }));
+  }
+
+  async createCollection(input: CreateCollectionInput): Promise<Collection> {
+    assertValidApiId(input.apiId, "collection apiId");
+
+    // A registry collection must not shadow a built-in one. The resolver
+    // prefers built-ins, so the row would be silently unreachable — the
+    // author would create a type, populate it, and never see it. Reject
+    // up front instead.
+    if (BUILTIN_COLLECTION_API_IDS.has(input.apiId)) {
+      throw new RegistryError(
+        `"${input.apiId}" is a built-in collection and cannot be redefined`,
+        "DUPLICATE_API_ID",
+      );
+    }
+
+    const existing = await this.db
+      .select({ id: collections.id })
+      .from(collections)
+      .where(eq(collections.apiId, input.apiId))
+      .limit(1)
+      .get();
+    if (existing) {
+      throw new RegistryError(
+        `A collection with apiId "${input.apiId}" already exists`,
+        "DUPLICATE_API_ID",
+      );
+    }
+
+    const id = nanoid();
+    const now = this.now();
+    await this.db.insert(collections).values({
+      id,
+      apiId: input.apiId,
+      kind: input.kind ?? "collection",
+      labelsJson: input.labels ? JSON.stringify(input.labels) : null,
+      draftPublish: input.draftPublish ?? true,
+      localized: input.localized ?? true,
+      system: false,
+      description: input.description ?? null,
+      createdBy: input.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await this.invalidate([input.apiId]);
+    return (await this.db
+      .select()
+      .from(collections)
+      .where(eq(collections.id, id))
+      .get())!;
+  }
+
+  async deleteCollection(apiId: string): Promise<void> {
+    const collection = await this.requireCollection(apiId);
+    if (collection.system) {
+      throw new RegistryError(
+        `Collection "${apiId}" is engine-owned and cannot be deleted`,
+        "SYSTEM_COLLECTION",
+      );
+    }
+    // Refuse while other collections still point here: the edges would
+    // cascade away silently and those collections' relation fields
+    // would be left targeting something that no longer exists.
+    const referencing = await this.findReferencingFields(apiId);
+    if (referencing.length > 0) {
+      throw new RegistryError(
+        `Cannot delete "${apiId}" — still targeted by: ${referencing.join(", ")}`,
+        "INVALID_CONFIG",
+      );
+    }
+    // entries + fields cascade via FK.
+    await this.db.delete(collections).where(eq(collections.id, collection.id));
+    await this.invalidate([apiId]);
+  }
+
+  /** `collection.field` paths of every relation/component field targeting apiId. */
+  private async findReferencingFields(apiId: string): Promise<string[]> {
+    const all = await this.listCollectionsWithFields();
+    const hits: string[] = [];
+    for (const c of all) {
+      if (c.apiId === apiId) continue;
+      for (const f of c.fields) {
+        if (!RELATIONAL_FIELD_TYPES.has(f.type)) continue;
+        const cfg = this.parseConfig(f);
+        if (
+          f.type === "relation" &&
+          (cfg as RelationFieldConfig).target === apiId
+        ) {
+          hits.push(`${c.apiId}.${f.apiId}`);
+        }
+        if (
+          f.type === "component" &&
+          (cfg as ComponentFieldConfig).allowed?.includes(apiId)
+        ) {
+          hits.push(`${c.apiId}.${f.apiId}`);
+        }
+      }
+    }
+    return hits;
+  }
+
+  // ─── Fields ───────────────────────────────────────────────
+
+  async addField(
+    collectionApiId: string,
+    input: CreateFieldInput,
+  ): Promise<CollectionField> {
+    assertValidApiId(input.apiId, "field apiId");
+    const collection = await this.requireCollection(collectionApiId);
+
+    const config = validateFieldConfig(input.type, input.config ?? {});
+
+    // A relation/component field must point at collections that exist,
+    // or populate would fail at read time on every entry.
+    await this.assertTargetsExist(input.type, config);
+
+    const duplicate = await this.db
+      .select({ id: collectionFields.id })
+      .from(collectionFields)
+      .where(
+        and(
+          eq(collectionFields.collectionId, collection.id),
+          eq(collectionFields.apiId, input.apiId),
+        ),
+      )
+      .limit(1)
+      .get();
+    if (duplicate) {
+      throw new RegistryError(
+        `Field "${input.apiId}" already exists on "${collectionApiId}"`,
+        "DUPLICATE_API_ID",
+      );
+    }
+
+    if (input.localized && !collection.localized) {
+      throw new RegistryError(
+        `Cannot add a localized field to "${collectionApiId}" — the collection is not localized`,
+        "INVALID_CONFIG",
+      );
+    }
+    if (input.promoted && RELATIONAL_FIELD_TYPES.has(input.type)) {
+      throw new RegistryError(
+        `Relational field "${input.apiId}" cannot be promoted — its values live in entry_relations, not the document`,
+        "INVALID_CONFIG",
+      );
+    }
+
+    const id = nanoid();
+    const now = this.now();
+    await this.db.insert(collectionFields).values({
+      id,
+      collectionId: collection.id,
+      apiId: input.apiId,
+      type: input.type,
+      labelsJson: input.labels ? JSON.stringify(input.labels) : null,
+      required: input.required ?? false,
+      localized: input.localized ?? false,
+      unique: input.unique ?? false,
+      promoted: input.promoted ?? false,
+      configJson: JSON.stringify(config),
+      position: input.position ?? 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Promotion is real DDL, so it happens after the registry row is
+    // committed: if the ALTER fails (budget exhausted) the definition
+    // still stands and an admin can retry or un-promote, rather than
+    // losing the field.
+    if (input.promoted) {
+      await this.promotions.promote({
+        collectionApiId,
+        fieldApiId: input.apiId,
+        fieldType: input.type,
+        localized: input.localized ?? false,
+      });
+    }
+
+    await this.invalidate([collectionApiId]);
+    return (await this.db
+      .select()
+      .from(collectionFields)
+      .where(eq(collectionFields.id, id))
+      .get())!;
+  }
+
+  async removeField(
+    collectionApiId: string,
+    fieldApiId: string,
+  ): Promise<void> {
+    const collection = await this.requireCollection(collectionApiId);
+    const field = collection.fields.find((f) => f.apiId === fieldApiId);
+    if (!field) {
+      throw new RegistryError(
+        `Field "${fieldApiId}" not found on "${collectionApiId}"`,
+        "UNKNOWN_FIELD",
+      );
+    }
+    if (field.promoted) {
+      await this.promotions.unpromote({ collectionApiId, fieldApiId });
+    }
+    await this.db
+      .delete(collectionFields)
+      .where(eq(collectionFields.id, field.id));
+    // Edges and index rows for this field are now orphaned; remove them
+    // so a re-added field of the same name doesn't inherit stale data.
+    await this.db
+      .delete(entryRelations)
+      .where(eq(entryRelations.fieldApiId, fieldApiId));
+    await this.db
+      .delete(entryFieldIndex)
+      .where(eq(entryFieldIndex.fieldApiId, fieldApiId));
+    // The value stays in each entry's dataJson. Deliberate: removing a
+    // field by mistake shouldn't destroy content, and re-adding it
+    // restores the data. Orphaned keys are ignored on read because
+    // projection is driven by the registry, not by the document.
+    await this.invalidate([collectionApiId]);
+  }
+
+  /** Reconcile promoted columns for every collection. Safe at boot. */
+  async reconcilePromotions() {
+    const all = await this.listCollectionsWithFields();
+    const targets: PromotionTarget[] = [];
+    for (const c of all) {
+      for (const f of c.fields) {
+        if (!f.promoted) continue;
+        targets.push({
+          collectionApiId: c.apiId,
+          fieldApiId: f.apiId,
+          fieldType: f.type,
+          localized: f.localized,
+        });
+      }
+    }
+    return this.promotions.reconcile(targets);
+  }
+
+  // ─── Entries ──────────────────────────────────────────────
+
+  async getEntry(id: string): Promise<Entry | null> {
+    return (
+      (await this.db.select().from(entries).where(eq(entries.id, id)).get()) ??
+      null
+    );
+  }
+
+  /**
+   * Create or update an entry, its localizations, and its relation
+   * edges.
+   *
+   * D1 has no interactive transactions, so this is a sequence of
+   * statements rather than an atomic unit. Ordering is chosen so a
+   * partial failure leaves something coherent: the base row first (an
+   * entry with missing localizations is recoverable), edges last (they
+   * are the cheapest to recompute).
+   */
+  async upsertEntry(
+    collectionApiId: string,
+    input: UpsertEntryInput,
+  ): Promise<Entry> {
+    const collection = await this.requireCollection(collectionApiId);
+    const fieldsByApiId = new Map(collection.fields.map((f) => [f.apiId, f]));
+    const now = this.now();
+
+    // A `single` collection may only ever hold one entry.
+    if (collection.kind === "single" && !input.id) {
+      const existing = await this.db
+        .select({ id: entries.id })
+        .from(entries)
+        .where(eq(entries.collectionId, collection.id))
+        .limit(1)
+        .get();
+      if (existing) {
+        throw new RegistryError(
+          `Collection "${collectionApiId}" is a single type and already has an entry`,
+          "CARDINALITY_VIOLATION",
+        );
+      }
+    }
+
+    // ── Validate the non-localized document
+    const document = this.buildDocument(
+      collection.fields.filter((f) => !f.localized),
+      input.data ?? {},
+      { requireAll: !input.id },
+    );
+
+    // ── Validate each locale's document
+    //
+    // On create, the default locale is validated even when the caller
+    // sent no `localizations` at all: the loop below only visits locales
+    // that were supplied, so omitting the key entirely would skip every
+    // required-localized-field check — exactly the case those checks
+    // exist for.
+    const suppliedLocalizations = { ...(input.localizations ?? {}) };
+    const hasRequiredLocalized = collection.fields.some(
+      (f) => f.localized && f.required,
+    );
+    if (
+      !input.id &&
+      hasRequiredLocalized &&
+      !suppliedLocalizations[this.opts.defaultLocale]
+    ) {
+      suppliedLocalizations[this.opts.defaultLocale] = {};
+    }
+
+    const localizedDocs: Record<string, Record<string, unknown>> = {};
+    for (const [locale, values] of Object.entries(suppliedLocalizations)) {
+      if (!this.opts.supportedLocales.includes(locale)) {
+        throw new RegistryError(
+          `Unsupported locale "${locale}". Supported: ${this.opts.supportedLocales.join(", ")}`,
+          "INVALID_LOCALE",
+        );
+      }
+      localizedDocs[locale] = this.buildDocument(
+        collection.fields.filter((f) => f.localized),
+        values,
+        // Required localized fields are only enforced for the default
+        // locale: demanding every translation up front would make a
+        // partially-translated site impossible, which is the normal
+        // editorial state.
+        { requireAll: !input.id && locale === this.opts.defaultLocale },
+      );
+    }
+
+    // ── Slug
+    let slug = input.slug;
+    if (slug !== undefined) {
+      slug = slugify(slug);
+    } else if (!input.id && collection.kind !== "component") {
+      slug = this.deriveSlug(collection, localizedDocs, document);
+    }
+    if (slug) {
+      await this.assertSlugAvailable(collection.id, slug, input.id);
+    }
+
+    // ── Uniqueness on fields marked unique
+    await this.assertUniqueFields(
+      collection,
+      document,
+      localizedDocs,
+      input.id,
+    );
+
+    const entryId = input.id ?? nanoid();
+
+    if (input.id) {
+      const existing = await this.getEntry(input.id);
+      if (!existing) {
+        throw new RegistryError(
+          `Entry "${input.id}" not found`,
+          "UNKNOWN_COLLECTION",
+        );
+      }
+      // Snapshot before mutating so history is complete (#68 §F).
+      await this.snapshot(existing, input.createdBy ?? null);
+
+      // Merge rather than replace: a caller sending only `{title}` must
+      // not blank every other field.
+      const merged = { ...safeParseObject(existing.dataJson), ...document };
+      await this.db
+        .update(entries)
+        .set({
+          ...(slug !== undefined ? { slug } : {}),
+          ...(input.status ? { status: input.status } : {}),
+          ...(input.publishedAt !== undefined
+            ? { publishedAt: input.publishedAt }
+            : {}),
+          dataJson: JSON.stringify(merged),
+          updatedAt: now,
+        })
+        .where(eq(entries.id, entryId));
+    } else {
+      const status =
+        input.status ?? (collection.draftPublish ? "draft" : "published");
+      await this.db.insert(entries).values({
+        id: entryId,
+        collectionId: collection.id,
+        slug: slug ?? null,
+        status,
+        publishedAt: input.publishedAt ?? (status === "published" ? now : null),
+        dataJson: JSON.stringify(document),
+        createdBy: input.createdBy ?? null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    // ── Localizations (merge per locale, same reasoning as above)
+    for (const [locale, doc] of Object.entries(localizedDocs)) {
+      const existing = await this.db
+        .select()
+        .from(entryLocalizations)
+        .where(
+          and(
+            eq(entryLocalizations.entryId, entryId),
+            eq(entryLocalizations.locale, locale),
+          ),
+        )
+        .limit(1)
+        .get();
+      if (existing) {
+        const merged = { ...safeParseObject(existing.dataJson), ...doc };
+        await this.db
+          .update(entryLocalizations)
+          .set({ dataJson: JSON.stringify(merged), updatedAt: now })
+          .where(eq(entryLocalizations.id, existing.id));
+      } else {
+        await this.db.insert(entryLocalizations).values({
+          id: nanoid(),
+          entryId,
+          locale,
+          dataJson: JSON.stringify(doc),
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    }
+
+    // ── Relation edges
+    if (input.relations) {
+      for (const [fieldApiId, targetIds] of Object.entries(input.relations)) {
+        const field = fieldsByApiId.get(fieldApiId);
+        if (!field || !RELATIONAL_FIELD_TYPES.has(field.type)) {
+          throw new RegistryError(
+            `"${fieldApiId}" is not a relation or component field on "${collectionApiId}"`,
+            "UNKNOWN_FIELD",
+          );
+        }
+        await this.setRelation(entryId, field, targetIds);
+      }
+    }
+
+    // ── Inverted index for filterable non-promoted fields
+    await this.reindexEntry(entryId, collection, document, localizedDocs);
+
+    await this.invalidate([collectionApiId]);
+    return (await this.getEntry(entryId))!;
+  }
+
+  async deleteEntry(id: string): Promise<void> {
+    // entry_localizations / entry_relations / entry_field_index /
+    // entry_versions all cascade on the FK.
+    await this.db.delete(entries).where(eq(entries.id, id));
+  }
+
+  // ─── Relations ────────────────────────────────────────────
+
+  /**
+   * Replace a field's edges with `targetIds`, in order.
+   *
+   * Replace rather than append: a form submits the full desired list, so
+   * append semantics would make removal impossible.
+   */
+  async setRelation(
+    entryId: string,
+    field: CollectionField,
+    targetIds: string[],
+  ): Promise<void> {
+    const config = this.parseConfig(field);
+    const cardinality =
+      field.type === "relation"
+        ? (config as RelationFieldConfig).cardinality
+        : (config as ComponentFieldConfig).cardinality;
+
+    const unique = Array.from(new Set(targetIds));
+    if (cardinality === "one" && unique.length > 1) {
+      throw new RegistryError(
+        `Field "${field.apiId}" accepts a single target but ${unique.length} were given`,
+        "CARDINALITY_VIOLATION",
+      );
+    }
+
+    // Targets must exist and be of an allowed collection. Without this
+    // an edge can point at an entry of the wrong type, and populate
+    // would return objects with an unexpected shape.
+    if (unique.length > 0) {
+      await this.assertValidTargets(field, config, unique);
+    }
+
+    await this.db
+      .delete(entryRelations)
+      .where(
+        and(
+          eq(entryRelations.entryId, entryId),
+          eq(entryRelations.fieldApiId, field.apiId),
+        ),
+      );
+
+    if (unique.length === 0) return;
+
+    const now = this.now();
+    const rows = unique.map((targetEntryId, i) => ({
+      id: nanoid(),
+      entryId,
+      fieldApiId: field.apiId,
+      targetEntryId,
+      position: i,
+      createdAt: now,
+    }));
+    // 5 columns per row against a 100-parameter ceiling → 20 rows max
+    // per statement.
+    const perStatement = Math.floor(D1_MAX_BIND_PARAMS / 6);
+    for (let i = 0; i < rows.length; i += perStatement) {
+      await this.db
+        .insert(entryRelations)
+        .values(rows.slice(i, i + perStatement));
+    }
+  }
+
+  private async assertValidTargets(
+    field: CollectionField,
+    config: unknown,
+    targetIds: string[],
+  ): Promise<void> {
+    const allowedApiIds =
+      field.type === "relation"
+        ? [(config as RelationFieldConfig).target]
+        : (config as ComponentFieldConfig).allowed;
+
+    const allowed = await this.db
+      .select({ id: collections.id, apiId: collections.apiId })
+      .from(collections)
+      .where(inArray(collections.apiId, allowedApiIds))
+      .all();
+    const allowedIds = new Set(allowed.map((c) => c.id));
+
+    const found = await this.loadChunked(targetIds, (chunk) =>
+      this.db
+        .select({ id: entries.id, collectionId: entries.collectionId })
+        .from(entries)
+        .where(inArray(entries.id, chunk))
+        .all(),
+    );
+    const foundById = new Map(found.map((e) => [e.id, e]));
+
+    for (const targetId of targetIds) {
+      const target = foundById.get(targetId);
+      if (!target) {
+        throw new RegistryError(
+          `Field "${field.apiId}": target entry "${targetId}" does not exist`,
+          "INVALID_VALUE",
+        );
+      }
+      if (!allowedIds.has(target.collectionId)) {
+        throw new RegistryError(
+          `Field "${field.apiId}": target "${targetId}" is not one of ${allowedApiIds.join(", ")}`,
+          "INVALID_VALUE",
+        );
+      }
+    }
+  }
+
+  private async assertTargetsExist(
+    type: FieldType,
+    config: unknown,
+  ): Promise<void> {
+    if (!RELATIONAL_FIELD_TYPES.has(type)) return;
+    const wanted =
+      type === "relation"
+        ? [(config as RelationFieldConfig).target]
+        : (config as ComponentFieldConfig).allowed;
+    const found = await this.db
+      .select({ apiId: collections.apiId, kind: collections.kind })
+      .from(collections)
+      .where(inArray(collections.apiId, wanted))
+      .all();
+    const foundIds = new Set(found.map((c) => c.apiId));
+    for (const apiId of wanted) {
+      if (!foundIds.has(apiId)) {
+        throw new RegistryError(
+          `Target collection "${apiId}" does not exist`,
+          "UNKNOWN_COLLECTION",
+        );
+      }
+    }
+    // A component field must point at component-kind collections; a
+    // relation field must not. Mixing them would let a page embed a
+    // whole addressable Article as if it were a layout block.
+    if (type === "component") {
+      for (const c of found) {
+        if (c.kind !== "component") {
+          throw new RegistryError(
+            `"${c.apiId}" is a ${c.kind}, not a component — component fields may only nest component collections`,
+            "INVALID_CONFIG",
+          );
+        }
+      }
+    }
+  }
+
+  // ─── Internals ────────────────────────────────────────────
+
+  private async requireCollection(
+    apiId: string,
+  ): Promise<CollectionWithFields> {
+    const collection = await this.getCollection(apiId);
+    if (!collection) {
+      throw new RegistryError(
+        `Unknown collection "${apiId}"`,
+        "UNKNOWN_COLLECTION",
+      );
+    }
+    return collection;
+  }
+
+  private parseConfig(field: CollectionField): unknown {
+    return field.configJson ? safeParseObject(field.configJson) : {};
+  }
+
+  /**
+   * Validate a set of incoming values against field definitions.
+   *
+   * Unknown keys are rejected rather than ignored: a typo'd field name
+   * silently vanishing is how content goes missing without anyone
+   * noticing.
+   */
+  private buildDocument(
+    fields: CollectionField[],
+    values: Record<string, unknown>,
+    opts: { requireAll: boolean },
+  ): Record<string, unknown> {
+    const byApiId = new Map(fields.map((f) => [f.apiId, f]));
+    for (const key of Object.keys(values)) {
+      if (!byApiId.has(key)) {
+        throw new RegistryError(`Unknown field "${key}"`, "UNKNOWN_FIELD");
+      }
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (RELATIONAL_FIELD_TYPES.has(field.type)) continue;
+      const provided = Object.prototype.hasOwnProperty.call(
+        values,
+        field.apiId,
+      );
+      // On update, a field the caller didn't mention keeps its stored
+      // value — so "required" is only checked when the field is absent
+      // on create, or explicitly cleared on update.
+      if (!provided && !opts.requireAll) continue;
+      const value = validateFieldValue(field, values[field.apiId]);
+      if (value !== undefined) out[field.apiId] = value;
+    }
+    return out;
+  }
+
+  private deriveSlug(
+    collection: CollectionWithFields,
+    localizedDocs: Record<string, Record<string, unknown>>,
+    document: Record<string, unknown>,
+  ): string | undefined {
+    // Prefer an explicit slug-typed field, then a title/name, mirroring
+    // the repo's existing English-derived-slug convention.
+    const slugField = collection.fields.find((f) => f.type === "slug");
+    const titleField = collection.fields.find(
+      (f) => f.apiId === "title" || f.apiId === "name",
+    );
+    const source =
+      (slugField &&
+        (document[slugField.apiId] ??
+          localizedDocs[this.opts.defaultLocale]?.[slugField.apiId])) ??
+      (titleField &&
+        (document[titleField.apiId] ??
+          localizedDocs[this.opts.defaultLocale]?.[titleField.apiId]));
+    if (typeof source !== "string" || !source) return undefined;
+    const slug = slugify(source);
+    return slug || undefined;
+  }
+
+  private async assertSlugAvailable(
+    collectionId: string,
+    slug: string,
+    excludeEntryId?: string,
+  ): Promise<void> {
+    const clash = await this.db
+      .select({ id: entries.id })
+      .from(entries)
+      .where(
+        and(eq(entries.collectionId, collectionId), eq(entries.slug, slug)),
+      )
+      .limit(1)
+      .get();
+    if (clash && clash.id !== excludeEntryId) {
+      throw new RegistryError(
+        `Slug "${slug}" is already used in this collection`,
+        "UNIQUE_VIOLATION",
+      );
+    }
+  }
+
+  /**
+   * Enforce `unique` on fields that declare it.
+   *
+   * Uses the inverted index rather than scanning documents — that's what
+   * it's for. Not race-free (D1 has no interactive transaction and this
+   * is a check-then-write), so a simultaneous duplicate can slip
+   * through; the check catches the realistic editorial case rather than
+   * a deliberate race.
+   */
+  private async assertUniqueFields(
+    collection: CollectionWithFields,
+    document: Record<string, unknown>,
+    localizedDocs: Record<string, Record<string, unknown>>,
+    excludeEntryId?: string,
+  ): Promise<void> {
+    const uniqueFields = collection.fields.filter((f) => f.unique);
+    if (uniqueFields.length === 0) return;
+
+    for (const field of uniqueFields) {
+      const column = indexColumnFor(field.type);
+      if (!column) continue;
+
+      // A localized unique field is unique PER LOCALE: two entries may
+      // share an English name only if neither collides in the same
+      // locale. Comparing the incoming default-locale value against
+      // index rows for every locale (the earlier behaviour) made a Thai
+      // value block an unrelated English one.
+      const checks: { locale: string | null; value: unknown }[] =
+        field.localized
+          ? Object.entries(localizedDocs).map(([locale, doc]) => ({
+              locale,
+              value: doc[field.apiId],
+            }))
+          : [{ locale: null, value: document[field.apiId] }];
+
+      for (const check of checks) {
+        if (check.value === undefined || check.value === null) continue;
+
+        // Joined against `entries` rather than using a subquery: scoping
+        // by collection matters (two collections may both have a unique
+        // `code`), and a real INNER JOIN is unambiguous across drizzle
+        // versions where passing a query builder to inArray is not.
+        const hits = await this.db
+          .select({ entryId: entryFieldIndex.entryId })
+          .from(entryFieldIndex)
+          .innerJoin(entries, eq(entries.id, entryFieldIndex.entryId))
+          .where(
+            and(
+              eq(entries.collectionId, collection.id),
+              eq(entryFieldIndex.fieldApiId, field.apiId),
+              eq(entryFieldIndex[column], check.value as never),
+              check.locale === null
+                ? isNull(entryFieldIndex.locale)
+                : eq(entryFieldIndex.locale, check.locale),
+            ),
+          )
+          .all();
+
+        if (hits.some((h) => h.entryId !== excludeEntryId)) {
+          throw new RegistryError(
+            `Field "${field.apiId}" must be unique — value already used${
+              check.locale ? ` in locale "${check.locale}"` : ""
+            }`,
+            "UNIQUE_VIOLATION",
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Rewrite this entry's rows in the inverted index.
+   *
+   * Only fields that are filterable and NOT promoted are indexed:
+   * a promoted field already has a real generated column plus a real
+   * index, so a row here would be pure duplication.
+   */
+  private async reindexEntry(
+    entryId: string,
+    collection: CollectionWithFields,
+    document: Record<string, unknown>,
+    localizedDocs: Record<string, Record<string, unknown>>,
+  ): Promise<void> {
+    await this.db
+      .delete(entryFieldIndex)
+      .where(eq(entryFieldIndex.entryId, entryId));
+
+    const rows: (typeof entryFieldIndex.$inferInsert)[] = [];
+
+    const push = (
+      field: CollectionField,
+      locale: string | null,
+      value: unknown,
+    ) => {
+      const column = indexColumnFor(field.type);
+      if (!column || value === undefined || value === null) return;
+      rows.push({
+        entryId,
+        fieldApiId: field.apiId,
+        locale,
+        valueText: column === "valueText" ? String(value) : null,
+        valueNumber: column === "valueNumber" ? Number(value) : null,
+        valueBool: column === "valueBool" ? Boolean(value) : null,
+      });
+    };
+
+    for (const field of collection.fields) {
+      if (field.promoted) continue;
+      if (field.localized) {
+        for (const [locale, doc] of Object.entries(localizedDocs)) {
+          push(field, locale, doc[field.apiId]);
+        }
+      } else {
+        push(field, null, document[field.apiId]);
+      }
+    }
+
+    if (rows.length === 0) return;
+    // 6 columns per row → 16 rows per statement under the 100-param cap.
+    const perStatement = Math.floor(D1_MAX_BIND_PARAMS / 6);
+    for (let i = 0; i < rows.length; i += perStatement) {
+      await this.db
+        .insert(entryFieldIndex)
+        .values(rows.slice(i, i + perStatement));
+    }
+  }
+
+  /** Snapshot an entry's full state, including relations. */
+  private async snapshot(entry: Entry, actorId: string | null): Promise<void> {
+    const [locs, rels] = await Promise.all([
+      this.db
+        .select()
+        .from(entryLocalizations)
+        .where(eq(entryLocalizations.entryId, entry.id))
+        .all(),
+      this.db
+        .select()
+        .from(entryRelations)
+        .where(eq(entryRelations.entryId, entry.id))
+        .orderBy(asc(entryRelations.position))
+        .all(),
+    ]);
+    await this.db.insert(entryVersions).values({
+      id: nanoid(),
+      entryId: entry.id,
+      snapshotJson: JSON.stringify({
+        slug: entry.slug,
+        status: entry.status,
+        publishedAt: entry.publishedAt,
+        data: safeParseObject(entry.dataJson),
+        localizations: Object.fromEntries(
+          locs.map((l) => [l.locale, safeParseObject(l.dataJson)]),
+        ),
+        relations: rels.map((r) => ({
+          fieldApiId: r.fieldApiId,
+          targetEntryId: r.targetEntryId,
+          position: r.position,
+        })),
+      }),
+      createdBy: actorId,
+      createdAt: this.now(),
+    });
+  }
+
+  private async loadChunked<T>(
+    ids: string[],
+    load: (chunk: string[]) => Promise<T[]>,
+  ): Promise<T[]> {
+    if (ids.length === 0) return [];
+    if (ids.length <= D1_MAX_BIND_PARAMS) return load(ids);
+    const out: T[] = [];
+    for (let i = 0; i < ids.length; i += D1_MAX_BIND_PARAMS) {
+      out.push(...(await load(ids.slice(i, i + D1_MAX_BIND_PARAMS))));
+    }
+    return out;
+  }
+}
+
+function safeParseObject(json: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/lib/server/content/registry/types.ts
+++ b/src/lib/server/content/registry/types.ts
@@ -1,0 +1,398 @@
+/**
+ * Registry types + per-field-type config contracts — Phase 2 (#68 §B).
+ *
+ * `collection_fields.configJson` is a different shape per field `type`.
+ * These are the shapes, plus the validators that police them, so a
+ * malformed field definition is rejected at write time rather than
+ * discovered when the admin form fails to render.
+ */
+import type { FieldType } from "./schema";
+
+/** Cardinality of a `relation` field. */
+export type RelationCardinality = "one" | "many";
+
+export interface RelationFieldConfig {
+  /** apiId of the target collection. */
+  target: string;
+  cardinality: RelationCardinality;
+  /**
+   * Optional inverse name. When set, the target collection can populate
+   * back along this edge without declaring its own field.
+   */
+  inverseOf?: string;
+}
+
+export interface ComponentFieldConfig {
+  /**
+   * apiIds of the `component`-kind collections allowed here. More than
+   * one makes this a dynamic zone: an ordered, mixed list of blocks.
+   */
+  allowed: string[];
+  /** A single nested component vs an ordered list. */
+  cardinality: RelationCardinality;
+}
+
+export interface EnumFieldConfig {
+  /** Stored values. Labels are per-locale in the field's labelsJson. */
+  options: string[];
+}
+
+export interface NumberFieldConfig {
+  min?: number;
+  max?: number;
+  /** Reject non-integers. */
+  integer?: boolean;
+}
+
+export interface TextFieldConfig {
+  minLength?: number;
+  maxLength?: number;
+  /** Anchored automatically; see `compilePattern`. */
+  pattern?: string;
+}
+
+export interface MediaFieldConfig {
+  cardinality: RelationCardinality;
+  /** e.g. ["image/png","image/jpeg"]. Empty/absent = any. */
+  mimeTypes?: string[];
+}
+
+export type FieldConfig =
+  | RelationFieldConfig
+  | ComponentFieldConfig
+  | EnumFieldConfig
+  | NumberFieldConfig
+  | TextFieldConfig
+  | MediaFieldConfig
+  | Record<string, never>;
+
+/** Raised for an invalid registry definition or entry payload. */
+export class RegistryError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "UNKNOWN_COLLECTION"
+      | "UNKNOWN_FIELD"
+      | "DUPLICATE_API_ID"
+      | "INVALID_API_ID"
+      | "INVALID_FIELD_TYPE"
+      | "INVALID_CONFIG"
+      | "INVALID_VALUE"
+      | "REQUIRED_FIELD_MISSING"
+      | "UNIQUE_VIOLATION"
+      | "INVALID_LOCALE"
+      | "CARDINALITY_VIOLATION"
+      | "IMMUTABLE"
+      | "SYSTEM_COLLECTION"
+      | "PROMOTION_BUDGET_EXCEEDED"
+      | "CYCLE_DETECTED",
+  ) {
+    super(message);
+    this.name = "RegistryError";
+  }
+}
+
+/**
+ * Machine names are used as JSON keys, URL segments, and — for promoted
+ * fields — SQL identifiers. Restricting them to this shape is what lets
+ * `promote.ts` build DDL by interpolation without an injection surface:
+ * a name that matches this cannot contain a quote, space, or semicolon.
+ *
+ * Leading digit excluded so a name is always a valid identifier.
+ *
+ * **Consecutive underscores are also excluded**, which is what reserves
+ * `__` as an unambiguous separator for promoted column names
+ * (`q_<collection>__<field>`). Without that reservation, collection
+ * `blog_post` + field `title` and collection `blog` + field `post_title`
+ * would collide on one column and silently read the wrong JSON path.
+ */
+export const API_ID_PATTERN = /^[a-z](?:_?[a-z0-9])*$/;
+
+/** Length cap, checked separately so the pattern stays readable. */
+const API_ID_MAX_LENGTH = 63;
+
+/**
+ * Reserved because they collide with real columns on `entries`, with
+ * engine-injected keys, or with SQLite internals. A field named `id`
+ * would be shadowed by the row's own id on read.
+ */
+const RESERVED_API_IDS = new Set([
+  "id",
+  "collectionid",
+  "collection_id",
+  "slug",
+  "status",
+  "publishedat",
+  "published_at",
+  "datajson",
+  "data_json",
+  "createdat",
+  "created_at",
+  "updatedat",
+  "updated_at",
+  "createdby",
+  "created_by",
+  "locale",
+  "localizations",
+  "rowid",
+  "oid",
+  "_rowid_",
+]);
+
+export function assertValidApiId(apiId: string, what: string): void {
+  if (!API_ID_PATTERN.test(apiId) || apiId.length > API_ID_MAX_LENGTH) {
+    throw new RegistryError(
+      `Invalid ${what} "${apiId}" — must be lowercase, start with a letter, ` +
+        `contain only letters/digits/single underscores, and be at most ` +
+        `${API_ID_MAX_LENGTH} characters`,
+      "INVALID_API_ID",
+    );
+  }
+  if (RESERVED_API_IDS.has(apiId.toLowerCase())) {
+    throw new RegistryError(
+      `"${apiId}" is reserved and cannot be used as a ${what}`,
+      "INVALID_API_ID",
+    );
+  }
+}
+
+/**
+ * Field types whose values live in `entry_relations` rather than in the
+ * entry document. They have no JSON representation at all.
+ */
+export const RELATIONAL_FIELD_TYPES = new Set<FieldType>([
+  "relation",
+  "component",
+]);
+
+/**
+ * Field types that can be promoted to a generated column.
+ *
+ * Excluded: `json` (no single scalar to extract), and the relational
+ * types (not in the document). `richtext` is excluded too — promoting a
+ * long body would bloat the index for no filtering benefit; full-text
+ * search is FTS5's job, not a generated column's.
+ */
+export const PROMOTABLE_FIELD_TYPES = new Set<FieldType>([
+  "text",
+  "number",
+  "boolean",
+  "date",
+  "datetime",
+  "email",
+  "url",
+  "slug",
+  "enum",
+]);
+
+/** Which typed column of `entry_field_index` a field's value belongs in. */
+export function indexColumnFor(
+  type: FieldType,
+): "valueText" | "valueNumber" | "valueBool" | null {
+  switch (type) {
+    case "number":
+      return "valueNumber";
+    case "boolean":
+      return "valueBool";
+    case "text":
+    case "date":
+    case "datetime":
+    case "email":
+    case "url":
+    case "slug":
+    case "enum":
+      return "valueText";
+    // richtext/json are not filterable; relational types aren't in the
+    // document at all.
+    default:
+      return null;
+  }
+}
+
+/**
+ * Validate a field's `configJson` against its type. Returns the parsed
+ * config so callers get a typed value rather than re-parsing.
+ */
+export function validateFieldConfig(
+  type: FieldType,
+  raw: unknown,
+): FieldConfig {
+  const cfg = (raw ?? {}) as Record<string, unknown>;
+
+  switch (type) {
+    case "relation": {
+      const target = cfg.target;
+      if (typeof target !== "string" || !target) {
+        throw new RegistryError(
+          "relation field requires config.target (a collection apiId)",
+          "INVALID_CONFIG",
+        );
+      }
+      const cardinality = cfg.cardinality ?? "one";
+      if (cardinality !== "one" && cardinality !== "many") {
+        throw new RegistryError(
+          'relation config.cardinality must be "one" or "many"',
+          "INVALID_CONFIG",
+        );
+      }
+      if (cfg.inverseOf !== undefined && typeof cfg.inverseOf !== "string") {
+        throw new RegistryError(
+          "relation config.inverseOf must be a string",
+          "INVALID_CONFIG",
+        );
+      }
+      return {
+        target,
+        cardinality,
+        ...(typeof cfg.inverseOf === "string"
+          ? { inverseOf: cfg.inverseOf }
+          : {}),
+      };
+    }
+
+    case "component": {
+      const allowed = cfg.allowed;
+      if (
+        !Array.isArray(allowed) ||
+        allowed.length === 0 ||
+        !allowed.every((a) => typeof a === "string" && a)
+      ) {
+        throw new RegistryError(
+          "component field requires a non-empty config.allowed array of component collection apiIds",
+          "INVALID_CONFIG",
+        );
+      }
+      const cardinality = cfg.cardinality ?? "many";
+      if (cardinality !== "one" && cardinality !== "many") {
+        throw new RegistryError(
+          'component config.cardinality must be "one" or "many"',
+          "INVALID_CONFIG",
+        );
+      }
+      return { allowed: allowed as string[], cardinality };
+    }
+
+    case "enum": {
+      const options = cfg.options;
+      if (
+        !Array.isArray(options) ||
+        options.length === 0 ||
+        !options.every((o) => typeof o === "string" && o)
+      ) {
+        throw new RegistryError(
+          "enum field requires a non-empty config.options array of strings",
+          "INVALID_CONFIG",
+        );
+      }
+      if (new Set(options).size !== options.length) {
+        throw new RegistryError(
+          "enum config.options contains duplicates",
+          "INVALID_CONFIG",
+        );
+      }
+      return { options: options as string[] };
+    }
+
+    case "number": {
+      const { min, max, integer } = cfg;
+      for (const [k, v] of [
+        ["min", min],
+        ["max", max],
+      ] as const) {
+        if (v !== undefined && typeof v !== "number") {
+          throw new RegistryError(
+            `number config.${k} must be a number`,
+            "INVALID_CONFIG",
+          );
+        }
+      }
+      if (typeof min === "number" && typeof max === "number" && min > max) {
+        throw new RegistryError(
+          "number config.min cannot exceed config.max",
+          "INVALID_CONFIG",
+        );
+      }
+      return {
+        ...(typeof min === "number" ? { min } : {}),
+        ...(typeof max === "number" ? { max } : {}),
+        ...(integer === true ? { integer: true } : {}),
+      };
+    }
+
+    case "media": {
+      const cardinality = cfg.cardinality ?? "one";
+      if (cardinality !== "one" && cardinality !== "many") {
+        throw new RegistryError(
+          'media config.cardinality must be "one" or "many"',
+          "INVALID_CONFIG",
+        );
+      }
+      const mimeTypes = cfg.mimeTypes;
+      if (
+        mimeTypes !== undefined &&
+        (!Array.isArray(mimeTypes) ||
+          !mimeTypes.every((m) => typeof m === "string"))
+      ) {
+        throw new RegistryError(
+          "media config.mimeTypes must be an array of strings",
+          "INVALID_CONFIG",
+        );
+      }
+      return {
+        cardinality,
+        ...(Array.isArray(mimeTypes)
+          ? { mimeTypes: mimeTypes as string[] }
+          : {}),
+      };
+    }
+
+    case "text":
+    case "slug":
+    case "email":
+    case "url": {
+      const { minLength, maxLength, pattern } = cfg;
+      for (const [k, v] of [
+        ["minLength", minLength],
+        ["maxLength", maxLength],
+      ] as const) {
+        if (v !== undefined && (typeof v !== "number" || v < 0)) {
+          throw new RegistryError(
+            `text config.${k} must be a non-negative number`,
+            "INVALID_CONFIG",
+          );
+        }
+      }
+      if (pattern !== undefined) {
+        if (typeof pattern !== "string") {
+          throw new RegistryError(
+            "text config.pattern must be a string",
+            "INVALID_CONFIG",
+          );
+        }
+        // Reject at definition time rather than letting an unparseable
+        // pattern throw on every entry write.
+        try {
+          new RegExp(pattern);
+        } catch {
+          throw new RegistryError(
+            `text config.pattern is not a valid regular expression: ${pattern}`,
+            "INVALID_CONFIG",
+          );
+        }
+      }
+      return {
+        ...(typeof minLength === "number" ? { minLength } : {}),
+        ...(typeof maxLength === "number" ? { maxLength } : {}),
+        ...(typeof pattern === "string" ? { pattern } : {}),
+      };
+    }
+
+    // No configurable options.
+    case "richtext":
+    case "boolean":
+    case "date":
+    case "datetime":
+    case "json":
+      return {};
+  }
+}

--- a/src/lib/server/content/registry/validate.ts
+++ b/src/lib/server/content/registry/validate.ts
@@ -1,0 +1,267 @@
+/**
+ * Entry payload validation — Phase 2.
+ *
+ * The registry is the schema, so it is also the only thing standing
+ * between a caller and the entry document. There is no DB constraint to
+ * fall back on: `dataJson` will happily store anything. Every value
+ * therefore gets checked here, on the way in.
+ */
+import type { CollectionField, FieldType } from "./schema";
+import {
+  RegistryError,
+  validateFieldConfig,
+  type EnumFieldConfig,
+  type NumberFieldConfig,
+  type TextFieldConfig,
+} from "./types";
+
+/** ISO-8601 date (`2026-07-30`). */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+/** Pragmatic email check — deliberately not RFC 5322. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Coerce and validate one field value.
+ *
+ * Returns the value to store. Returns `undefined` for "absent", which
+ * the caller omits from the document rather than storing as null — a
+ * missing key and an explicit null mean different things when a field is
+ * later added to an existing collection.
+ */
+export function validateFieldValue(
+  field: Pick<CollectionField, "apiId" | "type" | "required" | "configJson">,
+  raw: unknown,
+): unknown {
+  const absent = raw === undefined || raw === null || raw === "";
+  if (absent) {
+    if (field.required) {
+      throw new RegistryError(
+        `Field "${field.apiId}" is required`,
+        "REQUIRED_FIELD_MISSING",
+      );
+    }
+    return undefined;
+  }
+
+  const config = validateFieldConfig(
+    field.type,
+    field.configJson ? safeParse(field.configJson) : {},
+  );
+
+  switch (field.type) {
+    case "text":
+    case "richtext":
+    case "slug": {
+      const s = expectString(field.apiId, raw);
+      checkTextConstraints(field.apiId, s, config as TextFieldConfig);
+      return s;
+    }
+
+    case "email": {
+      const s = expectString(field.apiId, raw);
+      checkTextConstraints(field.apiId, s, config as TextFieldConfig);
+      if (!EMAIL_RE.test(s)) {
+        throw new RegistryError(
+          `Field "${field.apiId}" is not a valid email address`,
+          "INVALID_VALUE",
+        );
+      }
+      return s;
+    }
+
+    case "url": {
+      const s = expectString(field.apiId, raw);
+      checkTextConstraints(field.apiId, s, config as TextFieldConfig);
+      let parsed: URL;
+      try {
+        parsed = new URL(s);
+      } catch {
+        throw new RegistryError(
+          `Field "${field.apiId}" is not a valid URL`,
+          "INVALID_VALUE",
+        );
+      }
+      // Only http(s). A stored `javascript:` or `data:` URL becomes an
+      // XSS vector the moment a template renders it into an href.
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be an http(s) URL (got "${parsed.protocol}")`,
+          "INVALID_VALUE",
+        );
+      }
+      return s;
+    }
+
+    case "number": {
+      const n = typeof raw === "string" ? Number(raw) : raw;
+      if (typeof n !== "number" || !Number.isFinite(n)) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be a finite number`,
+          "INVALID_VALUE",
+        );
+      }
+      const cfg = config as NumberFieldConfig;
+      if (cfg.integer && !Number.isInteger(n)) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be an integer`,
+          "INVALID_VALUE",
+        );
+      }
+      if (cfg.min !== undefined && n < cfg.min) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be >= ${cfg.min}`,
+          "INVALID_VALUE",
+        );
+      }
+      if (cfg.max !== undefined && n > cfg.max) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be <= ${cfg.max}`,
+          "INVALID_VALUE",
+        );
+      }
+      return n;
+    }
+
+    case "boolean": {
+      if (typeof raw === "boolean") return raw;
+      if (raw === "true" || raw === "1" || raw === 1) return true;
+      if (raw === "false" || raw === "0" || raw === 0) return false;
+      throw new RegistryError(
+        `Field "${field.apiId}" must be a boolean`,
+        "INVALID_VALUE",
+      );
+    }
+
+    case "date": {
+      const s = expectString(field.apiId, raw);
+      if (!DATE_RE.test(s) || Number.isNaN(Date.parse(s))) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be an ISO date (YYYY-MM-DD)`,
+          "INVALID_VALUE",
+        );
+      }
+      return s;
+    }
+
+    case "datetime": {
+      const s = expectString(field.apiId, raw);
+      const t = Date.parse(s);
+      if (Number.isNaN(t)) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be an ISO datetime`,
+          "INVALID_VALUE",
+        );
+      }
+      // Normalize so sorting and range filters compare consistently —
+      // "2026-07-30T00:00+07:00" and its UTC equivalent must not sort
+      // as different strings.
+      return new Date(t).toISOString();
+    }
+
+    case "enum": {
+      const s = expectString(field.apiId, raw);
+      const { options } = config as EnumFieldConfig;
+      if (!options.includes(s)) {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be one of: ${options.join(", ")}`,
+          "INVALID_VALUE",
+        );
+      }
+      return s;
+    }
+
+    case "json": {
+      // Stored as-is, but it must survive a round-trip: a value with a
+      // cycle or a BigInt would throw at JSON.stringify time, after
+      // other fields had already been written.
+      try {
+        JSON.parse(JSON.stringify(raw));
+      } catch {
+        throw new RegistryError(
+          `Field "${field.apiId}" must be JSON-serializable`,
+          "INVALID_VALUE",
+        );
+      }
+      return raw;
+    }
+
+    case "media": {
+      // Media ids, not URLs — entries reference media by id and serving
+      // stays with the existing /api/media route.
+      const ids = Array.isArray(raw) ? raw : [raw];
+      for (const id of ids) {
+        if (typeof id !== "string" || !id) {
+          throw new RegistryError(
+            `Field "${field.apiId}" must be a media id (or array of ids)`,
+            "INVALID_VALUE",
+          );
+        }
+      }
+      return Array.isArray(raw) ? ids : ids[0];
+    }
+
+    case "relation":
+    case "component":
+      // Not stored in the document — these live in entry_relations and
+      // are handled by the service, which needs to write edge rows.
+      throw new RegistryError(
+        `Field "${field.apiId}" is relational and cannot be set as a document value`,
+        "INVALID_VALUE",
+      );
+  }
+}
+
+function expectString(apiId: string, raw: unknown): string {
+  if (typeof raw !== "string") {
+    throw new RegistryError(
+      `Field "${apiId}" must be a string`,
+      "INVALID_VALUE",
+    );
+  }
+  return raw;
+}
+
+function checkTextConstraints(
+  apiId: string,
+  value: string,
+  cfg: TextFieldConfig,
+): void {
+  if (cfg.minLength !== undefined && value.length < cfg.minLength) {
+    throw new RegistryError(
+      `Field "${apiId}" must be at least ${cfg.minLength} characters`,
+      "INVALID_VALUE",
+    );
+  }
+  if (cfg.maxLength !== undefined && value.length > cfg.maxLength) {
+    throw new RegistryError(
+      `Field "${apiId}" must be at most ${cfg.maxLength} characters`,
+      "INVALID_VALUE",
+    );
+  }
+  if (cfg.pattern !== undefined) {
+    // Anchored so a pattern like `[a-z]+` means "the whole value",
+    // which is what a schema author intends. An unanchored test would
+    // accept "abc!!!" for `^?[a-z]+$?`.
+    const anchored = new RegExp(`^(?:${cfg.pattern})$`);
+    if (!anchored.test(value)) {
+      throw new RegistryError(
+        `Field "${apiId}" does not match the required pattern`,
+        "INVALID_VALUE",
+      );
+    }
+  }
+}
+
+function safeParse(json: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return {};
+  }
+}
+
+/** Types whose document value is an array. */
+export function isMultiValue(type: FieldType, config: unknown): boolean {
+  if (type !== "media") return false;
+  return (config as { cardinality?: string })?.cardinality === "many";
+}

--- a/src/routes/api/public/entries/[collection]/+server.ts
+++ b/src/routes/api/public/entries/[collection]/+server.ts
@@ -1,0 +1,101 @@
+/**
+ * GET /api/public/entries/[collection] — read user-defined content.
+ *
+ * The Phase 2 counterpart to `/api/public/content/[collection]`, which
+ * serves the built-in code-defined types. Same Strapi-shaped params,
+ * same engine, same populate/cache behaviour — the only difference is
+ * that these collections were created by inserting registry rows rather
+ * than by writing Drizzle schema:
+ *
+ *   /api/public/entries/product_line
+ *     ?populate=variants,brand&locale=th&sort=-publishedAt
+ *
+ * ## Auth
+ *
+ * Registry collections have no per-collection API scope — scopes are a
+ * closed union in the code (`articles:read` … ), and a user-defined type
+ * cannot mint a new one at runtime. So this endpoint requires the
+ * catch-all `*:read`. That is deliberately conservative: a key limited
+ * to `articles:read` must not silently gain access to every content type
+ * an admin invents later.
+ *
+ * Per-collection scopes for registry types need the scope column to
+ * become open text, which is a migration and an admin-UI change — out of
+ * scope for Phase 2 and explicitly out of scope for the whole task
+ * ("no per-collection RBAC").
+ */
+import { json } from "@sveltejs/kit";
+import { authenticate, hasScope } from "$lib/server/api-auth";
+import { parseFindQuery, QueryError } from "$lib/server/content/query";
+import { createRegistryQuery } from "$lib/server/content/registry";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({
+  params,
+  url,
+  request,
+  locals,
+  platform,
+}) => {
+  const env = platform?.env;
+  if (!env) {
+    return json({ error: "Platform not ready" }, { status: 503 });
+  }
+
+  const auth = await authenticate(request, locals.content);
+  if (!auth.ok || !auth.key) {
+    return json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth.key, "*:read")) {
+    return json(
+      {
+        error: "Forbidden — *:read scope required for user-defined collections",
+      },
+      { status: 403 },
+    );
+  }
+
+  const registry = createRegistryQuery(env);
+
+  // 404 before parsing, so a bad collection name doesn't surface as a
+  // confusing filter error.
+  const available = await registry.listCollections();
+  if (!available.includes(params.collection)) {
+    return json(
+      { error: `Unknown collection "${params.collection}"` },
+      { status: 404 },
+    );
+  }
+
+  let query;
+  try {
+    query = parseFindQuery(url);
+  } catch (err) {
+    if (err instanceof QueryError) {
+      return json({ error: err.message, code: err.code }, { status: 400 });
+    }
+    throw err;
+  }
+
+  // Published-only, and the scheduled-publishing guard applied by the
+  // engine. Set after parsing so a caller's own `filters[status]` is
+  // overwritten rather than merged.
+  const filters = { ...(query.filters ?? {}), status: { $eq: "published" } };
+
+  try {
+    const result = await registry.findCached(params.collection, {
+      ...query,
+      filters,
+      onlyPublished: true,
+    });
+    return json(
+      { data: result.data, meta: result.meta },
+      { headers: { "cache-control": "public, max-age=60" } },
+    );
+  } catch (err) {
+    if (err instanceof QueryError) {
+      return json({ error: err.message, code: err.code }, { status: 400 });
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
Phase 2 of #68. **Content types and fields become data**: adding a type is an INSERT into `collections` + `collection_fields` — no migration, no deploy. The engine tables themselves ship as migration `0020`.

Builds directly on Phase 1 (#90). Admin UI stays Phase 4, as specified.

## Storage

- Entry scalars in **one JSON document** (`entries.data_json`); per-locale scalars in `entry_localizations.data_json`
- **All** relations — 1:1, 1:n, n:m — in the single `entry_relations` table, with `position` for ordered relations. A curated product list needs it, and for a dynamic zone the block order *is* the layout. `article_tags` can't express order; this can.
- Components are collections with `kind='component'` — nested-only, never addressable on their own
- `locale` is plain text, **not an enum** (#68 §E). Adding a locale no longer means a migration across ~8 tables.
- `entry_versions` generalizes `article_versions`, snapshotting document + localizations + edges so a restore is exact

## Hot-field promotion — the part that makes it fast

SQLite's `json_extract` is **O(N) in document size**, so an unindexed JSON filter scans every row. A field marked `promoted` gets a `VIRTUAL` generated column plus an index — the pattern [Cloudflare explicitly recommends](https://developers.cloudflare.com/d1/sql-api/query-json/). VIRTUAL because SQLite can only `ADD` that kind to an existing table.

Verified against local D1 rather than asserted:

```
EXPLAIN QUERY PLAN
  SELECT * FROM entries WHERE collection_id=? AND q_variant__weight_kg > 15
→ SEARCH entries USING INDEX idx_q_variant__weight_kg
```

An actual index seek, and numeric filters compare as numbers (`> 15` returns the 18kg variant, not "9 > 100" string ordering).

Promotion is **opt-in per field with a hard budget check**: D1 caps a table at 100 columns and every promotion across every collection spends from that one budget. That ceiling — not join performance — is the real constraint here, and it's the same wall SonicJS documents.

## Composition with Phase 1

The engine is reused unchanged in substance. Three small generic seams keep it oblivious to which storage backs a collection:

- `flattenRow` — lift JSON document keys before projection
- `scopeFilter` — registry collections share one table
- an injectable collection resolver

Built-ins win on name collision, and `createCollection` rejects those names up front anyway.

## Why the registry, against the standing #68 verdict

The 2026-07-28 verdict overturned this design. Re-research found **all three of its pillars failed** — full write-up in [the correction comment](https://github.com/codustry/khaopad/issues/68#issuecomment-5120307316):

1. The Cloudflare "avoid runtime DDL" quote **isn't in current docs**; today's wording narrows the rationale to REST-API rate limits.
2. Payload does **not** use real SQL joins for `hasMany` — reading shipped source, relations fold into the join only when single-valued *and* monomorphic, and the list path hardcodes `depth: 0`. Code-first buys none of the claimed advantage for catalog-shaped relations.
3. wp_postmeta argues against **per-field EAV**, not against one-document-per-entry. Karwin's own essay — the source of that whole argument — lists "serialized LOB with an inverted index" among its *recommended* alternatives, and Akeneo migrated *toward* this shape in 2.0.

SonicJS ships essentially this design on D1 today.

## Bug hunt — 6 defects found and fixed before commit

1. **BLOCKER — cross-collection + draft leak.** Populate loaded targets by id alone, ignoring the target's `scopeFilter` *and* `status`. Since registry collections share `entries`, a mistyped edge could return another content type's row projected through this collection's field names, and drafts rode along inside published parents. Targets now inherit the root query's visibility.
2. **BLOCKER — `populate=*` hard-failed.** Components were excluded from resolution, so the documented example threw `UNKNOWN_COLLECTION` on any collection with a component field. They're now resolvable but still not query roots.
3. **No cache invalidation on any registry write.** `findCached` served pre-edit content for the full TTL, including after a collection was deleted. Now invalidates the written collection plus every collection with a relation pointing at it.
4. **Uniqueness was broken two ways** — passed a drizzle query builder into `inArray` (unreliable across versions), and compared one locale's value against every locale's index rows, so a Thai value blocked an unrelated English one. Now a real `INNER JOIN`, per locale.
5. **Required localized fields were skipped** entirely when the caller sent no `localizations` key at all — the exact case the check exists for.
6. **Promoted column names could collide.** `blog_post`+`title` and `blog`+`post_title` both produced `q_blog_post_title`; the second promotion silently no-op'd onto the wrong JSON path, giving wrong filter results with no error. Separator is now `__`, and apiIds forbid consecutive underscores to reserve it.

## Verification

Migration applied and seed run against local D1:

```
4 collections · 16 fields · 7 entries · 14 localizations · 6 ordered edges · 4 promoted columns
```

Three-level graph traverses (`alpha-series → brand → northwind`, ordered `variants[0]→a100, [1]→a200`), collections stay isolated in the shared table, index seeks confirmed.

`pnpm check` clean apart from the 3 pre-existing paraglide errors. ESLint clean on all touched files. `pnpm build` passes.

> Note on `pnpm lint`: it fails repo-wide on ~556 files of pre-existing Prettier drift — a file taken straight from `main` fails too. New files here are formatted; the backlog is untouched and worth its own PR.

## Seed / import path

`pnpm db:seed:registry` loads `scripts/fixtures/registry-demo.json` — a three-level catalog with an ordered component and EN+TH content. Deliberately **source-agnostic**: the importer is a thin script over the public write API, so a Strapi export, a CSV, or another CMS's dump is a different reader against the same methods. Nothing client-specific is in the engine; `brand`/`product_line`/`variant` are ordinary user collections defined through the registry.

## Known limits

- **Promoted columns are effectively permanent.** SQLite can't drop a column an index references, so `unpromote` drops only the index; the column stays inert and still consumes budget. `budget()` reports that honestly rather than pretending the space came back.
- A dynamic zone allowing several component collections resolves against the first; per-edge type resolution lands with the Phase 4 block editor that renders them.
- Registry collections require `*:read` — API scopes are a closed union in code and a runtime-defined type can't mint one. Per-collection scopes are explicitly out of scope for this task.
- Uniqueness is check-then-write, so a deliberate race can still slip a duplicate through (D1 has no interactive transactions).

## Remaining phases

Phase 3 (typed spec/attribute layer, #88) and Phase 4 (registry-driven admin UI + `entry_versions` wiring). Phase 3 does not strictly depend on this PR — `attribute_values` keys off `(entity_type, entity_id)` and works against today's tables too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
