### PR TITLE
chore(infra): provision real Cloudflare envs + fix deploy DB-name resolution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,11 @@ jobs:
     outputs:
       environment: ${{ steps.pick.outputs.environment }}
       public_url: ${{ steps.pick.outputs.public_url }}
+      d1_name: ${{ steps.pick.outputs.d1_name }}
     steps:
+      # Needed so the step below can read the D1 name out of wrangler.toml.
+      - uses: actions/checkout@v4
+
       - id: pick
         env:
           STAGING_URL: ${{ vars.STAGING_PUBLIC_URL }}
@@ -88,9 +92,27 @@ jobs:
           else
             URL="${STAGING_URL:-}"
           fi
+          # D1 name is read from wrangler.toml rather than hardcoded, so the
+          # two can never drift apart again. `wrangler d1 migrations apply`
+          # resolves the name inside the selected env, so passing the
+          # top-level default name with `--env staging` fails outright.
+          D1_NAME=$(
+            awk -v env="$ENV" '
+              $0 ~ "^\\[\\[env\\." env "\\.d1_databases\\]\\]" { inblock=1; next }
+              inblock && /^\[/ { inblock=0 }
+              inblock && /^database_name/ {
+                gsub(/^database_name[[:space:]]*=[[:space:]]*"|"$/, ""); print; exit
+              }
+            ' wrangler.toml
+          )
+          if [[ -z "$D1_NAME" ]]; then
+            echo "::error::No d1_databases entry found for env '$ENV' in wrangler.toml" >&2
+            exit 1
+          fi
           echo "environment=$ENV" >> "$GITHUB_OUTPUT"
           echo "public_url=$URL" >> "$GITHUB_OUTPUT"
-          echo "→ deploying to: $ENV (url: ${URL:-<unset>})"
+          echo "d1_name=$D1_NAME" >> "$GITHUB_OUTPUT"
+          echo "→ deploying to: $ENV (db: $D1_NAME, url: ${URL:-<unset>})"
 
   # ──────────────────────────────────────
   # Deploy: migrate D1, then deploy the Worker.
@@ -123,7 +145,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply khaopad-db --remote --env ${{ needs.resolve-env.outputs.environment }}
+          # The DB name must match the one declared under the SELECTED env
+          # in wrangler.toml, not the top-level default — wrangler resolves
+          # the name within the chosen env and errors otherwise. staging
+          # uses `khaopad-db-staging`; production uses `khaopad-db`.
+          command: d1 migrations apply ${{ needs.resolve-env.outputs.d1_name }} --remote --env ${{ needs.resolve-env.outputs.environment }}
 
       - name: Deploy Worker (${{ needs.resolve-env.outputs.environment }})
         uses: cloudflare/wrangler-action@v3

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,7 +20,7 @@ assets = { directory = ".svelte-kit/cloudflare", binding = "ASSETS" }
 [[d1_databases]]
 binding = "DB"
 database_name = "khaopad-db"
-database_id = "LOCAL_DB_ID"           # Replace with actual D1 ID for production
+database_id = "046fad4d-f438-4c1c-97b9-28ed2cf58d40"
 migrations_dir = "drizzle"
 
 # ──────────────────────────────────────
@@ -35,7 +35,7 @@ bucket_name = "khaopad-media"
 # ──────────────────────────────────────
 [[kv_namespaces]]
 binding = "CONTENT_CACHE"
-id = "LOCAL_KV_ID"                    # Replace with actual KV ID for production
+id = "8fccdd8be6c944058d7e4e95c3793b0d"
 
 # ──────────────────────────────────────
 # Environment variables
@@ -80,7 +80,7 @@ BETTER_AUTH_URL = "https://staging.example.com"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "khaopad-db-staging"
-database_id = "STAGING_DB_ID"
+database_id = "f5a80c39-9339-4f71-a63b-84bc5806c2ad"
 migrations_dir = "drizzle"
 
 [[env.staging.r2_buckets]]
@@ -89,7 +89,7 @@ bucket_name = "khaopad-media-staging"
 
 [[env.staging.kv_namespaces]]
 binding = "CONTENT_CACHE"
-id = "STAGING_KV_ID"
+id = "05c40ce176a446b4b948ece08a6fc32a"
 
 [env.production]
 name = "khaopad"
@@ -107,7 +107,7 @@ BETTER_AUTH_URL = "https://example.com"
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "khaopad-db"
-database_id = "PRODUCTION_DB_ID"
+database_id = "046fad4d-f438-4c1c-97b9-28ed2cf58d40"
 migrations_dir = "drizzle"
 
 [[env.production.r2_buckets]]
@@ -116,7 +116,7 @@ bucket_name = "khaopad-media"
 
 [[env.production.kv_namespaces]]
 binding = "CONTENT_CACHE"
-id = "PRODUCTION_KV_ID"
+id = "8fccdd8be6c944058d7e4e95c3793b0d"
 
 # ──────────────────────────────────────
 # Cron Triggers (v3.2 shop plugin)


### PR DESCRIPTION
Follow-up to #92. Fixing the lint gate let the deploy pipeline advance one step further, where it hit the next problem: **the D1 databases it targets did not exist, and the workflow asked for the wrong one anyway.**

## Two separate bugs

**1. Wrong DB name for the env.** The workflow hardcoded `d1 migrations apply khaopad-db --env staging`, but `[env.staging]` declares `khaopad-db-staging`. Wrangler resolves the name *within* the selected env, so this could never have worked:

```
✘ Couldn't find a D1 DB with the name or binding 'khaopad-db' in your wrangler.toml file.
```

The name is now read out of `wrangler.toml` for the resolved env, so config and workflow can't drift apart again. `resolve-env` gained an `actions/checkout` (it needs the file) and fails loudly if no `d1_databases` entry exists for the target env, rather than passing an empty name to wrangler.

**2. Placeholder resource IDs.** All five bindings were literal strings — `LOCAL_DB_ID`, `STAGING_DB_ID`, `PRODUCTION_DB_ID`, `STAGING_KV_ID`, `PRODUCTION_KV_ID` — with "replace me" comments.

## Resources created

Codustry account `4becdbe0…`. Distinct from the demo's `khaopad-example-*` resources, which are untouched.

| Resource | Type | ID |
|---|---|---|
| `khaopad-db-staging` | D1 (APAC) | `f5a80c39-9339-4f71-a63b-84bc5806c2ad` |
| `khaopad-db` | D1 (APAC) | `046fad4d-f438-4c1c-97b9-28ed2cf58d40` |
| `khaopad-media-staging` | R2 | — |
| `khaopad-media` | R2 | — |
| `khaopad-staging-CONTENT_CACHE` | KV | `05c40ce176a446b4b948ece08a6fc32a` |
| `khaopad-CONTENT_CACHE` | KV | `8fccdd8be6c944058d7e4e95c3793b0d` |

D1 primary region is APAC, matching the Thailand-first stack. Top-level (bare `wrangler dev --remote`) bindings point at the production DB/KV, matching the original comment's intent.

## Verified, not assumed

- `wrangler deploy --dry-run --env staging` resolves every binding
- All 20 migrations applied to the real staging D1; `sqlite_master` reports **66 tables**, served from APAC/KIX
- The name extraction returns `khaopad-db-staging` for staging, `khaopad-db` for production

## ⚠️ Still required before CI can deploy — needs a human

These cannot be set from a coding session:

- **`CLOUDFLARE_API_TOKEN`** — repo secret, must be created by you
- **`CLOUDFLARE_ACCOUNT_ID`** — repo secret, value is `4becdbe083803fc00f06fdfb6d0bcc17`
- **`STAGING_PUBLIC_URL`** / **`PRODUCTION_PUBLIC_URL`** — repo variables, used by the smoke test

For reference, `codustry/khaopad-example` already has `CLOUDFLARE_ACCOUNT_ID` and both URL variables set, but no API token either — so it has been deploying manually.

**Also unresolved:** `[env.staging].vars` still points at `https://staging.example.com`. `BETTER_AUTH_URL` must match the real origin or auth cookies silently break, so inventing a hostname would be worse than leaving it. Needs a deliberate choice (e.g. `khaopad-staging.codustry.workers.dev`).

## Worth reconsidering

This gives the engine repo its own staging + production, which is genuinely useful for testing migrations before they reach the demo. But it also means **two full CMS deployments of the same product**, each with its own database, bucket, and admin panel. If you'd rather collapse to the demo as the single deployment, everything created here is trivially deletable and nothing depends on it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)