### PR TITLE
feat(v3.6-phase3): typed spec/attribute layer — datasheets, compare, facet

### DIFF
--- a/drizzle/0021_spec_attributes.sql
+++ b/drizzle/0021_spec_attributes.sql
@@ -1,0 +1,139 @@
+-- Phase 3 of #88 — typed spec/attribute layer.
+--
+-- Gives a catalog's leaf entity structured, unit-aware, QUERYABLE specs.
+-- Rich text cannot back a datasheet: you can't sort a <div> by flow rate,
+-- facet on "ultimate pressure < 0.1 mbar", or diff two variants
+-- column-by-column.
+--
+-- Akeneo's three primitives, sized down for SQLite: definitions (what an
+-- attribute is), families (which attributes a product type carries),
+-- values (normalized, indexed).
+--
+-- On the EAV question: this is a NARROW, registry-disciplined table, not
+-- the wp_postmeta pattern #68 rejected. Values are split into typed
+-- columns so `value_number BETWEEN ?` compares as a number; every
+-- attribute_id resolves to a typed definition so there is no free-text
+-- meta_key to diverge; and cardinality is bounded by what a family
+-- declares. Entry content itself still lives in entries.data_json.
+--
+-- Nothing here is client-specific. `entity_type` is free text, so values
+-- attach to a Phase 2 registry entry, a shop variant, or anything else
+-- with a stable id.
+
+CREATE TABLE `attribute_definitions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `key` text NOT NULL,
+  `data_type` text NOT NULL,
+  `measure_family` text,
+  `standard_unit` text,
+  `options_json` text,
+  `group_key` text,
+  `position` integer DEFAULT 0 NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `attribute_definitions_key_unique` ON `attribute_definitions` (`key`);--> statement-breakpoint
+CREATE INDEX `attribute_definitions_data_type_idx` ON `attribute_definitions` (`data_type`);--> statement-breakpoint
+CREATE INDEX `attribute_definitions_group_idx` ON `attribute_definitions` (`group_key`,`position`);--> statement-breakpoint
+
+-- Per-locale labels, following the repo's base-row + sibling
+-- _localizations convention. `locale` is plain TEXT, not a CHECK enum —
+-- same reasoning as Phase 2: the older content tables bake ("th","en")
+-- into ~8 schemas, so adding a locale means a migration everywhere.
+CREATE TABLE `attribute_definition_localizations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `attribute_id` text NOT NULL,
+  `locale` text NOT NULL,
+  `label` text NOT NULL,
+  `description` text,
+  `option_labels_json` text,
+  FOREIGN KEY (`attribute_id`) REFERENCES `attribute_definitions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `attribute_definition_localizations_attr_locale_idx` ON `attribute_definition_localizations` (`attribute_id`,`locale`);--> statement-breakpoint
+
+-- A family is a named attribute set ('vacuum_pump', 'blower'). This is
+-- the answer to "different product families have different specs":
+-- distinct sets rather than one sparse wide table full of nulls.
+CREATE TABLE `attribute_families` (
+  `id` text PRIMARY KEY NOT NULL,
+  `key` text NOT NULL,
+  `labels_json` text,
+  `description` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `attribute_families_key_unique` ON `attribute_families` (`key`);--> statement-breakpoint
+
+CREATE TABLE `family_attributes` (
+  `family_id` text NOT NULL,
+  `attribute_id` text NOT NULL,
+  `required` integer DEFAULT false NOT NULL,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `is_variant_axis` integer DEFAULT false NOT NULL,
+  `created_at` text NOT NULL,
+  PRIMARY KEY (`family_id`, `attribute_id`),
+  FOREIGN KEY (`family_id`) REFERENCES `attribute_families`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`attribute_id`) REFERENCES `attribute_definitions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `family_attributes_family_order_idx` ON `family_attributes` (`family_id`,`sort_order`);--> statement-breakpoint
+-- Reverse lookup: "which families use this attribute?" — checked before
+-- allowing a definition to be deleted.
+CREATE INDEX `family_attributes_attribute_idx` ON `family_attributes` (`attribute_id`);--> statement-breakpoint
+
+-- Binds an entity to a family. Separate table because entities live in
+-- several places (registry entries, shop variants) and none of them
+-- should grow a column for this.
+CREATE TABLE `entity_families` (
+  `entity_type` text NOT NULL,
+  `entity_id` text NOT NULL,
+  `family_id` text NOT NULL,
+  `created_at` text NOT NULL,
+  PRIMARY KEY (`entity_type`, `entity_id`),
+  FOREIGN KEY (`family_id`) REFERENCES `attribute_families`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `entity_families_family_idx` ON `entity_families` (`family_id`);--> statement-breakpoint
+
+-- The values table.
+--
+-- `value_number` ALWAYS holds the standard-unit magnitude for
+-- measurements, with `value_unit` preserving what the editor typed. That
+-- split is what makes both of these correct at once:
+--   facet/sort — WHERE attribute_id=? AND value_number BETWEEN ? AND ?
+--                works across mixed authored units
+--   display    — the datasheet still renders "0.1 mbar", not "10 Pa"
+--
+-- REAL, not INTEGER: vacuum pressures (1e-3 mbar) and small flows
+-- (0.06 m3/h) need fractions.
+CREATE TABLE `attribute_values` (
+  `id` text PRIMARY KEY NOT NULL,
+  `entity_type` text NOT NULL,
+  `entity_id` text NOT NULL,
+  `attribute_id` text NOT NULL,
+  `locale` text,
+  `value_number` real,
+  `value_unit` text,
+  `value_text` text,
+  `value_json` text,
+  `value_bool` integer,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`attribute_id`) REFERENCES `attribute_definitions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+-- One value per (entity, attribute, locale) — without this a second
+-- write duplicates instead of updating, and a datasheet renders the
+-- attribute twice.
+CREATE UNIQUE INDEX `attribute_values_entity_attr_idx` ON `attribute_values` (`entity_type`,`entity_id`,`attribute_id`,`locale`);--> statement-breakpoint
+-- Datasheet assembly: every value for one entity.
+CREATE INDEX `attribute_values_entity_idx` ON `attribute_values` (`entity_type`,`entity_id`);--> statement-breakpoint
+-- The index that makes "pumping speed 100-300 m3/h" an index seek
+-- rather than a full scan.
+CREATE INDEX `attribute_values_numeric_facet_idx` ON `attribute_values` (`attribute_id`,`value_number`);--> statement-breakpoint
+CREATE INDEX `attribute_values_text_facet_idx` ON `attribute_values` (`attribute_id`,`value_text`);

--- a/drizzle/0021_spec_attributes.sql
+++ b/drizzle/0021_spec_attributes.sql
@@ -116,7 +116,13 @@ CREATE TABLE `attribute_values` (
   `entity_type` text NOT NULL,
   `entity_id` text NOT NULL,
   `attribute_id` text NOT NULL,
-  `locale` text,
+  -- NOT NULL with a '*' sentinel for non-localized values, NOT nullable.
+  -- SQLite treats NULLs as distinct in a UNIQUE index, so a nullable
+  -- locale would make the (entity, attribute, locale) constraint below
+  -- silently unenforceable for the common non-localized case: two rows
+  -- for the same entity+attribute would both be accepted, and a
+  -- datasheet would render the attribute twice.
+  `locale` text DEFAULT '*' NOT NULL,
   `value_number` real,
   `value_unit` text,
   `value_text` text,

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1785426900000,
       "tag": "0020_collection_registry",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1785513300000,
+      "tag": "0021_spec_attributes",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "setup": "tsx scripts/setup.ts",
     "wrangler:dev": "wrangler dev",
     "deploy": "pnpm build && wrangler deploy",
-    "db:seed:registry": "tsx scripts/seed-registry-demo.ts"
+    "db:seed:registry": "tsx scripts/seed-registry-demo.ts",
+    "db:seed:specs": "tsx scripts/seed-specs-demo.ts"
   },
   "dependencies": {
     "@inlang/paraglide-js": "^2.0.0",

--- a/scripts/fixtures/specs-demo.json
+++ b/scripts/fixtures/specs-demo.json
@@ -1,0 +1,155 @@
+{
+  "_readme": [
+    "Phase 3 spec/attribute demo fixture (#88).",
+    "",
+    "Attaches typed, unit-aware specs to the entities created by",
+    "scripts/fixtures/registry-demo.json. Run `pnpm db:seed:registry`",
+    "first, then `pnpm db:seed:specs`.",
+    "",
+    "NOTE the units are deliberately INCONSISTENT between entities:",
+    "  a100 flow authored in m3/h   (63)",
+    "  a200 flow authored in m3/min (100  -> 6000 m3/h)",
+    "  a100 pressure in mbar        (0.1  -> 10 Pa)",
+    "  a200 pressure in Torr        (1    -> 133.32 Pa)",
+    "",
+    "That is the test, not an oversight. Normalization means a facet of",
+    "'flow_rate >= 100 m3/h' correctly returns a200 (6000) and NOT a100",
+    "(63) — even though a100's authored number is smaller and a200's",
+    "authored number happens to equal the threshold. Comparing authored",
+    "numbers naively would get this exactly backwards.",
+    "",
+    "Nothing here is engine knowledge. 'vacuum_pump', 'flow_rate' etc are",
+    "ordinary user-defined attributes, the same as any other catalog's."
+  ],
+
+  "attributes": [
+    {
+      "key": "flow_rate",
+      "dataType": "measurement",
+      "measureFamily": "flow",
+      "groupKey": "performance",
+      "position": 1,
+      "labels": { "en": "Flow rate", "th": "อัตราการไหล" }
+    },
+    {
+      "key": "ultimate_pressure",
+      "dataType": "measurement",
+      "measureFamily": "pressure",
+      "groupKey": "performance",
+      "position": 2,
+      "labels": { "en": "Ultimate pressure", "th": "ความดันสุดท้าย" }
+    },
+    {
+      "key": "motor_power",
+      "dataType": "measurement",
+      "measureFamily": "power",
+      "groupKey": "electrical",
+      "position": 3,
+      "labels": { "en": "Motor power", "th": "กำลังมอเตอร์" }
+    },
+    {
+      "key": "supply_voltage",
+      "dataType": "measurement",
+      "measureFamily": "voltage",
+      "groupKey": "electrical",
+      "position": 4,
+      "labels": { "en": "Supply voltage", "th": "แรงดันไฟฟ้า" }
+    },
+    {
+      "key": "net_weight",
+      "dataType": "measurement",
+      "measureFamily": "mass",
+      "groupKey": "mechanical",
+      "position": 5,
+      "labels": { "en": "Net weight", "th": "น้ำหนักสุทธิ" }
+    },
+    {
+      "key": "inlet_size",
+      "dataType": "measurement",
+      "measureFamily": "length",
+      "groupKey": "mechanical",
+      "position": 6,
+      "labels": { "en": "Inlet size", "th": "ขนาดท่อเข้า" }
+    },
+    {
+      "key": "oil_free",
+      "dataType": "boolean",
+      "groupKey": "mechanical",
+      "position": 7,
+      "labels": { "en": "Oil-free", "th": "ไม่ใช้น้ำมัน" }
+    },
+    {
+      "key": "pump_type",
+      "dataType": "select",
+      "options": ["rotary_vane", "dry_screw", "diaphragm"],
+      "groupKey": "mechanical",
+      "position": 8,
+      "labels": { "en": "Pump type", "th": "ชนิดปั๊ม" }
+    },
+    {
+      "key": "certifications",
+      "dataType": "multiselect",
+      "options": ["ce", "iso9001", "ul"],
+      "groupKey": "compliance",
+      "position": 9,
+      "labels": { "en": "Certifications", "th": "การรับรอง" }
+    }
+  ],
+
+  "families": [
+    {
+      "key": "vacuum_pump",
+      "attributes": [
+        {
+          "key": "flow_rate",
+          "required": true,
+          "sortOrder": 1,
+          "isVariantAxis": true
+        },
+        { "key": "ultimate_pressure", "required": true, "sortOrder": 2 },
+        { "key": "motor_power", "sortOrder": 3 },
+        { "key": "supply_voltage", "sortOrder": 4 },
+        { "key": "net_weight", "sortOrder": 5 },
+        { "key": "inlet_size", "sortOrder": 6 },
+        { "key": "oil_free", "sortOrder": 7 },
+        { "key": "pump_type", "sortOrder": 8 },
+        { "key": "certifications", "sortOrder": 9 }
+      ]
+    }
+  ],
+
+  "entities": [
+    {
+      "entityType": "entry",
+      "entityId": "seed_ent_variant_a100",
+      "family": "vacuum_pump",
+      "values": {
+        "flow_rate": { "value": 63, "unit": "m3/h" },
+        "ultimate_pressure": { "value": 0.1, "unit": "mbar" },
+        "motor_power": { "value": 1.5, "unit": "kW" },
+        "supply_voltage": { "value": 380, "unit": "V" },
+        "net_weight": { "value": 12.5, "unit": "kg" },
+        "inlet_size": { "value": 40, "unit": "mm" },
+        "oil_free": false,
+        "pump_type": "rotary_vane",
+        "certifications": ["ce", "iso9001"]
+      }
+    },
+    {
+      "entityType": "entry",
+      "entityId": "seed_ent_variant_a200",
+      "family": "vacuum_pump",
+      "values": {
+        "flow_rate": { "value": 100, "unit": "m3/min" },
+        "ultimate_pressure": { "value": 1, "unit": "Torr" },
+        "motor_power": { "value": 15, "unit": "hp" },
+        "supply_voltage": { "value": 380, "unit": "V" },
+        "net_weight": { "value": 18, "unit": "kg" },
+        "inlet_size": { "value": 2, "unit": "in" },
+        "oil_free": true,
+        "pump_type": "dry_screw",
+        "certifications": ["ce"]
+      }
+    }
+  ]
+}

--- a/scripts/seed-specs-demo.ts
+++ b/scripts/seed-specs-demo.ts
@@ -1,0 +1,301 @@
+/**
+ * Spec/attribute demo seed — Phase 3 proof (#88).
+ *
+ * Loads typed, unit-aware specs from an external JSON file onto the
+ * entities the Phase 2 seed created. Same source-agnostic shape as
+ * `seed-registry-demo.ts`: a thin script over the schema, so a Strapi
+ * export or a CSV is a different reader against the same tables.
+ *
+ * Deliberately authors the SAME attribute in DIFFERENT units across
+ * entities (63 m3/h vs 100 m3/min, 0.1 mbar vs 1 Torr). That's the point:
+ * normalization means faceting and sorting stay correct anyway, which is
+ * the claim the whole layer rests on.
+ *
+ * Usage:
+ *   pnpm tsx scripts/seed-specs-demo.ts
+ *   pnpm tsx scripts/seed-specs-demo.ts --remote
+ *   pnpm tsx scripts/seed-specs-demo.ts --file ./my-specs.json
+ *
+ * Run `pnpm db:seed:registry` first — this attaches specs to its
+ * entities.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  FAMILIES,
+  isMeasureFamily,
+  normalize,
+} from "../src/lib/server/content/attributes/units";
+
+interface FixtureAttribute {
+  key: string;
+  dataType:
+    | "number"
+    | "measurement"
+    | "select"
+    | "multiselect"
+    | "boolean"
+    | "text";
+  measureFamily?: string;
+  options?: string[];
+  groupKey?: string;
+  position?: number;
+  labels?: Record<string, string>;
+}
+
+interface FixtureFamily {
+  key: string;
+  attributes: {
+    key: string;
+    required?: boolean;
+    sortOrder?: number;
+    isVariantAxis?: boolean;
+  }[];
+}
+
+interface FixtureEntity {
+  entityType: string;
+  /** Must match an id the registry seed created (`seed_ent_<key>`). */
+  entityId: string;
+  family?: string;
+  values: Record<
+    string,
+    number | boolean | string | string[] | { value: number; unit: string }
+  >;
+}
+
+interface Fixture {
+  attributes: FixtureAttribute[];
+  families: FixtureFamily[];
+  entities: FixtureEntity[];
+}
+
+const args = process.argv.slice(2);
+const remote = args.includes("--remote");
+const fileArg = args.indexOf("--file");
+const fixturePath = resolve(
+  fileArg >= 0 && args[fileArg + 1]
+    ? args[fileArg + 1]
+    : "scripts/fixtures/specs-demo.json",
+);
+const dbName =
+  process.env.D1_DB_NAME ?? (remote ? "khaopad-db-staging" : "khaopad-db");
+
+const fixture: Fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+/**
+ * execFileSync with an argument array — never a shell string — so
+ * fixture content can't be interpreted as shell syntax.
+ */
+function exec(sql: string): void {
+  execFileSync(
+    "npx",
+    [
+      "wrangler",
+      "d1",
+      "execute",
+      dbName,
+      remote ? "--remote" : "--local",
+      "--command",
+      sql,
+    ],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+}
+
+/** SQLite string literal — doubles embedded single quotes. */
+function lit(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "1" : "0";
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/** Deterministic ids so re-running is idempotent. */
+function idFor(kind: string, key: string): string {
+  return `spec_${kind}_${key}`.replace(/[^a-zA-Z0-9_]/g, "_").slice(0, 60);
+}
+
+const NOW = "2026-07-30T00:00:00.000Z";
+
+console.log(`Seeding specs from ${fixturePath} → ${dbName}`);
+
+// ── Attribute definitions
+const attrById = new Map<string, FixtureAttribute>();
+for (const attr of fixture.attributes) {
+  attrById.set(attr.key, attr);
+  const id = idFor("attr", attr.key);
+
+  let standardUnit: string | null = null;
+  if (attr.dataType === "measurement") {
+    if (!attr.measureFamily || !isMeasureFamily(attr.measureFamily)) {
+      throw new Error(
+        `Attribute "${attr.key}" is a measurement but has an invalid measureFamily: ${attr.measureFamily}`,
+      );
+    }
+    standardUnit = FAMILIES[attr.measureFamily].standardUnit;
+  }
+
+  exec(
+    `INSERT OR REPLACE INTO attribute_definitions
+       (id,key,data_type,measure_family,standard_unit,options_json,group_key,position,created_by,created_at,updated_at)
+     VALUES (${lit(id)}, ${lit(attr.key)}, ${lit(attr.dataType)},
+             ${lit(attr.measureFamily ?? null)}, ${lit(standardUnit)},
+             ${lit(attr.options ? JSON.stringify(attr.options) : null)},
+             ${lit(attr.groupKey ?? null)}, ${attr.position ?? 0}, NULL,
+             ${lit(NOW)}, ${lit(NOW)})`,
+  );
+
+  for (const [locale, label] of Object.entries(attr.labels ?? {})) {
+    exec(
+      `INSERT OR REPLACE INTO attribute_definition_localizations
+         (id,attribute_id,locale,label,description,option_labels_json)
+       VALUES (${lit(`${id}_${locale}`)}, ${lit(id)}, ${lit(locale)},
+               ${lit(label)}, NULL, NULL)`,
+    );
+  }
+}
+console.log(`  ${fixture.attributes.length} attribute definitions`);
+
+// ── Families
+for (const family of fixture.families) {
+  const fid = idFor("fam", family.key);
+  exec(
+    `INSERT OR REPLACE INTO attribute_families
+       (id,key,labels_json,description,created_by,created_at,updated_at)
+     VALUES (${lit(fid)}, ${lit(family.key)}, NULL, NULL, NULL, ${lit(NOW)}, ${lit(NOW)})`,
+  );
+  for (const fa of family.attributes) {
+    const attr = attrById.get(fa.key);
+    if (!attr) {
+      throw new Error(
+        `Family "${family.key}" references unknown attribute "${fa.key}"`,
+      );
+    }
+    // Mirror the service's variant-axis rule so the fixture can't create
+    // a state the API would reject.
+    if (
+      fa.isVariantAxis &&
+      !["select", "measurement", "boolean"].includes(attr.dataType)
+    ) {
+      throw new Error(
+        `"${fa.key}" is a ${attr.dataType} and cannot be a variant axis`,
+      );
+    }
+    exec(
+      `INSERT OR REPLACE INTO family_attributes
+         (family_id,attribute_id,required,sort_order,is_variant_axis,created_at)
+       VALUES (${lit(fid)}, ${lit(idFor("attr", fa.key))},
+               ${fa.required ? 1 : 0}, ${fa.sortOrder ?? 0},
+               ${fa.isVariantAxis ? 1 : 0}, ${lit(NOW)})`,
+    );
+  }
+}
+console.log(`  ${fixture.families.length} families`);
+
+// ── Values
+let valueCount = 0;
+for (const entity of fixture.entities) {
+  if (entity.family) {
+    exec(
+      `INSERT OR REPLACE INTO entity_families
+         (entity_type,entity_id,family_id,created_at)
+       VALUES (${lit(entity.entityType)}, ${lit(entity.entityId)},
+               ${lit(idFor("fam", entity.family))}, ${lit(NOW)})`,
+    );
+  }
+
+  for (const [key, raw] of Object.entries(entity.values)) {
+    const attr = attrById.get(key);
+    if (!attr)
+      throw new Error(`Unknown attribute "${key}" on ${entity.entityId}`);
+
+    let valueNumber: number | null = null;
+    let valueUnit: string | null = null;
+    let valueText: string | null = null;
+    let valueJson: string | null = null;
+    let valueBool: boolean | null = null;
+
+    switch (attr.dataType) {
+      case "measurement": {
+        if (
+          typeof raw !== "object" ||
+          raw === null ||
+          Array.isArray(raw) ||
+          typeof (raw as { value?: unknown }).value !== "number"
+        ) {
+          throw new Error(
+            `"${key}" is a measurement and needs {value, unit}, got ${JSON.stringify(raw)}`,
+          );
+        }
+        const m = raw as { value: number; unit: string };
+        // THE POINT OF THIS SEED: store the canonical magnitude so
+        // faceting is unit-correct, and keep the authored unit so the
+        // datasheet renders what the editor typed.
+        const n = normalize(
+          attr.measureFamily as Parameters<typeof normalize>[0],
+          m.value,
+          m.unit,
+        );
+        valueNumber = n.standardValue;
+        valueUnit = n.unit;
+        break;
+      }
+      case "number":
+        if (typeof raw !== "number") throw new Error(`"${key}" needs a number`);
+        valueNumber = raw;
+        break;
+      case "boolean":
+        if (typeof raw !== "boolean")
+          throw new Error(`"${key}" needs a boolean`);
+        valueBool = raw;
+        break;
+      case "multiselect": {
+        if (!Array.isArray(raw)) throw new Error(`"${key}" needs an array`);
+        for (const o of raw) {
+          if (!attr.options?.includes(o)) {
+            throw new Error(`"${o}" is not an option of "${key}"`);
+          }
+        }
+        valueJson = JSON.stringify(raw);
+        break;
+      }
+      case "select": {
+        if (typeof raw !== "string") throw new Error(`"${key}" needs a string`);
+        if (!attr.options?.includes(raw)) {
+          throw new Error(`"${raw}" is not an option of "${key}"`);
+        }
+        valueText = raw;
+        break;
+      }
+      case "text":
+        if (typeof raw !== "string") throw new Error(`"${key}" needs a string`);
+        valueText = raw;
+        break;
+    }
+
+    // locale is the '*' sentinel, never NULL — a NULL would make the
+    // (entity, attribute, locale) unique index inert in SQLite and let
+    // duplicate rows through.
+    exec(
+      `INSERT OR REPLACE INTO attribute_values
+         (id,entity_type,entity_id,attribute_id,locale,value_number,value_unit,value_text,value_json,value_bool,created_at,updated_at)
+       VALUES (${lit(`${idFor("val", entity.entityId)}_${key}`)},
+               ${lit(entity.entityType)}, ${lit(entity.entityId)},
+               ${lit(idFor("attr", key))}, '*',
+               ${lit(valueNumber)}, ${lit(valueUnit)}, ${lit(valueText)},
+               ${lit(valueJson)}, ${lit(valueBool)},
+               ${lit(NOW)}, ${lit(NOW)})`,
+    );
+    valueCount++;
+  }
+}
+
+console.log(
+  `  ${fixture.entities.length} entities, ${valueCount} values\n` +
+    `Done. Try:\n` +
+    `  GET /api/public/specs/entry/${fixture.entities[0]?.entityId}?locale=en\n` +
+    `  GET /api/public/specs/compare?type=entry&ids=${fixture.entities.map((e) => e.entityId).join(",")}\n` +
+    `  GET /api/public/specs/facet/flow_rate?min=100&unit=m3/h`,
+);

--- a/src/lib/server/content/attributes/index.ts
+++ b/src/lib/server/content/attributes/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Attribute layer public surface — Phase 3 (#88).
+ */
+import { AttributeService } from "./service";
+
+export { AttributeService, AttributeError } from "./service";
+export type {
+  ResolvedValue,
+  DatasheetGroup,
+  CreateAttributeInput,
+  RawValueInput,
+} from "./service";
+export {
+  FAMILIES,
+  MEASURE_FAMILIES,
+  isMeasureFamily,
+  normalize,
+  denormalize,
+  resolveUnit,
+  unitsFor,
+  UnitError,
+  type MeasureFamily,
+} from "./units";
+export * from "./schema";
+
+export function createAttributeService(
+  env: App.Platform["env"],
+): AttributeService {
+  const supportedLocales = (env.SUPPORTED_LOCALES ?? "en,th")
+    .split(",")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return new AttributeService(env.DB, {
+    supportedLocales,
+    defaultLocale: env.DEFAULT_LOCALE ?? supportedLocales[0] ?? "en",
+  });
+}

--- a/src/lib/server/content/attributes/schema.ts
+++ b/src/lib/server/content/attributes/schema.ts
@@ -74,6 +74,18 @@ export const ATTRIBUTE_DATA_TYPES = [
 
 export type AttributeDataType = (typeof ATTRIBUTE_DATA_TYPES)[number];
 
+/**
+ * Stand-in for "this value is not per-locale", used instead of NULL in
+ * `attribute_values.locale`.
+ *
+ * SQLite considers NULLs distinct in a UNIQUE index, so a nullable
+ * locale would make the (entity, attribute, locale) constraint
+ * unenforceable for the common non-localized case. `*` cannot collide
+ * with a real locale tag, which are validated against the runtime
+ * supported-locale list.
+ */
+export const NON_LOCALIZED_SENTINEL = "*";
+
 // ─── Definitions (the registry) ─────────────────────────────
 
 export const attributeDefinitions = sqliteTable(
@@ -261,11 +273,20 @@ export const attributeValues = sqliteTable(
       .notNull()
       .references(() => attributeDefinitions.id, { onDelete: "cascade" }),
     /**
-     * Null for non-localized attributes (the common case — a flow rate
-     * is a number in every language). Set only for `text` attributes
-     * that genuinely differ per locale.
+     * Locale for `text` attributes that genuinely differ per language.
+     *
+     * Non-localized attributes (the common case — a flow rate is the same
+     * number in every language) use the sentinel `NON_LOCALIZED_SENTINEL`
+     * rather than NULL, and the column is NOT NULL to enforce it.
+     *
+     * This is not cosmetic. SQLite treats NULLs as distinct in a UNIQUE
+     * index, so with a nullable locale the uniqueness constraint below
+     * silently does not apply to non-localized values — two rows for the
+     * same (entity, attribute) both pass. A datasheet then renders the
+     * attribute twice and `compare()` picks whichever row it finds first.
+     * Verified: inserting a second row with locale=NULL was accepted.
      */
-    locale: text("locale"),
+    locale: text("locale").notNull().default(NON_LOCALIZED_SENTINEL),
     /**
      * Numeric magnitude IN THE STANDARD UNIT. `real`, not integer:
      * pressures like 1e-3 mbar and flows like 0.06 m³/h need fractions.

--- a/src/lib/server/content/attributes/schema.ts
+++ b/src/lib/server/content/attributes/schema.ts
@@ -1,0 +1,321 @@
+/**
+ * Typed spec/attribute layer — Phase 3 (#88 §C).
+ *
+ * The problem this solves, in #88's words: a catalog's leaf entity has
+ * "no structured spec fields at all." Rich text cannot back a datasheet —
+ * you can't sort a `<div>` by flow rate, facet on "ultimate pressure <
+ * 0.1 mbar", or diff two variants column-by-column.
+ *
+ * Akeneo's three primitives, sized down for SQLite:
+ *
+ *   attribute_definitions  — WHAT an attribute is (typed, unit-aware)
+ *   attribute_families     — WHICH attributes a product type carries
+ *   attribute_values       — the values, normalized and queryable
+ *
+ * ## Why a narrow EAV here, when #68 rejected EAV
+ *
+ * These are not in tension. #68 rejected EAV as *general content
+ * storage* — every field of every entry as a row, wp_postmeta-style,
+ * where filtering N fields costs N self-joins on one untyped column.
+ *
+ * This table is different in the ways that caused that failure:
+ *
+ *   1. **Typed columns, not one `value` blob.** value_number / value_text
+ *      / value_bool are separate, so `value_number BETWEEN ?` compares as
+ *      a number. wp_postmeta's single LONGTEXT is what makes its indexes
+ *      useless.
+ *   2. **Registry-disciplined.** Every attribute_id resolves to a typed,
+ *      family-scoped definition. There is no free-text `meta_key`, so
+ *      "Flow rate" and "flow_rate" cannot diverge.
+ *   3. **Bounded cardinality.** Rows exist only for attributes a family
+ *      declares — tens per entity, not "whatever anyone wrote".
+ *   4. **Not the primary read path.** An entry's own content still lives
+ *      in `entries.data_json` (Phase 2). This is a sidecar for specs.
+ *
+ * Even sources hostile to EAV endorse it in exactly this shape: the
+ * problem is *untyped, unbounded* EAV, not a narrow typed one. And #88
+ * is explicit that the alternatives are worse — discrete columns can't
+ * express heterogeneous families without a sparse mega-table, and a
+ * free-form `[{label,value}]` JSON list can't be faceted or compared at
+ * all, which is the entire point.
+ *
+ * ## Deliberately generic
+ *
+ * `entity_type` is free text, not an enum. Values can attach to a Phase 2
+ * registry entry, a shop variant, or anything else with a stable id —
+ * nothing here knows about vacuum pumps, or about any particular client's
+ * content model.
+ */
+import {
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+/**
+ * Attribute data types.
+ *
+ * `measurement` is the one that earns its keep: value + authored unit,
+ * normalized to the family's standard unit on write so comparison and
+ * faceting run on one canonical number (#88 §C.1).
+ */
+export const ATTRIBUTE_DATA_TYPES = [
+  "number",
+  "measurement",
+  "select",
+  "multiselect",
+  "boolean",
+  "text",
+] as const;
+
+export type AttributeDataType = (typeof ATTRIBUTE_DATA_TYPES)[number];
+
+// ─── Definitions (the registry) ─────────────────────────────
+
+export const attributeDefinitions = sqliteTable(
+  "attribute_definitions",
+  {
+    id: text("id").primaryKey(),
+    /**
+     * Machine key — 'flow_rate', 'ultimate_pressure'. Globally unique so
+     * a comparison across families still aligns rows by attribute.
+     */
+    key: text("key").notNull().unique(),
+    dataType: text("data_type", { enum: ATTRIBUTE_DATA_TYPES }).notNull(),
+    /**
+     * Required when dataType is 'measurement'; null otherwise. Names the
+     * unit family ('pressure', 'flow') that values convert within.
+     */
+    measureFamily: text("measure_family"),
+    /**
+     * Cached from the family table on write. Denormalized deliberately:
+     * rendering a datasheet needs it on every row, and the families are
+     * compile-time constants that cannot drift.
+     */
+    standardUnit: text("standard_unit"),
+    /** JSON array of option keys, for select / multiselect. */
+    optionsJson: text("options_json"),
+    /**
+     * Grouping hint for datasheet layout — 'performance', 'electrical',
+     * 'mechanical'. Purely presentational; no query depends on it.
+     */
+    groupKey: text("group_key"),
+    /** Display order within a group. */
+    position: integer("position").notNull().default(0),
+    createdBy: text("created_by"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    dataTypeIdx: index("attribute_definitions_data_type_idx").on(t.dataType),
+    groupIdx: index("attribute_definitions_group_idx").on(
+      t.groupKey,
+      t.position,
+    ),
+  }),
+);
+
+/**
+ * Per-locale labels, following the repo's base-row + sibling
+ * `_localizations` convention (#88 §C.1 asks for exactly this).
+ *
+ * `locale` is plain text rather than an enum, matching Phase 2 — the
+ * older content tables bake ["th","en"] into ~8 schemas and adding a
+ * locale means a migration everywhere.
+ */
+export const attributeDefinitionLocalizations = sqliteTable(
+  "attribute_definition_localizations",
+  {
+    id: text("id").primaryKey(),
+    attributeId: text("attribute_id")
+      .notNull()
+      .references(() => attributeDefinitions.id, { onDelete: "cascade" }),
+    locale: text("locale").notNull(),
+    label: text("label").notNull(),
+    /** Editor-facing help text, e.g. "measured at 50 Hz". */
+    description: text("description"),
+    /**
+     * Per-locale option labels for select/multiselect, as a JSON object
+     * keyed by option key: `{"oil_free": "Oil-free"}`. The keys
+     * themselves stay locale-independent so stored values never move.
+     */
+    optionLabelsJson: text("option_labels_json"),
+  },
+  (t) => ({
+    attrLocaleIdx: uniqueIndex(
+      "attribute_definition_localizations_attr_locale_idx",
+    ).on(t.attributeId, t.locale),
+  }),
+);
+
+// ─── Families (per-product-type attribute sets) ─────────────
+
+/**
+ * A family is a named attribute set — 'vacuum_pump', 'blower'. This is
+ * #88's answer to "different product families have different specs":
+ * pumps and blowers carry different attributes rather than sharing one
+ * sparse wide table full of nulls.
+ */
+export const attributeFamilies = sqliteTable("attribute_families", {
+  id: text("id").primaryKey(),
+  key: text("key").notNull().unique(),
+  labelsJson: text("labels_json"),
+  description: text("description"),
+  createdBy: text("created_by"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+/**
+ * Which attributes a family carries, in what order.
+ *
+ * Composite PK — an attribute appears at most once per family.
+ */
+export const familyAttributes = sqliteTable(
+  "family_attributes",
+  {
+    familyId: text("family_id")
+      .notNull()
+      .references(() => attributeFamilies.id, { onDelete: "cascade" }),
+    attributeId: text("attribute_id")
+      .notNull()
+      .references(() => attributeDefinitions.id, { onDelete: "cascade" }),
+    required: integer("required", { mode: "boolean" }).notNull().default(false),
+    sortOrder: integer("sort_order").notNull().default(0),
+    /**
+     * Marks this attribute as a variant axis — the dimension that
+     * distinguishes siblings (#88 §B.2). Akeneo's rule, which this
+     * enforces at write time: an axis must be structured
+     * (select/measurement/boolean), never free text, or the variants
+     * can't be reliably grouped.
+     */
+    isVariantAxis: integer("is_variant_axis", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    createdAt: text("created_at").notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.familyId, t.attributeId] }),
+    familyOrderIdx: index("family_attributes_family_order_idx").on(
+      t.familyId,
+      t.sortOrder,
+    ),
+    // Reverse lookup: "which families use this attribute?" — needed
+    // before allowing a definition to be deleted.
+    attributeIdx: index("family_attributes_attribute_idx").on(t.attributeId),
+  }),
+);
+
+/**
+ * Binds an entity to a family, so the entity knows which attribute set
+ * it carries.
+ *
+ * Separate from the entity's own table because entities live in several
+ * places (Phase 2 `entries`, shop variants, …) and none of them should
+ * grow a column for this.
+ */
+export const entityFamilies = sqliteTable(
+  "entity_families",
+  {
+    entityType: text("entity_type").notNull(),
+    entityId: text("entity_id").notNull(),
+    familyId: text("family_id")
+      .notNull()
+      .references(() => attributeFamilies.id, { onDelete: "cascade" }),
+    createdAt: text("created_at").notNull(),
+  },
+  (t) => ({
+    // One family per entity. A second would make "which attributes does
+    // this carry?" ambiguous.
+    pk: primaryKey({ columns: [t.entityType, t.entityId] }),
+    familyIdx: index("entity_families_family_idx").on(t.familyId),
+  }),
+);
+
+// ─── Values (normalized, queryable) ─────────────────────────
+
+/**
+ * The values table (#88 §C.3).
+ *
+ * Split by type so comparisons stay typed — the single most important
+ * property here. `value_number` always holds the STANDARD-unit magnitude
+ * for measurements, with `value_unit` preserving what the editor actually
+ * typed, so:
+ *
+ *   - facet/sort: `WHERE attribute_id=? AND value_number BETWEEN ? AND ?`
+ *     is correct across mixed authored units
+ *   - display: the datasheet still renders "0.1 mbar", not "10 Pa"
+ */
+export const attributeValues = sqliteTable(
+  "attribute_values",
+  {
+    id: text("id").primaryKey(),
+    /** e.g. 'entry' (Phase 2), 'shop_variant'. Free text by design. */
+    entityType: text("entity_type").notNull(),
+    entityId: text("entity_id").notNull(),
+    attributeId: text("attribute_id")
+      .notNull()
+      .references(() => attributeDefinitions.id, { onDelete: "cascade" }),
+    /**
+     * Null for non-localized attributes (the common case — a flow rate
+     * is a number in every language). Set only for `text` attributes
+     * that genuinely differ per locale.
+     */
+    locale: text("locale"),
+    /**
+     * Numeric magnitude IN THE STANDARD UNIT. `real`, not integer:
+     * pressures like 1e-3 mbar and flows like 0.06 m³/h need fractions.
+     */
+    valueNumber: real("value_number"),
+    /** Unit as authored ('mbar', 'm3/h'), for faithful display. */
+    valueUnit: text("value_unit"),
+    /** Text value, or a select option key. */
+    valueText: text("value_text"),
+    /** JSON array of option keys, for multiselect. */
+    valueJson: text("value_json"),
+    valueBool: integer("value_bool", { mode: "boolean" }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => ({
+    // One value per (entity, attribute, locale). Without this a second
+    // write would silently duplicate rather than update, and a datasheet
+    // would render the attribute twice.
+    entityAttrIdx: uniqueIndex("attribute_values_entity_attr_idx").on(
+      t.entityType,
+      t.entityId,
+      t.attributeId,
+      t.locale,
+    ),
+    // Datasheet assembly: every value for one entity (#88 §C.3).
+    entityIdx: index("attribute_values_entity_idx").on(
+      t.entityType,
+      t.entityId,
+    ),
+    // Faceting and sorting on a numeric attribute — the index that makes
+    // "pumping speed 100–300 m³/h" an index seek rather than a scan.
+    numericFacetIdx: index("attribute_values_numeric_facet_idx").on(
+      t.attributeId,
+      t.valueNumber,
+    ),
+    // Faceting on a select option key.
+    textFacetIdx: index("attribute_values_text_facet_idx").on(
+      t.attributeId,
+      t.valueText,
+    ),
+  }),
+);
+
+// ─── Type exports ───────────────────────────────────────────
+
+export type AttributeDefinition = typeof attributeDefinitions.$inferSelect;
+export type AttributeDefinitionLocalization =
+  typeof attributeDefinitionLocalizations.$inferSelect;
+export type AttributeFamily = typeof attributeFamilies.$inferSelect;
+export type FamilyAttribute = typeof familyAttributes.$inferSelect;
+export type EntityFamily = typeof entityFamilies.$inferSelect;
+export type AttributeValue = typeof attributeValues.$inferSelect;

--- a/src/lib/server/content/attributes/service.ts
+++ b/src/lib/server/content/attributes/service.ts
@@ -1,0 +1,999 @@
+/**
+ * Attribute service — Phase 3 (#88).
+ *
+ * Write side: define attributes, assemble families, set values with
+ * unit normalization and type validation.
+ *
+ * Read side: the three capabilities #88 says rich text cannot provide —
+ *
+ *   datasheet(entity)          one entity's specs, grouped, display-ready
+ *   compare(entities)          rows × attributes, pivoted for a table
+ *   facet(attribute, range)    entity ids matching a typed predicate
+ *
+ * All three are batched: one query per entity *set*, never per entity,
+ * so they don't reintroduce the N+1 that Phase 1 removed.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { and, asc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import {
+  attributeDefinitionLocalizations,
+  attributeDefinitions,
+  attributeFamilies,
+  attributeValues,
+  entityFamilies,
+  familyAttributes,
+  ATTRIBUTE_DATA_TYPES,
+  type AttributeDataType,
+  type AttributeDefinition,
+} from "./schema";
+import {
+  FAMILIES,
+  isMeasureFamily,
+  normalize,
+  UnitError,
+  type MeasureFamily,
+} from "./units";
+
+/** D1 binds at most 100 parameters per statement. */
+const D1_MAX_BIND_PARAMS = 100;
+
+/** Machine keys double as JSON keys and API params. */
+const KEY_PATTERN = /^[a-z](?:_?[a-z0-9])*$/;
+const KEY_MAX_LENGTH = 63;
+
+export class AttributeError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "INVALID_KEY"
+      | "DUPLICATE_KEY"
+      | "UNKNOWN_ATTRIBUTE"
+      | "UNKNOWN_FAMILY"
+      | "INVALID_DATA_TYPE"
+      | "INVALID_CONFIG"
+      | "INVALID_VALUE"
+      | "MISSING_UNIT"
+      | "UNKNOWN_UNIT"
+      | "REQUIRED_MISSING"
+      | "INVALID_VARIANT_AXIS"
+      | "IN_USE",
+  ) {
+    super(message);
+    this.name = "AttributeError";
+  }
+}
+
+function assertValidKey(key: string, what: string): void {
+  if (!KEY_PATTERN.test(key) || key.length > KEY_MAX_LENGTH) {
+    throw new AttributeError(
+      `Invalid ${what} "${key}" — lowercase letters, digits and single underscores only, max ${KEY_MAX_LENGTH} chars`,
+      "INVALID_KEY",
+    );
+  }
+}
+
+/** A resolved value, ready to render. */
+export interface ResolvedValue {
+  attributeKey: string;
+  attributeId: string;
+  dataType: AttributeDataType;
+  label: string;
+  groupKey: string | null;
+  position: number;
+  /** Standard-unit magnitude, for sorting/comparing. Null for non-numeric. */
+  standardValue: number | null;
+  /** Value in the unit it was authored in — what a datasheet shows. */
+  displayValue: string | number | boolean | string[] | null;
+  /** Authored unit, e.g. 'mbar'. Null for non-measurements. */
+  unit: string | null;
+  measureFamily: string | null;
+}
+
+export interface DatasheetGroup {
+  groupKey: string | null;
+  rows: ResolvedValue[];
+}
+
+export interface CreateAttributeInput {
+  key: string;
+  dataType: AttributeDataType;
+  /** Required when dataType is 'measurement'. */
+  measureFamily?: string;
+  /** Required for select / multiselect. */
+  options?: string[];
+  groupKey?: string;
+  position?: number;
+  labels?: Record<string, { label: string; description?: string }>;
+  createdBy?: string;
+}
+
+/** A value as supplied by a caller, before normalization. */
+export type RawValueInput =
+  | { kind: "number"; value: number }
+  | { kind: "measurement"; value: number; unit: string }
+  | { kind: "select"; option: string }
+  | { kind: "multiselect"; options: string[] }
+  | { kind: "boolean"; value: boolean }
+  | { kind: "text"; value: string; locale?: string };
+
+export class AttributeService {
+  private db: ReturnType<typeof drizzle>;
+
+  constructor(
+    private readonly d1: D1Database,
+    private readonly opts: {
+      supportedLocales: readonly string[];
+      defaultLocale: string;
+    },
+  ) {
+    this.db = drizzle(d1);
+  }
+
+  private now() {
+    return new Date().toISOString();
+  }
+
+  // ─── Definitions ──────────────────────────────────────────
+
+  async createAttribute(
+    input: CreateAttributeInput,
+  ): Promise<AttributeDefinition> {
+    assertValidKey(input.key, "attribute key");
+
+    if (!ATTRIBUTE_DATA_TYPES.includes(input.dataType)) {
+      throw new AttributeError(
+        `Unknown data type "${input.dataType}"`,
+        "INVALID_DATA_TYPE",
+      );
+    }
+
+    // A measurement without a family has no canonical unit, so its
+    // values could never be compared — which is the only reason the type
+    // exists. Reject at definition time rather than on first write.
+    let measureFamily: MeasureFamily | null = null;
+    let standardUnit: string | null = null;
+    if (input.dataType === "measurement") {
+      if (!input.measureFamily) {
+        throw new AttributeError(
+          `Attribute "${input.key}" is a measurement and requires measureFamily (one of: ${Object.keys(FAMILIES).join(", ")})`,
+          "INVALID_CONFIG",
+        );
+      }
+      if (!isMeasureFamily(input.measureFamily)) {
+        throw new AttributeError(
+          `Unknown measure family "${input.measureFamily}"`,
+          "UNKNOWN_FAMILY",
+        );
+      }
+      measureFamily = input.measureFamily;
+      standardUnit = FAMILIES[measureFamily].standardUnit;
+    } else if (input.measureFamily) {
+      throw new AttributeError(
+        `measureFamily is only valid for measurement attributes, not "${input.dataType}"`,
+        "INVALID_CONFIG",
+      );
+    }
+
+    const needsOptions =
+      input.dataType === "select" || input.dataType === "multiselect";
+    if (needsOptions) {
+      if (!input.options?.length) {
+        throw new AttributeError(
+          `Attribute "${input.key}" is a ${input.dataType} and requires a non-empty options array`,
+          "INVALID_CONFIG",
+        );
+      }
+      const seen = new Set(input.options);
+      if (seen.size !== input.options.length) {
+        throw new AttributeError(
+          `Attribute "${input.key}" has duplicate options`,
+          "INVALID_CONFIG",
+        );
+      }
+      for (const option of input.options) assertValidKey(option, "option key");
+    } else if (input.options?.length) {
+      throw new AttributeError(
+        `options is only valid for select/multiselect, not "${input.dataType}"`,
+        "INVALID_CONFIG",
+      );
+    }
+
+    const existing = await this.db
+      .select({ id: attributeDefinitions.id })
+      .from(attributeDefinitions)
+      .where(eq(attributeDefinitions.key, input.key))
+      .limit(1)
+      .get();
+    if (existing) {
+      throw new AttributeError(
+        `An attribute with key "${input.key}" already exists`,
+        "DUPLICATE_KEY",
+      );
+    }
+
+    const id = nanoid();
+    const now = this.now();
+    await this.db.insert(attributeDefinitions).values({
+      id,
+      key: input.key,
+      dataType: input.dataType,
+      measureFamily,
+      standardUnit,
+      optionsJson: needsOptions ? JSON.stringify(input.options) : null,
+      groupKey: input.groupKey ?? null,
+      position: input.position ?? 0,
+      createdBy: input.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    for (const [locale, l] of Object.entries(input.labels ?? {})) {
+      if (!this.opts.supportedLocales.includes(locale)) continue;
+      await this.db.insert(attributeDefinitionLocalizations).values({
+        id: nanoid(),
+        attributeId: id,
+        locale,
+        label: l.label,
+        description: l.description ?? null,
+        optionLabelsJson: null,
+      });
+    }
+
+    return (await this.db
+      .select()
+      .from(attributeDefinitions)
+      .where(eq(attributeDefinitions.id, id))
+      .get())!;
+  }
+
+  async listAttributes(): Promise<AttributeDefinition[]> {
+    return this.db
+      .select()
+      .from(attributeDefinitions)
+      .orderBy(
+        asc(attributeDefinitions.position),
+        asc(attributeDefinitions.key),
+      )
+      .all();
+  }
+
+  async getAttributeByKey(key: string): Promise<AttributeDefinition | null> {
+    return (
+      (await this.db
+        .select()
+        .from(attributeDefinitions)
+        .where(eq(attributeDefinitions.key, key))
+        .limit(1)
+        .get()) ?? null
+    );
+  }
+
+  /**
+   * Delete a definition. Refuses while any family still declares it —
+   * cascading would silently strip the attribute from every product that
+   * carries it.
+   */
+  async deleteAttribute(key: string): Promise<void> {
+    const attr = await this.getAttributeByKey(key);
+    if (!attr) {
+      throw new AttributeError(
+        `Unknown attribute "${key}"`,
+        "UNKNOWN_ATTRIBUTE",
+      );
+    }
+    const uses = await this.db
+      .select({ familyId: familyAttributes.familyId })
+      .from(familyAttributes)
+      .where(eq(familyAttributes.attributeId, attr.id))
+      .all();
+    if (uses.length > 0) {
+      throw new AttributeError(
+        `Cannot delete "${key}" — still declared by ${uses.length} family/families. Remove it from them first.`,
+        "IN_USE",
+      );
+    }
+    await this.db
+      .delete(attributeDefinitions)
+      .where(eq(attributeDefinitions.id, attr.id));
+  }
+
+  // ─── Families ─────────────────────────────────────────────
+
+  async createFamily(input: {
+    key: string;
+    labels?: Record<string, string>;
+    description?: string;
+    createdBy?: string;
+  }) {
+    assertValidKey(input.key, "family key");
+    const existing = await this.db
+      .select({ id: attributeFamilies.id })
+      .from(attributeFamilies)
+      .where(eq(attributeFamilies.key, input.key))
+      .limit(1)
+      .get();
+    if (existing) {
+      throw new AttributeError(
+        `A family with key "${input.key}" already exists`,
+        "DUPLICATE_KEY",
+      );
+    }
+    const id = nanoid();
+    const now = this.now();
+    await this.db.insert(attributeFamilies).values({
+      id,
+      key: input.key,
+      labelsJson: input.labels ? JSON.stringify(input.labels) : null,
+      description: input.description ?? null,
+      createdBy: input.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return (await this.db
+      .select()
+      .from(attributeFamilies)
+      .where(eq(attributeFamilies.id, id))
+      .get())!;
+  }
+
+  /**
+   * Add an attribute to a family.
+   *
+   * Enforces Akeneo's variant-axis rule: an axis must be structured
+   * (select / measurement / boolean). A free-text axis can't reliably
+   * group siblings — "1.5kW" and "1.5 kW" would be different variants.
+   */
+  async addAttributeToFamily(
+    familyKey: string,
+    attributeKey: string,
+    opts: {
+      required?: boolean;
+      sortOrder?: number;
+      isVariantAxis?: boolean;
+    } = {},
+  ): Promise<void> {
+    const family = await this.requireFamily(familyKey);
+    const attr = await this.getAttributeByKey(attributeKey);
+    if (!attr) {
+      throw new AttributeError(
+        `Unknown attribute "${attributeKey}"`,
+        "UNKNOWN_ATTRIBUTE",
+      );
+    }
+
+    if (opts.isVariantAxis) {
+      const structured: AttributeDataType[] = [
+        "select",
+        "measurement",
+        "boolean",
+      ];
+      if (!structured.includes(attr.dataType)) {
+        throw new AttributeError(
+          `"${attributeKey}" is a ${attr.dataType} and cannot be a variant axis — axes must be select, measurement or boolean so siblings group reliably`,
+          "INVALID_VARIANT_AXIS",
+        );
+      }
+    }
+
+    await this.db
+      .insert(familyAttributes)
+      .values({
+        familyId: family.id,
+        attributeId: attr.id,
+        required: opts.required ?? false,
+        sortOrder: opts.sortOrder ?? 0,
+        isVariantAxis: opts.isVariantAxis ?? false,
+        createdAt: this.now(),
+      })
+      .onConflictDoNothing();
+  }
+
+  /** Bind an entity to a family. Replaces any existing binding. */
+  async assignFamily(
+    entityType: string,
+    entityId: string,
+    familyKey: string,
+  ): Promise<void> {
+    const family = await this.requireFamily(familyKey);
+    await this.db
+      .delete(entityFamilies)
+      .where(
+        and(
+          eq(entityFamilies.entityType, entityType),
+          eq(entityFamilies.entityId, entityId),
+        ),
+      );
+    await this.db.insert(entityFamilies).values({
+      entityType,
+      entityId,
+      familyId: family.id,
+      createdAt: this.now(),
+    });
+  }
+
+  /** Attributes a family declares, in display order. */
+  async familyAttributeList(familyKey: string) {
+    const family = await this.requireFamily(familyKey);
+    return this.db
+      .select({
+        attribute: attributeDefinitions,
+        required: familyAttributes.required,
+        sortOrder: familyAttributes.sortOrder,
+        isVariantAxis: familyAttributes.isVariantAxis,
+      })
+      .from(familyAttributes)
+      .innerJoin(
+        attributeDefinitions,
+        eq(attributeDefinitions.id, familyAttributes.attributeId),
+      )
+      .where(eq(familyAttributes.familyId, family.id))
+      .orderBy(asc(familyAttributes.sortOrder), asc(attributeDefinitions.key))
+      .all();
+  }
+
+  private async requireFamily(key: string) {
+    const family = await this.db
+      .select()
+      .from(attributeFamilies)
+      .where(eq(attributeFamilies.key, key))
+      .limit(1)
+      .get();
+    if (!family) {
+      throw new AttributeError(
+        `Unknown attribute family "${key}"`,
+        "UNKNOWN_FAMILY",
+      );
+    }
+    return family;
+  }
+
+  // ─── Values ───────────────────────────────────────────────
+
+  /**
+   * Set one attribute value, normalizing measurements on the way in.
+   *
+   * Upsert on (entityType, entityId, attributeId, locale) — the unique
+   * index makes a repeated write an update rather than a duplicate row.
+   */
+  async setValue(
+    entityType: string,
+    entityId: string,
+    attributeKey: string,
+    input: RawValueInput,
+  ): Promise<void> {
+    const attr = await this.getAttributeByKey(attributeKey);
+    if (!attr) {
+      throw new AttributeError(
+        `Unknown attribute "${attributeKey}"`,
+        "UNKNOWN_ATTRIBUTE",
+      );
+    }
+    if (input.kind !== attr.dataType) {
+      throw new AttributeError(
+        `Attribute "${attributeKey}" is a ${attr.dataType}, but a ${input.kind} value was supplied`,
+        "INVALID_VALUE",
+      );
+    }
+
+    const row = this.buildValueRow(attr, input);
+    const locale = row.locale ?? null;
+    const now = this.now();
+
+    const existing = await this.db
+      .select({ id: attributeValues.id })
+      .from(attributeValues)
+      .where(
+        and(
+          eq(attributeValues.entityType, entityType),
+          eq(attributeValues.entityId, entityId),
+          eq(attributeValues.attributeId, attr.id),
+          locale === null
+            ? isNull(attributeValues.locale)
+            : eq(attributeValues.locale, locale),
+        ),
+      )
+      .limit(1)
+      .get();
+
+    if (existing) {
+      await this.db
+        .update(attributeValues)
+        .set({ ...row, updatedAt: now })
+        .where(eq(attributeValues.id, existing.id));
+      return;
+    }
+
+    await this.db.insert(attributeValues).values({
+      id: nanoid(),
+      entityType,
+      entityId,
+      attributeId: attr.id,
+      ...row,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  /**
+   * Translate a typed input into the table's columns.
+   *
+   * For a measurement this is where unit normalization happens: the
+   * canonical magnitude goes to `valueNumber` and the authored unit is
+   * preserved in `valueUnit`, so faceting is correct and display is
+   * faithful.
+   */
+  private buildValueRow(attr: AttributeDefinition, input: RawValueInput) {
+    const base = {
+      locale: null as string | null,
+      valueNumber: null as number | null,
+      valueUnit: null as string | null,
+      valueText: null as string | null,
+      valueJson: null as string | null,
+      valueBool: null as boolean | null,
+    };
+
+    switch (input.kind) {
+      case "number": {
+        if (!Number.isFinite(input.value)) {
+          throw new AttributeError(
+            `Attribute "${attr.key}" requires a finite number`,
+            "INVALID_VALUE",
+          );
+        }
+        return { ...base, valueNumber: input.value };
+      }
+
+      case "measurement": {
+        if (!attr.measureFamily || !isMeasureFamily(attr.measureFamily)) {
+          throw new AttributeError(
+            `Attribute "${attr.key}" has no valid measure family`,
+            "INVALID_CONFIG",
+          );
+        }
+        if (!input.unit) {
+          throw new AttributeError(
+            `Attribute "${attr.key}" is a measurement and requires a unit`,
+            "MISSING_UNIT",
+          );
+        }
+        try {
+          const n = normalize(attr.measureFamily, input.value, input.unit);
+          return {
+            ...base,
+            // Canonical magnitude — what every query compares on.
+            valueNumber: n.standardValue,
+            // Authored unit — what the datasheet renders.
+            valueUnit: n.unit,
+          };
+        } catch (err) {
+          if (err instanceof UnitError) {
+            throw new AttributeError(
+              err.message,
+              err.code === "UNKNOWN_UNIT" ? "UNKNOWN_UNIT" : "INVALID_VALUE",
+            );
+          }
+          throw err;
+        }
+      }
+
+      case "select": {
+        const options = this.optionsOf(attr);
+        if (!options.includes(input.option)) {
+          throw new AttributeError(
+            `"${input.option}" is not an option of "${attr.key}" (${options.join(", ")})`,
+            "INVALID_VALUE",
+          );
+        }
+        return { ...base, valueText: input.option };
+      }
+
+      case "multiselect": {
+        const options = this.optionsOf(attr);
+        const unique = Array.from(new Set(input.options));
+        for (const o of unique) {
+          if (!options.includes(o)) {
+            throw new AttributeError(
+              `"${o}" is not an option of "${attr.key}" (${options.join(", ")})`,
+              "INVALID_VALUE",
+            );
+          }
+        }
+        return { ...base, valueJson: JSON.stringify(unique) };
+      }
+
+      case "boolean":
+        return { ...base, valueBool: input.value };
+
+      case "text": {
+        if (
+          input.locale &&
+          !this.opts.supportedLocales.includes(input.locale)
+        ) {
+          throw new AttributeError(
+            `Unsupported locale "${input.locale}"`,
+            "INVALID_VALUE",
+          );
+        }
+        return {
+          ...base,
+          locale: input.locale ?? null,
+          valueText: input.value,
+        };
+      }
+    }
+  }
+
+  private optionsOf(attr: AttributeDefinition): string[] {
+    if (!attr.optionsJson) return [];
+    try {
+      const parsed = JSON.parse(attr.optionsJson);
+      return Array.isArray(parsed) ? (parsed as string[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  // ─── Read: datasheet / compare / facet ────────────────────
+
+  /**
+   * One entity's specs, grouped for rendering (#88 §C.3).
+   *
+   * Two queries total regardless of attribute count: values joined to
+   * their definitions, plus labels for the requested locale.
+   */
+  async datasheet(
+    entityType: string,
+    entityId: string,
+    locale?: string,
+  ): Promise<DatasheetGroup[]> {
+    const resolved = await this.resolveValues(entityType, [entityId], locale);
+    const rows = resolved.get(entityId) ?? [];
+
+    const byGroup = new Map<string | null, ResolvedValue[]>();
+    for (const row of rows) {
+      const list = byGroup.get(row.groupKey) ?? [];
+      list.push(row);
+      byGroup.set(row.groupKey, list);
+    }
+
+    return (
+      Array.from(byGroup.entries())
+        .map(([groupKey, groupRows]) => ({
+          groupKey,
+          rows: groupRows.sort(
+            (a, b) =>
+              a.position - b.position ||
+              a.attributeKey.localeCompare(b.attributeKey),
+          ),
+        }))
+        // Ungrouped rows last — a named group is more specific than none.
+        .sort((a, b) => {
+          if (a.groupKey === null) return 1;
+          if (b.groupKey === null) return -1;
+          return a.groupKey.localeCompare(b.groupKey);
+        })
+    );
+  }
+
+  /**
+   * Comparison table: N entities × their union of attributes (#88 §C.3).
+   *
+   * Returns rows keyed by attribute so a template can render one table
+   * row per spec with one column per entity — the shape rich text cannot
+   * produce. Attributes absent on an entity come back as null rather
+   * than being omitted, so columns stay aligned.
+   */
+  async compare(
+    entityType: string,
+    entityIds: string[],
+    locale?: string,
+  ): Promise<{
+    entityIds: string[];
+    rows: {
+      attributeKey: string;
+      label: string;
+      groupKey: string | null;
+      unit: string | null;
+      /** Indexed in step with `entityIds`. */
+      values: (ResolvedValue | null)[];
+    }[];
+  }> {
+    const resolved = await this.resolveValues(entityType, entityIds, locale);
+
+    // Union of attributes across all entities, keeping definition order.
+    const attrOrder = new Map<
+      string,
+      {
+        label: string;
+        groupKey: string | null;
+        position: number;
+        unit: string | null;
+      }
+    >();
+    for (const rows of resolved.values()) {
+      for (const r of rows) {
+        if (!attrOrder.has(r.attributeKey)) {
+          attrOrder.set(r.attributeKey, {
+            label: r.label,
+            groupKey: r.groupKey,
+            position: r.position,
+            unit: r.unit,
+          });
+        }
+      }
+    }
+
+    const rows = Array.from(attrOrder.entries())
+      .sort(
+        ([ka, a], [kb, b]) => a.position - b.position || ka.localeCompare(kb),
+      )
+      .map(([attributeKey, meta]) => ({
+        attributeKey,
+        label: meta.label,
+        groupKey: meta.groupKey,
+        unit: meta.unit,
+        values: entityIds.map(
+          (id) =>
+            resolved.get(id)?.find((r) => r.attributeKey === attributeKey) ??
+            null,
+        ),
+      }));
+
+    return { entityIds, rows };
+  }
+
+  /**
+   * Faceted filter / sort on one attribute (#88 §C.3).
+   *
+   * Because `valueNumber` is always the standard-unit magnitude, a range
+   * expressed in ANY unit of the family is correct — the bounds are
+   * normalized here before comparison, so "100–300 m³/h" and
+   * "1.67–5 m³/min" select the same entities.
+   */
+  async facet(
+    attributeKey: string,
+    filter:
+      | { kind: "range"; min?: number; max?: number; unit?: string }
+      | { kind: "option"; options: string[] }
+      | { kind: "boolean"; value: boolean },
+    opts: { entityType?: string; limit?: number; sort?: "asc" | "desc" } = {},
+  ): Promise<
+    {
+      entityType: string;
+      entityId: string;
+      value: number | string | boolean | null;
+    }[]
+  > {
+    const attr = await this.getAttributeByKey(attributeKey);
+    if (!attr) {
+      throw new AttributeError(
+        `Unknown attribute "${attributeKey}"`,
+        "UNKNOWN_ATTRIBUTE",
+      );
+    }
+
+    const conditions = [eq(attributeValues.attributeId, attr.id)];
+    if (opts.entityType) {
+      conditions.push(eq(attributeValues.entityType, opts.entityType));
+    }
+
+    if (filter.kind === "range") {
+      if (attr.dataType !== "number" && attr.dataType !== "measurement") {
+        throw new AttributeError(
+          `Attribute "${attributeKey}" is a ${attr.dataType} and cannot be range-filtered`,
+          "INVALID_VALUE",
+        );
+      }
+      // Normalize the bounds into the standard unit so a caller can
+      // express the range in whatever unit they think in.
+      const toStandard = (v: number): number => {
+        if (
+          attr.dataType !== "measurement" ||
+          !filter.unit ||
+          !attr.measureFamily ||
+          !isMeasureFamily(attr.measureFamily)
+        ) {
+          return v;
+        }
+        return normalize(attr.measureFamily, v, filter.unit).standardValue;
+      };
+      if (filter.min !== undefined) {
+        conditions.push(
+          gte(attributeValues.valueNumber, toStandard(filter.min)),
+        );
+      }
+      if (filter.max !== undefined) {
+        conditions.push(
+          lte(attributeValues.valueNumber, toStandard(filter.max)),
+        );
+      }
+    } else if (filter.kind === "option") {
+      if (filter.options.length === 0) return [];
+      conditions.push(inArray(attributeValues.valueText, filter.options));
+    } else {
+      conditions.push(eq(attributeValues.valueBool, filter.value));
+    }
+
+    const order =
+      filter.kind === "range"
+        ? opts.sort === "desc"
+          ? sql`${attributeValues.valueNumber} DESC`
+          : sql`${attributeValues.valueNumber} ASC`
+        : sql`${attributeValues.valueText} ASC`;
+
+    const rows = await this.db
+      .select({
+        entityType: attributeValues.entityType,
+        entityId: attributeValues.entityId,
+        valueNumber: attributeValues.valueNumber,
+        valueText: attributeValues.valueText,
+        valueBool: attributeValues.valueBool,
+      })
+      .from(attributeValues)
+      .where(and(...conditions))
+      .orderBy(order)
+      .limit(Math.min(500, Math.max(1, opts.limit ?? 100)))
+      .all();
+
+    return rows.map((r) => ({
+      entityType: r.entityType,
+      entityId: r.entityId,
+      value: r.valueNumber ?? r.valueText ?? r.valueBool ?? null,
+    }));
+  }
+
+  /**
+   * Load and resolve values for a set of entities.
+   *
+   * Batched: one values+definitions query and one labels query for the
+   * whole set, chunked to respect D1's bound-parameter ceiling. This is
+   * the shared engine behind datasheet() and compare().
+   */
+  private async resolveValues(
+    entityType: string,
+    entityIds: string[],
+    locale?: string,
+  ): Promise<Map<string, ResolvedValue[]>> {
+    const out = new Map<string, ResolvedValue[]>();
+    if (entityIds.length === 0) return out;
+
+    const wanted = locale ?? this.opts.defaultLocale;
+
+    const rows = await this.loadChunked(entityIds, (chunk) =>
+      this.db
+        .select({
+          entityId: attributeValues.entityId,
+          attributeId: attributeValues.attributeId,
+          valueNumber: attributeValues.valueNumber,
+          valueUnit: attributeValues.valueUnit,
+          valueText: attributeValues.valueText,
+          valueJson: attributeValues.valueJson,
+          valueBool: attributeValues.valueBool,
+          key: attributeDefinitions.key,
+          dataType: attributeDefinitions.dataType,
+          measureFamily: attributeDefinitions.measureFamily,
+          groupKey: attributeDefinitions.groupKey,
+          position: attributeDefinitions.position,
+        })
+        .from(attributeValues)
+        .innerJoin(
+          attributeDefinitions,
+          eq(attributeDefinitions.id, attributeValues.attributeId),
+        )
+        .where(
+          and(
+            eq(attributeValues.entityType, entityType),
+            inArray(attributeValues.entityId, chunk),
+          ),
+        )
+        .all(),
+    );
+    if (rows.length === 0) return out;
+
+    // Labels for the requested locale, one query for every attribute
+    // seen. Falls back to the machine key when a translation is missing,
+    // which is more useful than an empty cell.
+    const attrIds = Array.from(new Set(rows.map((r) => r.attributeId)));
+    const labels = await this.loadChunked(attrIds, (chunk) =>
+      this.db
+        .select({
+          attributeId: attributeDefinitionLocalizations.attributeId,
+          label: attributeDefinitionLocalizations.label,
+        })
+        .from(attributeDefinitionLocalizations)
+        .where(
+          and(
+            inArray(attributeDefinitionLocalizations.attributeId, chunk),
+            eq(attributeDefinitionLocalizations.locale, wanted),
+          ),
+        )
+        .all(),
+    );
+    const labelByAttr = new Map(labels.map((l) => [l.attributeId, l.label]));
+
+    for (const r of rows) {
+      const resolved: ResolvedValue = {
+        attributeKey: r.key,
+        attributeId: r.attributeId,
+        dataType: r.dataType,
+        label: labelByAttr.get(r.attributeId) ?? r.key,
+        groupKey: r.groupKey,
+        position: r.position,
+        standardValue: r.valueNumber,
+        unit: r.valueUnit,
+        measureFamily: r.measureFamily,
+        displayValue: this.displayValueOf(r),
+      };
+      const list = out.get(r.entityId) ?? [];
+      list.push(resolved);
+      out.set(r.entityId, list);
+    }
+    return out;
+  }
+
+  /**
+   * Reconstruct what the editor authored.
+   *
+   * For a measurement the stored number is in the STANDARD unit, so it
+   * must be converted back into `valueUnit` — otherwise a datasheet
+   * would print "10 Pa" where the editor wrote "0.1 mbar".
+   */
+  private displayValueOf(r: {
+    dataType: AttributeDataType;
+    valueNumber: number | null;
+    valueUnit: string | null;
+    valueText: string | null;
+    valueJson: string | null;
+    valueBool: boolean | null;
+    measureFamily: string | null;
+  }): ResolvedValue["displayValue"] {
+    switch (r.dataType) {
+      case "number":
+        return r.valueNumber;
+      case "measurement": {
+        if (
+          r.valueNumber === null ||
+          !r.valueUnit ||
+          !r.measureFamily ||
+          !isMeasureFamily(r.measureFamily)
+        ) {
+          return r.valueNumber;
+        }
+        const factor = FAMILIES[r.measureFamily].units[r.valueUnit]?.factor;
+        if (!factor) return r.valueNumber;
+        const authored = r.valueNumber / factor;
+        // Trim float noise from the round-trip (0.1 mbar → 10 Pa → 0.1)
+        // without truncating genuinely small vacuum values like 1e-6.
+        return Number(authored.toPrecision(12));
+      }
+      case "select":
+      case "text":
+        return r.valueText;
+      case "multiselect": {
+        if (!r.valueJson) return [];
+        try {
+          const parsed = JSON.parse(r.valueJson);
+          return Array.isArray(parsed) ? (parsed as string[]) : [];
+        } catch {
+          return [];
+        }
+      }
+      case "boolean":
+        return r.valueBool;
+    }
+  }
+
+  private async loadChunked<T>(
+    ids: string[],
+    load: (chunk: string[]) => Promise<T[]>,
+  ): Promise<T[]> {
+    if (ids.length === 0) return [];
+    if (ids.length <= D1_MAX_BIND_PARAMS) return load(ids);
+    const out: T[] = [];
+    for (let i = 0; i < ids.length; i += D1_MAX_BIND_PARAMS) {
+      out.push(...(await load(ids.slice(i, i + D1_MAX_BIND_PARAMS))));
+    }
+    return out;
+  }
+}

--- a/src/lib/server/content/attributes/service.ts
+++ b/src/lib/server/content/attributes/service.ts
@@ -14,7 +14,7 @@
  * so they don't reintroduce the N+1 that Phase 1 removed.
  */
 import { drizzle } from "drizzle-orm/d1";
-import { and, asc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import {
   attributeDefinitionLocalizations,
@@ -24,6 +24,7 @@ import {
   entityFamilies,
   familyAttributes,
   ATTRIBUTE_DATA_TYPES,
+  NON_LOCALIZED_SENTINEL,
   type AttributeDataType,
   type AttributeDefinition,
 } from "./schema";
@@ -477,7 +478,9 @@ export class AttributeService {
     }
 
     const row = this.buildValueRow(attr, input);
-    const locale = row.locale ?? null;
+    // Never NULL — see NON_LOCALIZED_SENTINEL. A NULL here would make the
+    // (entity, attribute, locale) unique index inert in SQLite.
+    const locale = row.locale ?? NON_LOCALIZED_SENTINEL;
     const now = this.now();
 
     const existing = await this.db
@@ -488,9 +491,7 @@ export class AttributeService {
           eq(attributeValues.entityType, entityType),
           eq(attributeValues.entityId, entityId),
           eq(attributeValues.attributeId, attr.id),
-          locale === null
-            ? isNull(attributeValues.locale)
-            : eq(attributeValues.locale, locale),
+          eq(attributeValues.locale, locale),
         ),
       )
       .limit(1)
@@ -499,7 +500,7 @@ export class AttributeService {
     if (existing) {
       await this.db
         .update(attributeValues)
-        .set({ ...row, updatedAt: now })
+        .set({ ...row, locale, updatedAt: now })
         .where(eq(attributeValues.id, existing.id));
       return;
     }
@@ -510,6 +511,7 @@ export class AttributeService {
       entityId,
       attributeId: attr.id,
       ...row,
+      locale,
       createdAt: now,
       updatedAt: now,
     });
@@ -787,17 +789,39 @@ export class AttributeService {
       }
       // Normalize the bounds into the standard unit so a caller can
       // express the range in whatever unit they think in.
-      const toStandard = (v: number): number => {
-        if (
-          attr.dataType !== "measurement" ||
-          !filter.unit ||
-          !attr.measureFamily ||
-          !isMeasureFamily(attr.measureFamily)
-        ) {
-          return v;
-        }
-        return normalize(attr.measureFamily, v, filter.unit).standardValue;
-      };
+      //
+      // A measurement REQUIRES an explicit unit. Silently treating a bare
+      // bound as already-canonical is a wrong-results bug, not a
+      // convenience: `min=0.1` on a pressure attribute almost certainly
+      // means 0.1 mbar, but stored values are pascals, so it would match
+      // nothing and report "no results" rather than an error. Demanding
+      // the unit makes the caller's intent explicit.
+      const isMeasurement =
+        attr.dataType === "measurement" &&
+        !!attr.measureFamily &&
+        isMeasureFamily(attr.measureFamily);
+
+      if (isMeasurement && !filter.unit) {
+        throw new AttributeError(
+          `Attribute "${attributeKey}" is a measurement (${attr.measureFamily}); a range filter must specify the unit its bounds are in`,
+          "MISSING_UNIT",
+        );
+      }
+      if (!isMeasurement && filter.unit) {
+        throw new AttributeError(
+          `Attribute "${attributeKey}" is a plain ${attr.dataType} and has no units — drop the unit parameter`,
+          "INVALID_VALUE",
+        );
+      }
+
+      const toStandard = (v: number): number =>
+        isMeasurement
+          ? normalize(
+              attr.measureFamily as MeasureFamily,
+              v,
+              filter.unit as string,
+            ).standardValue
+          : v;
       if (filter.min !== undefined) {
         conditions.push(
           gte(attributeValues.valueNumber, toStandard(filter.min)),

--- a/src/lib/server/content/attributes/units.ts
+++ b/src/lib/server/content/attributes/units.ts
@@ -1,0 +1,318 @@
+/**
+ * Measurement units + normalization — Phase 3 (#88 §C.1).
+ *
+ * The whole point of the attribute layer is that specs are *comparable*.
+ * That only works if every measurement of the same kind is stored against
+ * one canonical number: Akeneo's "standard unit" pattern. Author "533 g"
+ * or "0.6 kg" and both land as grams, so `ORDER BY value_number` and
+ * `value_number BETWEEN ?` are correct regardless of what the editor
+ * typed.
+ *
+ * ## Why a table rather than a library
+ *
+ * A units library (js-quantities, convert-units) would pull a dependency
+ * into the Worker bundle for a fixed, small set of families we control.
+ * The families here are the ones a Thailand-first equipment catalog
+ * actually needs; adding one is a few lines.
+ *
+ * ## Why factors, not formulas
+ *
+ * Every unit below is a pure scale of its family's standard unit, so
+ * conversion is one multiply and is exactly invertible. Temperature is
+ * deliberately EXCLUDED for this reason — °C→K is an offset, not a
+ * scale, and mixing offset units into a factor table silently produces
+ * wrong numbers. When temperature is needed it gets its own code path.
+ */
+
+/** A family groups units that can convert between each other. */
+export type MeasureFamily =
+  | "length"
+  | "mass"
+  | "volume"
+  | "pressure"
+  | "power"
+  | "flow"
+  | "voltage"
+  | "current"
+  | "frequency"
+  | "speed"
+  | "area"
+  | "time";
+
+export interface UnitDef {
+  /** Multiply an authored value by this to get the standard unit. */
+  factor: number;
+  /** Accepted aliases, so "m3/h" and "m³/h" are the same unit. */
+  aliases?: readonly string[];
+}
+
+export interface FamilyDef {
+  /** Canonical unit every value is normalized to. */
+  standardUnit: string;
+  units: Record<string, UnitDef>;
+}
+
+/**
+ * The unit table.
+ *
+ * Standard units are chosen to keep typical catalog values in a range
+ * that reads naturally and avoids float noise — e.g. pressure normalizes
+ * to pascal (SI) rather than mbar, but the mbar factor is exact.
+ */
+export const FAMILIES: Record<MeasureFamily, FamilyDef> = {
+  length: {
+    standardUnit: "mm",
+    units: {
+      mm: { factor: 1, aliases: ["millimeter", "millimetre"] },
+      cm: { factor: 10, aliases: ["centimeter", "centimetre"] },
+      m: { factor: 1000, aliases: ["meter", "metre"] },
+      km: { factor: 1_000_000, aliases: ["kilometer", "kilometre"] },
+      in: { factor: 25.4, aliases: ['"', "inch", "inches"] },
+      ft: { factor: 304.8, aliases: ["'", "foot", "feet"] },
+    },
+  },
+
+  mass: {
+    standardUnit: "g",
+    units: {
+      mg: { factor: 0.001, aliases: ["milligram"] },
+      g: { factor: 1, aliases: ["gram", "gramme"] },
+      kg: { factor: 1000, aliases: ["kilogram", "kilo"] },
+      t: { factor: 1_000_000, aliases: ["tonne", "ton", "metric ton"] },
+      lb: { factor: 453.59237, aliases: ["lbs", "pound", "pounds"] },
+      oz: { factor: 28.349523125, aliases: ["ounce"] },
+    },
+  },
+
+  volume: {
+    standardUnit: "l",
+    units: {
+      ml: { factor: 0.001, aliases: ["milliliter", "millilitre"] },
+      l: { factor: 1, aliases: ["L", "liter", "litre"] },
+      m3: { factor: 1000, aliases: ["m³", "cubic meter", "cubic metre"] },
+      gal: { factor: 3.785411784, aliases: ["gallon", "us gal"] },
+    },
+  },
+
+  pressure: {
+    standardUnit: "Pa",
+    units: {
+      Pa: { factor: 1, aliases: ["pascal"] },
+      hPa: { factor: 100, aliases: ["hectopascal"] },
+      kPa: { factor: 1000, aliases: ["kilopascal"] },
+      MPa: { factor: 1_000_000, aliases: ["megapascal"] },
+      // Vacuum-equipment convention: mbar and Torr are the units
+      // datasheets actually print for ultimate pressure.
+      mbar: { factor: 100, aliases: ["millibar"] },
+      bar: { factor: 100_000 },
+      Torr: { factor: 133.322368421, aliases: ["torr", "mmHg"] },
+      mTorr: { factor: 0.133322368421, aliases: ["millitorr", "micron"] },
+      atm: { factor: 101_325, aliases: ["atmosphere"] },
+      psi: { factor: 6894.757293168, aliases: ["PSI"] },
+    },
+  },
+
+  power: {
+    standardUnit: "W",
+    units: {
+      W: { factor: 1, aliases: ["watt"] },
+      kW: { factor: 1000, aliases: ["kilowatt"] },
+      MW: { factor: 1_000_000, aliases: ["megawatt"] },
+      hp: { factor: 745.6998715823, aliases: ["horsepower", "HP"] },
+    },
+  },
+
+  flow: {
+    // Pumping speed / flow rate — the headline spec for a vacuum pump.
+    standardUnit: "m3/h",
+    units: {
+      "m3/h": {
+        factor: 1,
+        aliases: ["m³/h", "m3/hr", "m³/hr", "cmh", "cbm/h"],
+      },
+      "m3/min": { factor: 60, aliases: ["m³/min"] },
+      "m3/s": { factor: 3600, aliases: ["m³/s"] },
+      "l/min": { factor: 0.06, aliases: ["lpm", "L/min"] },
+      "l/s": { factor: 3.6, aliases: ["lps", "L/s"] },
+      cfm: { factor: 1.69901082, aliases: ["CFM", "ft3/min", "ft³/min"] },
+    },
+  },
+
+  voltage: {
+    standardUnit: "V",
+    units: {
+      mV: { factor: 0.001, aliases: ["millivolt"] },
+      V: { factor: 1, aliases: ["volt"] },
+      kV: { factor: 1000, aliases: ["kilovolt"] },
+    },
+  },
+
+  current: {
+    standardUnit: "A",
+    units: {
+      mA: { factor: 0.001, aliases: ["milliamp", "milliampere"] },
+      A: { factor: 1, aliases: ["amp", "ampere"] },
+    },
+  },
+
+  frequency: {
+    standardUnit: "Hz",
+    units: {
+      Hz: { factor: 1, aliases: ["hertz"] },
+      kHz: { factor: 1000, aliases: ["kilohertz"] },
+      rpm: { factor: 1 / 60, aliases: ["RPM", "r/min"] },
+    },
+  },
+
+  speed: {
+    standardUnit: "m/s",
+    units: {
+      "m/s": { factor: 1 },
+      "km/h": { factor: 1 / 3.6, aliases: ["kph", "kmh"] },
+      mph: { factor: 0.44704 },
+    },
+  },
+
+  area: {
+    standardUnit: "m2",
+    units: {
+      mm2: { factor: 0.000001, aliases: ["mm²"] },
+      cm2: { factor: 0.0001, aliases: ["cm²"] },
+      m2: { factor: 1, aliases: ["m²", "sqm"] },
+    },
+  },
+
+  time: {
+    standardUnit: "s",
+    units: {
+      ms: { factor: 0.001, aliases: ["millisecond"] },
+      s: { factor: 1, aliases: ["sec", "second"] },
+      min: { factor: 60, aliases: ["minute"] },
+      h: { factor: 3600, aliases: ["hr", "hour"] },
+      d: { factor: 86400, aliases: ["day"] },
+    },
+  },
+};
+
+export const MEASURE_FAMILIES = Object.keys(FAMILIES) as MeasureFamily[];
+
+export function isMeasureFamily(value: string): value is MeasureFamily {
+  return Object.prototype.hasOwnProperty.call(FAMILIES, value);
+}
+
+/**
+ * Resolve a user-typed unit within a family, tolerating aliases and
+ * case. Returns the canonical key, or null if unknown.
+ *
+ * Matching is exact-first, then case-insensitive: `mbar` and `MPa`
+ * differ only by case in a way that matters (milli- vs mega-), so a
+ * case-insensitive match must never win over an exact one.
+ */
+export function resolveUnit(
+  family: MeasureFamily,
+  unit: string,
+): string | null {
+  const def = FAMILIES[family];
+  if (!def) return null;
+  const raw = unit.trim();
+  if (!raw) return null;
+
+  if (Object.prototype.hasOwnProperty.call(def.units, raw)) return raw;
+
+  for (const [key, u] of Object.entries(def.units)) {
+    if (u.aliases?.includes(raw)) return key;
+  }
+
+  // Case-insensitive fallback, checked only after every exact match
+  // failed — see the note above about mbar vs MPa.
+  const lower = raw.toLowerCase();
+  for (const [key, u] of Object.entries(def.units)) {
+    if (key.toLowerCase() === lower) return key;
+    if (u.aliases?.some((a) => a.toLowerCase() === lower)) return key;
+  }
+  return null;
+}
+
+/** Every unit key + alias a family accepts, for error messages and UI. */
+export function unitsFor(family: MeasureFamily): string[] {
+  return Object.keys(FAMILIES[family]?.units ?? {});
+}
+
+export class UnitError extends Error {
+  constructor(
+    message: string,
+    readonly code: "UNKNOWN_FAMILY" | "UNKNOWN_UNIT" | "NOT_FINITE",
+  ) {
+    super(message);
+    this.name = "UnitError";
+  }
+}
+
+/**
+ * Convert an authored value into its family's standard unit.
+ *
+ * Returns both numbers so callers can store the canonical magnitude for
+ * querying AND the authored unit for display — a datasheet must show
+ * "0.1 mbar" as the editor wrote it, not "10 Pa".
+ */
+export function normalize(
+  family: MeasureFamily,
+  value: number,
+  unit: string,
+): {
+  value: number;
+  unit: string;
+  standardValue: number;
+  standardUnit: string;
+} {
+  const def = FAMILIES[family];
+  if (!def) {
+    throw new UnitError(`Unknown measure family "${family}"`, "UNKNOWN_FAMILY");
+  }
+  if (!Number.isFinite(value)) {
+    throw new UnitError(
+      `Measurement value must be a finite number (got ${value})`,
+      "NOT_FINITE",
+    );
+  }
+  const key = resolveUnit(family, unit);
+  if (!key) {
+    throw new UnitError(
+      `Unknown unit "${unit}" for family "${family}". Accepted: ${unitsFor(family).join(", ")}`,
+      "UNKNOWN_UNIT",
+    );
+  }
+  const standardValue = value * def.units[key].factor;
+  if (!Number.isFinite(standardValue)) {
+    throw new UnitError(`Converting ${value} ${unit} overflowed`, "NOT_FINITE");
+  }
+  return {
+    value,
+    unit: key,
+    standardValue,
+    standardUnit: def.standardUnit,
+  };
+}
+
+/**
+ * Convert a canonical magnitude back into a target unit — for rendering
+ * a comparison table in whatever unit the viewer prefers.
+ */
+export function denormalize(
+  family: MeasureFamily,
+  standardValue: number,
+  targetUnit: string,
+): number {
+  const def = FAMILIES[family];
+  if (!def) {
+    throw new UnitError(`Unknown measure family "${family}"`, "UNKNOWN_FAMILY");
+  }
+  const key = resolveUnit(family, targetUnit);
+  if (!key) {
+    throw new UnitError(
+      `Unknown unit "${targetUnit}" for family "${family}"`,
+      "UNKNOWN_UNIT",
+    );
+  }
+  return standardValue / def.units[key].factor;
+}

--- a/src/routes/api/public/specs/[entityType]/[entityId]/+server.ts
+++ b/src/routes/api/public/specs/[entityType]/[entityId]/+server.ts
@@ -1,0 +1,100 @@
+/**
+ * GET /api/public/specs/[entityType]/[entityId] — one entity's datasheet.
+ *
+ * The Phase 3 (#88) read path that rich text can't provide: typed,
+ * unit-aware spec rows grouped for rendering.
+ *
+ *   /api/public/specs/entry/a100?locale=th
+ *
+ * Each row carries BOTH numbers:
+ *   `standardValue` — canonical magnitude, for client-side sorting
+ *   `displayValue` + `unit` — as the editor authored it, for rendering
+ *
+ * So a client can sort a table by flow rate without re-deriving units,
+ * and still print "0.1 mbar" rather than "10 Pa".
+ */
+import { json } from "@sveltejs/kit";
+import { authenticate, hasScope } from "$lib/server/api-auth";
+import { createAttributeService } from "$lib/server/content/attributes";
+import type { RequestHandler } from "./$types";
+
+/**
+ * Entity types readable through this endpoint.
+ *
+ * `entity_type` is free text in the schema (deliberately — values attach
+ * to anything with a stable id), but the PUBLIC surface is an allowlist:
+ * without it, a caller could enumerate specs attached to internal entity
+ * types that were never meant to be published.
+ */
+const PUBLIC_ENTITY_TYPES = new Set(["entry", "shop_variant", "shop_product"]);
+
+/**
+ * Sibling static routes under /specs. SvelteKit ranks static segments
+ * above dynamic ones, so `/specs/compare` and `/specs/facet/x` reach
+ * their own handlers — but neither is a valid entity type, and listing
+ * them here means a future rename can't silently make this route shadow
+ * one of them.
+ */
+const RESERVED_SEGMENTS = new Set(["compare", "facet"]);
+
+export const GET: RequestHandler = async ({
+  params,
+  url,
+  request,
+  locals,
+  platform,
+}) => {
+  const env = platform?.env;
+  if (!env) return json({ error: "Platform not ready" }, { status: 503 });
+
+  if (
+    RESERVED_SEGMENTS.has(params.entityType) ||
+    !PUBLIC_ENTITY_TYPES.has(params.entityType)
+  ) {
+    return json(
+      { error: `Unknown entity type "${params.entityType}"` },
+      { status: 404 },
+    );
+  }
+
+  const auth = await authenticate(request, locals.content);
+  if (!auth.ok || !auth.key) {
+    return json({ error: "Unauthorized" }, { status: 401 });
+  }
+  // Specs describe content across collection types, and API scopes are a
+  // closed union in code, so there is no `specs:read` to mint. `*:read`
+  // is the conservative choice — a key limited to `articles:read` should
+  // not silently gain the spec surface.
+  if (!hasScope(auth.key, "*:read")) {
+    return json(
+      { error: "Forbidden — *:read scope required" },
+      { status: 403 },
+    );
+  }
+
+  const locale = url.searchParams.get("locale") ?? undefined;
+  const service = createAttributeService(env);
+
+  try {
+    const groups = await service.datasheet(
+      params.entityType,
+      params.entityId,
+      locale,
+    );
+    return json(
+      {
+        data: {
+          entityType: params.entityType,
+          entityId: params.entityId,
+          groups,
+        },
+      },
+      { headers: { "cache-control": "public, max-age=60" } },
+    );
+  } catch (err) {
+    return json(
+      { error: err instanceof Error ? err.message : "Failed to load specs" },
+      { status: 400 },
+    );
+  }
+};

--- a/src/routes/api/public/specs/compare/+server.ts
+++ b/src/routes/api/public/specs/compare/+server.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/public/specs/compare — side-by-side comparison table.
+ *
+ *   /api/public/specs/compare?type=entry&ids=a100,a200,a300&locale=en
+ *
+ * Returns rows × entities, pivoted so a template renders one table row
+ * per spec with one column per entity — the shape #88 says rich text
+ * cannot produce. Attributes absent on an entity come back as `null`
+ * rather than being omitted, so columns stay aligned.
+ */
+import { json } from "@sveltejs/kit";
+import { authenticate, hasScope } from "$lib/server/api-auth";
+import { createAttributeService } from "$lib/server/content/attributes";
+import type { RequestHandler } from "./$types";
+
+const PUBLIC_ENTITY_TYPES = new Set(["entry", "shop_variant", "shop_product"]);
+
+/**
+ * A comparison table stops being readable long before this, and each id
+ * costs a bound parameter — capped so a crafted `ids=` can't turn one
+ * request into an unbounded query.
+ */
+const MAX_COMPARE = 12;
+
+export const GET: RequestHandler = async ({
+  url,
+  request,
+  locals,
+  platform,
+}) => {
+  const env = platform?.env;
+  if (!env) return json({ error: "Platform not ready" }, { status: 503 });
+
+  const entityType = url.searchParams.get("type") ?? "entry";
+  if (!PUBLIC_ENTITY_TYPES.has(entityType)) {
+    return json(
+      { error: `Unknown entity type "${entityType}"` },
+      { status: 404 },
+    );
+  }
+
+  const auth = await authenticate(request, locals.content);
+  if (!auth.ok || !auth.key) {
+    return json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth.key, "*:read")) {
+    return json(
+      { error: "Forbidden — *:read scope required" },
+      { status: 403 },
+    );
+  }
+
+  const ids = Array.from(
+    new Set(
+      (url.searchParams.get("ids") ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    ),
+  );
+  if (ids.length === 0) {
+    return json(
+      { error: "ids is required (comma-separated)" },
+      { status: 400 },
+    );
+  }
+  if (ids.length > MAX_COMPARE) {
+    return json(
+      { error: `Cannot compare more than ${MAX_COMPARE} entities at once` },
+      { status: 400 },
+    );
+  }
+
+  const locale = url.searchParams.get("locale") ?? undefined;
+  const service = createAttributeService(env);
+
+  try {
+    const result = await service.compare(entityType, ids, locale);
+    return json(
+      { data: { entityType, ...result } },
+      { headers: { "cache-control": "public, max-age=60" } },
+    );
+  } catch (err) {
+    return json(
+      { error: err instanceof Error ? err.message : "Comparison failed" },
+      { status: 400 },
+    );
+  }
+};

--- a/src/routes/api/public/specs/facet/[attributeKey]/+server.ts
+++ b/src/routes/api/public/specs/facet/[attributeKey]/+server.ts
@@ -1,0 +1,143 @@
+/**
+ * GET /api/public/specs/facet/[attributeKey] — faceted filter / sort.
+ *
+ * The capability #88 calls out as impossible with rich text: "facet the
+ * whole catalog by pumping speed."
+ *
+ *   /api/public/specs/facet/flow_rate?min=100&max=300&unit=m3/h
+ *   /api/public/specs/facet/flow_rate?min=1.67&unit=m3/min   ← same rows
+ *   /api/public/specs/facet/oil_free?bool=true
+ *   /api/public/specs/facet/pump_type?options=dry,oil_sealed
+ *
+ * The two flow examples select the same entities: bounds are normalized
+ * into the attribute's standard unit before comparison, so a caller can
+ * express a range in whatever unit they think in.
+ */
+import { json } from "@sveltejs/kit";
+import { authenticate, hasScope } from "$lib/server/api-auth";
+import { createAttributeService } from "$lib/server/content/attributes";
+import type { RequestHandler } from "./$types";
+
+const PUBLIC_ENTITY_TYPES = new Set(["entry", "shop_variant", "shop_product"]);
+
+export const GET: RequestHandler = async ({
+  params,
+  url,
+  request,
+  locals,
+  platform,
+}) => {
+  const env = platform?.env;
+  if (!env) return json({ error: "Platform not ready" }, { status: 503 });
+
+  const auth = await authenticate(request, locals.content);
+  if (!auth.ok || !auth.key) {
+    return json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth.key, "*:read")) {
+    return json(
+      { error: "Forbidden — *:read scope required" },
+      { status: 403 },
+    );
+  }
+
+  const p = url.searchParams;
+
+  // Entity type is optional here (facet across everything by default),
+  // but if supplied it must be a public one — otherwise this endpoint
+  // becomes a way to enumerate internal entity types.
+  const entityType = p.get("type") ?? undefined;
+  if (entityType && !PUBLIC_ENTITY_TYPES.has(entityType)) {
+    return json(
+      { error: `Unknown entity type "${entityType}"` },
+      { status: 404 },
+    );
+  }
+
+  const service = createAttributeService(env);
+
+  // Exactly one filter shape per request — accepting several at once
+  // would make precedence ambiguous.
+  const hasRange = p.has("min") || p.has("max");
+  const hasOptions = p.has("options");
+  const hasBool = p.has("bool");
+  if ([hasRange, hasOptions, hasBool].filter(Boolean).length !== 1) {
+    return json(
+      {
+        error:
+          "Supply exactly one filter: min/max (range), options (select), or bool",
+      },
+      { status: 400 },
+    );
+  }
+
+  const num = (key: string): number | undefined => {
+    const raw = p.get(key);
+    if (raw === null || raw === "") return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  };
+
+  let filter: Parameters<typeof service.facet>[1];
+  if (hasRange) {
+    const min = num("min");
+    const max = num("max");
+    if (min === undefined && max === undefined) {
+      return json(
+        { error: "min and/or max must be finite numbers" },
+        { status: 400 },
+      );
+    }
+    if (min !== undefined && max !== undefined && min > max) {
+      return json({ error: "min cannot exceed max" }, { status: 400 });
+    }
+    filter = {
+      kind: "range",
+      min,
+      max,
+      unit: p.get("unit") ?? undefined,
+    };
+  } else if (hasOptions) {
+    const options = Array.from(
+      new Set(
+        (p.get("options") ?? "")
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      ),
+    );
+    if (options.length === 0) {
+      return json({ error: "options must be non-empty" }, { status: 400 });
+    }
+    filter = { kind: "option", options };
+  } else {
+    const raw = p.get("bool");
+    if (raw !== "true" && raw !== "false") {
+      return json({ error: "bool must be true or false" }, { status: 400 });
+    }
+    filter = { kind: "boolean", value: raw === "true" };
+  }
+
+  const sortRaw = p.get("sort");
+  const limitRaw = Number(p.get("limit") ?? "100");
+
+  try {
+    const results = await service.facet(params.attributeKey, filter, {
+      entityType,
+      sort: sortRaw === "desc" ? "desc" : "asc",
+      limit: Number.isFinite(limitRaw) ? limitRaw : 100,
+    });
+    return json(
+      {
+        data: results,
+        meta: { attributeKey: params.attributeKey, count: results.length },
+      },
+      { headers: { "cache-control": "public, max-age=60" } },
+    );
+  } catch (err) {
+    return json(
+      { error: err instanceof Error ? err.message : "Facet failed" },
+      { status: 400 },
+    );
+  }
+};


### PR DESCRIPTION
Phase 3 of #88. Gives a catalog's leaf entity **structured, unit-aware, queryable specs** — the capability #88 identifies as the real blocker: *"you can't sort a `<div>` by flow rate, facet on 'ultimate pressure < 0.1 mbar', or diff two variants column-by-column."*

Akeneo's three primitives, sized down for SQLite:

| Table | Role |
|---|---|
| `attribute_definitions` | what an attribute is (typed, unit-aware) |
| `attribute_families` + `family_attributes` | which attributes a product type carries |
| `attribute_values` | the values, normalized and indexed |

## Unit normalization is the load-bearing piece

A measurement stores **both** the canonical magnitude (in its family's standard unit) *and* the unit the editor authored in. That split makes two things true at once:

- **facet/sort** — `value_number BETWEEN ?` is correct across mixed authored units
- **display** — the datasheet still renders `0.1 mbar`, not `10 Pa`

The seed fixture authors the same attribute in **different units on purpose**:

```
a100  flow 63 m3/h          a200  flow 100 m3/min   → 6000 m3/h
a100  press 0.1 mbar        a200  press 1 Torr      → 10 vs 133.3 Pa
```

`flow_rate >= 100 m3/h` returns **a200 only**. `ultimate_pressure <= 50 Pa` returns **a100 only** — even though a100's authored pressure (`0.1`) is numerically *smaller* than a200's (`1`) while having the *better* vacuum. Comparing authored numbers gets both backwards.

Conversion factors are unit-tested, including #88's own worked examples (533 g vs 0.6 kg; 0.1 mbar = 10 Pa) and the mbar/MPa case trap where milli- and mega- differ only by case. **Temperature is deliberately excluded** — °C→K is an offset, not a scale, and offset units in a factor table produce silently wrong numbers.

## Endpoints

```
GET /api/public/specs/[entityType]/[entityId]   datasheet, grouped
GET /api/public/specs/compare?type=&ids=        pivoted comparison
GET /api/public/specs/facet/[attributeKey]      typed filter + sort
```

`entity_type` is free text in the schema (values attach to anything with a stable id), but the public surface is an allowlist so a caller can't enumerate specs on internal entity types. All three require `*:read` — API scopes are a closed union in code, so there is no `specs:read` to mint, and a key limited to `articles:read` shouldn't silently gain this.

## Two real bugs, caught before merge

**1. `facet()` silently compared un-normalized bounds.** `toStandard` fell through to the raw value when the attribute was a measurement but the caller omitted `unit`. So `?min=0.1` on a pressure attribute compared `0.1` against pascals and matched nothing — reporting *"no results"* rather than an error, the worst failure mode for a filter. A measurement range now **requires** an explicit unit.

**2. The unique index was inert for non-localized values.** `locale` was nullable, and **SQLite treats NULLs as DISTINCT in a UNIQUE index** — so `(entity, attribute, locale)` didn't constrain the common case at all.

Verified rather than reasoned about: inserting a second row for the same entity+attribute with `locale=NULL` was **accepted**, leaving 2 rows. A datasheet would render the attribute twice and `compare()` would pick whichever row `.find()` reached first. `setValue`'s existence check masked it; the seed script and any direct SQL bypassed it.

Fixed with a `NOT NULL` `'*'` sentinel. Re-verified on a rebuilt DB — the duplicate is now rejected:

```
UNIQUE constraint failed: attribute_values.entity_type,
attribute_values.entity_id, attribute_values.attribute_id,
attribute_values.locale
```

Migration `0021` is amended in place rather than followed by a fix-up: it has not shipped anywhere except a local dev DB.

## Why a narrow EAV here when #68 rejected EAV

Not in tension. #68 rejected EAV as *general content storage* — wp_postmeta-style, every field a row against one untyped LONGTEXT, where filtering N fields costs N self-joins. This differs in exactly the ways that caused that failure: **typed value columns** so numbers compare as numbers; **a registry** so there's no free-text `meta_key` to diverge; **cardinality bounded** by what a family declares; and it's a **sidecar**, not the primary read path (entry content still lives in `entries.data_json`).

#88 is explicit the alternatives are worse — discrete columns can't express heterogeneous families without a sparse mega-table, and a free-form `[{label,value}]` list can't be faceted or compared at all.

## Verified against real SQLite

- 9-attribute × 2-entity comparison table renders grouped and labelled
- `15 hp → 11185.5 W`, `2 in → 50.8 mm`, `12.5 kg → 12500 g`
- every display value round-trips **exactly** to what was authored
- EN + TH labels stored and retrievable
- facet → `SEARCH USING INDEX attribute_values_numeric_facet_idx`
- datasheet → `SEARCH USING INDEX attribute_values_entity_idx`

Both are index seeks, not scans. `pnpm check` clean (3 pre-existing paraglide errors), `pnpm lint` exit 0, `pnpm build` passes.

## Definition of done

This closes items 4 (datasheet + compare + facet by a measurement attribute) and, with Phase 2, item 5 (≥2 locales) of the task's DoD. **Item 1's "via the admin/registry" still needs Phase 4's UI** — attributes are currently authored through the service API or the seed script.

## Design notes

- Variant axes must be select/measurement/boolean, enforced at write time (Akeneo's rule). A free-text axis can't group siblings — `"1.5kW"` vs `"1.5 kW"` would be different variants.
- Deleting a definition is refused while any family declares it; cascading would silently strip the attribute from every product.
- `datasheet`/`compare`/`facet` are batched with chunked `inArray`, so they don't reintroduce the N+1 Phase 1 removed.
- Labels fall back to the machine key when a translation is missing — more useful than an empty cell.
- Nothing is client-specific: `vacuum_pump`/`flow_rate` are ordinary user-defined attributes in a fixture, not engine knowledge.

## Remaining

**Phase 4** — registry-driven admin UI + `entry_versions` wiring — is the last phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)