### PR TITLE
feat(v3.6-phase4): registry-driven admin UI — closes the #68/#88 roadmap

### DIFF
--- a/src/lib/components/admin/registry/RegistryField.svelte
+++ b/src/lib/components/admin/registry/RegistryField.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	/**
+	 * Renders ONE registry field as the right editor — Phase 4 (#68 §F).
+	 *
+	 * Driven entirely by the field's registry row, so a content type added
+	 * by inserting rows gets a working form with no code change. Replaces
+	 * the per-type hand-built forms.
+	 */
+	import { Input, Label } from '$lib/components/ui';
+	import MarkdownEditor from '$lib/components/editor/MarkdownEditor.svelte';
+	import { FIELD_EDITORS, fieldName, labelFor } from './field-map';
+	import type { CollectionField } from '$lib/server/content/registry/schema';
+
+	let {
+		field,
+		value = '',
+		locale,
+		uiLocale = 'en',
+		relationChoices = [],
+	}: {
+		field: CollectionField;
+		value?: unknown;
+		/** Set for localized fields — namespaces the input name per locale. */
+		locale?: string;
+		/** Which label translation to show in the admin chrome. */
+		uiLocale?: string;
+		/** Entry pick-list for relation/component fields. */
+		relationChoices?: { id: string; label: string }[];
+	} = $props();
+
+	const spec = $derived(FIELD_EDITORS[field.type]);
+	const name = $derived(fieldName(field.type, field.apiId, locale));
+	const label = $derived(labelFor(field.labelsJson, field.apiId, uiLocale));
+	const config = $derived.by(() => {
+		if (!field.configJson) return {} as Record<string, unknown>;
+		try {
+			const parsed = JSON.parse(field.configJson);
+			return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: {};
+		} catch {
+			return {} as Record<string, unknown>;
+		}
+	});
+
+	const enumOptions = $derived(
+		Array.isArray(config.options) ? (config.options as string[]) : []
+	);
+
+	/**
+	 * Relation values arrive as an array of ids; the form posts them as one
+	 * comma-separated field so a single FormData entry carries order.
+	 */
+	const selectedIds = $derived(
+		Array.isArray(value) ? (value as unknown[]).map(String) : []
+	);
+
+	const asText = $derived(
+		value === null || value === undefined
+			? ''
+			: typeof value === 'object'
+				? JSON.stringify(value, null, 2)
+				: String(value)
+	);
+</script>
+
+<div class="space-y-1.5">
+	<Label for={name} class="text-xs font-medium">
+		{label}
+		{#if field.required}
+			<span class="text-destructive" title="Required">*</span>
+		{/if}
+		{#if locale}
+			<span class="ml-1 font-normal text-muted-foreground">({locale})</span>
+		{/if}
+	</Label>
+
+	{#if spec.editor === 'richtext'}
+		<MarkdownEditor {name} value={asText} />
+	{:else if spec.editor === 'textarea' || spec.editor === 'json'}
+		<textarea
+			id={name}
+			{name}
+			rows={spec.editor === 'json' ? 6 : 3}
+			class="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm"
+			value={asText}
+		></textarea>
+	{:else if spec.editor === 'checkbox'}
+		<!-- Hidden companion so an unchecked box still posts a value —
+		     otherwise "false" is indistinguishable from "not submitted",
+		     and unchecking could never clear the field. -->
+		<input type="hidden" {name} value="false" />
+		<input
+			id={name}
+			type="checkbox"
+			{name}
+			value="true"
+			checked={value === true || value === 'true'}
+			class="h-4 w-4 rounded border-input"
+		/>
+	{:else if spec.editor === 'select'}
+		<select
+			id={name}
+			{name}
+			class="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+		>
+			<option value="">— none —</option>
+			{#each enumOptions as option (option)}
+				<option value={option} selected={String(value) === option}>
+					{option}
+				</option>
+			{/each}
+		</select>
+	{:else if spec.editor === 'relation' || spec.editor === 'component'}
+		{#if relationChoices.length === 0}
+			<p class="text-xs text-muted-foreground">
+				No entries available to link yet.
+			</p>
+			<input type="hidden" {name} value={selectedIds.join(',')} />
+		{:else}
+			<select
+				id={name}
+				{name}
+				multiple={config.cardinality !== 'one'}
+				size={Math.min(6, Math.max(3, relationChoices.length))}
+				class="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+			>
+				{#each relationChoices as choice (choice.id)}
+					<option value={choice.id} selected={selectedIds.includes(choice.id)}>
+						{choice.label}
+					</option>
+				{/each}
+			</select>
+			<p class="text-xs text-muted-foreground">
+				{config.cardinality === 'one'
+					? 'Pick one.'
+					: 'Ctrl/Cmd-click for several. Selection order is preserved.'}
+			</p>
+		{/if}
+	{:else if spec.editor === 'media'}
+		<!-- Media is referenced by id; the existing picker lands in a
+		     follow-up, so this accepts an id directly for now. -->
+		<Input id={name} {name} value={asText} placeholder="media id" />
+		<p class="text-xs text-muted-foreground">
+			Media id. The library picker is not wired into registry forms yet.
+		</p>
+	{:else}
+		<Input id={name} {name} type={spec.inputType ?? 'text'} value={asText} />
+	{/if}
+
+	{#if spec.hint}
+		<p class="text-xs text-muted-foreground">{spec.hint}</p>
+	{/if}
+</div>

--- a/src/lib/components/admin/registry/field-map.ts
+++ b/src/lib/components/admin/registry/field-map.ts
@@ -1,0 +1,143 @@
+/**
+ * Field-type → editor-component map — Phase 4 (#68 §F).
+ *
+ * The registry stores what a field IS; this decides how to edit it. One
+ * table replaces the per-type hand-built forms (`ArticleForm.svelte`,
+ * `PageForm.svelte`), which is the whole point: adding a content type
+ * should not mean writing a form.
+ *
+ * Deliberately data, not a `{#if type === …}` chain in the template —
+ * a new field type is one entry here plus one component, and the
+ * exhaustiveness check below makes a missing entry a compile error
+ * rather than a silently unrendered field.
+ */
+import type { FieldType } from "$lib/server/content/registry/schema";
+
+/** Which input primitive renders a field. */
+export type EditorKind =
+  | "text"
+  | "textarea"
+  | "richtext"
+  | "number"
+  | "checkbox"
+  | "date"
+  | "datetime"
+  | "select"
+  | "json"
+  | "media"
+  | "relation"
+  | "component";
+
+export interface FieldRenderSpec {
+  editor: EditorKind;
+  /** `type` attribute for plain <input> editors. */
+  inputType?: "text" | "number" | "email" | "url" | "date" | "datetime-local";
+  /**
+   * True when the value lives in `entry_relations` rather than the
+   * entry document — the form posts ids, not scalars.
+   */
+  relational?: boolean;
+  /** Shown under the input when the field has no description. */
+  hint?: string;
+}
+
+/**
+ * Exhaustive by construction: `Record<FieldType, …>` means adding a
+ * `FieldType` without adding it here fails the type-check. That matters
+ * because the fallback for an unmapped field would be to render nothing,
+ * i.e. silently drop editable content.
+ */
+export const FIELD_EDITORS: Record<FieldType, FieldRenderSpec> = {
+  text: { editor: "text", inputType: "text" },
+  richtext: {
+    editor: "richtext",
+    hint: "Markdown. Supports the same {{block:key}} shortcodes as articles.",
+  },
+  number: { editor: "number", inputType: "number" },
+  boolean: { editor: "checkbox" },
+  date: { editor: "date", inputType: "date" },
+  datetime: { editor: "datetime", inputType: "datetime-local" },
+  email: { editor: "text", inputType: "email" },
+  url: { editor: "text", inputType: "url", hint: "Must be http(s)." },
+  slug: {
+    editor: "text",
+    inputType: "text",
+    hint: "Lowercase ASCII, hyphens. Shared across locales.",
+  },
+  enum: { editor: "select" },
+  json: {
+    editor: "json",
+    hint: "Raw JSON. Validated on save.",
+  },
+  media: { editor: "media", relational: false },
+  relation: { editor: "relation", relational: true },
+  component: { editor: "component", relational: true },
+};
+
+/** Field types whose values are posted as ids, not document scalars. */
+export function isRelational(type: FieldType): boolean {
+  return FIELD_EDITORS[type].relational === true;
+}
+
+/**
+ * Form field name for a field, namespaced so the action can tell
+ * document values, per-locale values and relations apart in one
+ * FormData.
+ *
+ *   f.sku            non-localized document value
+ *   l.en.title       localized document value
+ *   r.variants       relation edge list (comma-separated ids)
+ */
+export function fieldName(
+  type: FieldType,
+  apiId: string,
+  locale?: string,
+): string {
+  if (isRelational(type)) return `r.${apiId}`;
+  return locale ? `l.${locale}.${apiId}` : `f.${apiId}`;
+}
+
+/** Parse a namespaced form key back into its parts. */
+export function parseFieldName(
+  key: string,
+):
+  | { kind: "doc"; apiId: string }
+  | { kind: "localized"; locale: string; apiId: string }
+  | { kind: "relation"; apiId: string }
+  | null {
+  if (key.startsWith("f.")) {
+    const apiId = key.slice(2);
+    return apiId ? { kind: "doc", apiId } : null;
+  }
+  if (key.startsWith("r.")) {
+    const apiId = key.slice(2);
+    return apiId ? { kind: "relation", apiId } : null;
+  }
+  if (key.startsWith("l.")) {
+    // `l.<locale>.<apiId>` — apiIds can't contain dots (API_ID_PATTERN),
+    // so splitting on the FIRST dot after the prefix is unambiguous.
+    const rest = key.slice(2);
+    const dot = rest.indexOf(".");
+    if (dot <= 0) return null;
+    const locale = rest.slice(0, dot);
+    const apiId = rest.slice(dot + 1);
+    return locale && apiId ? { kind: "localized", locale, apiId } : null;
+  }
+  return null;
+}
+
+/** Human label for a field, falling back to its machine key. */
+export function labelFor(
+  labelsJson: string | null,
+  apiId: string,
+  locale: string,
+): string {
+  if (!labelsJson) return apiId;
+  try {
+    const parsed = JSON.parse(labelsJson) as Record<string, unknown>;
+    const hit = parsed[locale] ?? parsed.en;
+    return typeof hit === "string" && hit ? hit : apiId;
+  } catch {
+    return apiId;
+  }
+}

--- a/src/lib/components/admin/sidebar-nav.ts
+++ b/src/lib/components/admin/sidebar-nav.ts
@@ -5,6 +5,7 @@ import {
   FileText,
   FilePlus,
   Image as ImageIcon,
+  Database,
   Folder,
   Menu as MenuIcon,
   Tag,
@@ -140,6 +141,14 @@ registerNavGroup({
   id: "taxonomy",
   title: m.cms_categories,
   items: [
+    {
+      // Phase 4 (#68): user-defined content types. Admin-only because
+      // defining a type changes what the public API exposes.
+      href: "/admin/content",
+      label: () => "Content types",
+      icon: Database,
+      roles: ["super_admin", "admin"],
+    },
     { href: "/admin/categories", label: m.cms_categories, icon: Folder },
     { href: "/admin/tags", label: m.cms_tags, icon: Tag },
     {

--- a/src/lib/server/content/registry/service.ts
+++ b/src/lib/server/content/registry/service.ts
@@ -1014,7 +1014,17 @@ export class RegistryService {
     };
 
     for (const field of collection.fields) {
-      if (field.promoted) continue;
+      // A promoted field has a real generated column, so it does NOT need
+      // an index row to be *filterable* — but it does need one to be
+      // checked for uniqueness, because `assertUniqueFields` reads this
+      // table. Skipping promoted fields here silently disabled `unique`
+      // on exactly the fields most likely to declare it (a SKU or ref
+      // code is the canonical case for BOTH flags). Verified: a duplicate
+      // value on a unique+promoted field was accepted.
+      //
+      // The extra row is cheap and keeps uniqueness enforcement in one
+      // place rather than forking on `promoted`.
+      if (field.promoted && !field.unique) continue;
       if (field.localized) {
         for (const [locale, doc] of Object.entries(localizedDocs)) {
           push(field, locale, doc[field.apiId]);

--- a/src/routes/(admin)/admin/content/+page.server.ts
+++ b/src/routes/(admin)/admin/content/+page.server.ts
@@ -1,0 +1,137 @@
+/**
+ * /admin/content — registry collection index — Phase 4 (#68 §F).
+ *
+ * Lists every user-defined content type with its field and entry counts,
+ * and creates new ones. This is the "add a content type without a
+ * deploy" surface the whole registry exists to enable.
+ */
+import { error, fail, redirect } from "@sveltejs/kit";
+import { hasRole } from "$lib/server/auth/permissions";
+import { logAudit } from "$lib/server/audit";
+import { drizzle } from "drizzle-orm/d1";
+import { count } from "drizzle-orm";
+import { createRegistryQuery } from "$lib/server/content/registry";
+import { entries } from "$lib/server/content/registry/schema";
+import { RegistryError } from "$lib/server/content/registry/types";
+import type { Actions, PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ locals, platform }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  // Defining a content type is a schema change in every meaningful sense
+  // — it alters what the public API exposes — so it sits with admins,
+  // not editors, matching how /admin/settings is gated.
+  if (!hasRole(locals.user, "admin")) throw redirect(302, "/admin");
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const registry = createRegistryQuery(env);
+  const collections = await registry.service.listCollectionsWithFields();
+
+  // Entry counts in ONE grouped query rather than one per collection.
+  const db = drizzle(env.DB);
+  const counts = await db
+    .select({ collectionId: entries.collectionId, total: count() })
+    .from(entries)
+    .groupBy(entries.collectionId)
+    .all();
+  const byCollection = new Map(counts.map((c) => [c.collectionId, c.total]));
+
+  const promotionBudget = await registry.service.promotions.budget();
+
+  return {
+    collections: collections.map((c) => ({
+      id: c.id,
+      apiId: c.apiId,
+      kind: c.kind,
+      localized: c.localized,
+      draftPublish: c.draftPublish,
+      system: c.system,
+      description: c.description,
+      fieldCount: c.fields.length,
+      promotedCount: c.fields.filter((f) => f.promoted).length,
+      entryCount: byCollection.get(c.id) ?? 0,
+    })),
+    promotionBudget,
+  };
+};
+
+export const actions: Actions = {
+  createCollection: async ({ request, locals, platform }) => {
+    if (!locals.user) throw redirect(302, "/admin/login");
+    if (!hasRole(locals.user, "admin"))
+      return fail(403, { error: "Forbidden" });
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const fd = await request.formData();
+    const apiId = String(fd.get("apiId") ?? "").trim();
+    const kind = String(fd.get("kind") ?? "collection");
+    const description = String(fd.get("description") ?? "").trim() || undefined;
+
+    if (kind !== "collection" && kind !== "single" && kind !== "component") {
+      return fail(400, { error: "Invalid kind" });
+    }
+
+    try {
+      const registry = createRegistryQuery(env);
+      const created = await registry.service.createCollection({
+        apiId,
+        kind,
+        localized: fd.get("localized") === "true",
+        draftPublish: fd.get("draftPublish") === "true",
+        description,
+        createdBy: locals.user.id,
+      });
+      await logAudit(env.DB, locals.user.id, "collection.create", created.id, {
+        apiId,
+        kind,
+      });
+      return { success: true, message: `Created "${apiId}"` };
+    } catch (err) {
+      // RegistryError carries a specific reason (bad apiId, reserved
+      // name, shadows a built-in) — surface it rather than a generic
+      // failure, because the fix is always caller-side.
+      return fail(400, {
+        error:
+          err instanceof RegistryError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "Failed to create collection",
+      });
+    }
+  },
+
+  deleteCollection: async ({ request, locals, platform }) => {
+    if (!locals.user) throw redirect(302, "/admin/login");
+    if (!hasRole(locals.user, "admin"))
+      return fail(403, { error: "Forbidden" });
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const fd = await request.formData();
+    const apiId = String(fd.get("apiId") ?? "").trim();
+    // Deleting a collection cascades to every entry in it. Require the
+    // apiId to be retyped so a stray click can't destroy content.
+    const confirm = String(fd.get("confirm") ?? "").trim();
+    if (!apiId) return fail(400, { error: "Missing apiId" });
+    if (confirm !== apiId) {
+      return fail(400, {
+        error: `Type "${apiId}" to confirm — this deletes every entry in it`,
+      });
+    }
+
+    try {
+      const registry = createRegistryQuery(env);
+      await registry.service.deleteCollection(apiId);
+      await logAudit(env.DB, locals.user.id, "collection.delete", apiId, {
+        apiId,
+      });
+      return { success: true, message: `Deleted "${apiId}"` };
+    } catch (err) {
+      return fail(400, {
+        error: err instanceof Error ? err.message : "Failed to delete",
+      });
+    }
+  },
+};

--- a/src/routes/(admin)/admin/content/+page.svelte
+++ b/src/routes/(admin)/admin/content/+page.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import { Database, Plus, Layers, Box } from 'lucide-svelte';
+	import { Badge, Button, Input, Label } from '$lib/components/ui';
+	import type { PageData, ActionData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+	let submitting = $state(false);
+	let confirmFor = $state<string | null>(null);
+
+	const KIND_ICON = { collection: Layers, single: Box, component: Box };
+</script>
+
+<div class="max-w-5xl space-y-6 p-6">
+	<header class="flex items-center gap-3">
+		<Database class="h-6 w-6 text-muted-foreground" />
+		<div>
+			<h1 class="text-2xl font-semibold">Content types</h1>
+			<p class="text-sm text-muted-foreground">
+				Define content types as data — no migration, no deploy.
+			</p>
+		</div>
+	</header>
+
+	{#if form?.error}
+		<div
+			class="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+		>
+			{form.error}
+		</div>
+	{/if}
+	{#if form?.success && form.message}
+		<div
+			class="rounded-md border border-green-600/50 bg-green-600/10 p-3 text-sm text-green-700"
+		>
+			{form.message}
+		</div>
+	{/if}
+
+	<section class="space-y-4 rounded-lg border border-border p-4">
+		<h2
+			class="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+		>
+			New content type
+		</h2>
+		<form
+			method="POST"
+			action="?/createCollection"
+			use:enhance={() => {
+				submitting = true;
+				return async ({ update }) => {
+					await update({ reset: true });
+					submitting = false;
+				};
+			}}
+			class="space-y-3"
+		>
+			<div class="grid grid-cols-2 gap-3">
+				<div class="space-y-1">
+					<Label for="apiId" class="text-xs">API id</Label>
+					<Input
+						id="apiId"
+						name="apiId"
+						required
+						maxlength={63}
+						placeholder="product_line"
+					/>
+					<p class="text-xs text-muted-foreground">
+						Lowercase, single underscores. Immutable once created.
+					</p>
+				</div>
+				<div class="space-y-1">
+					<Label for="kind" class="text-xs">Kind</Label>
+					<select
+						id="kind"
+						name="kind"
+						class="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm"
+					>
+						<option value="collection">Collection — many entries</option>
+						<option value="single">Single — exactly one entry</option>
+						<option value="component">Component — nested block only</option>
+					</select>
+				</div>
+			</div>
+
+			<div class="space-y-1">
+				<Label for="description" class="text-xs">Description (internal)</Label>
+				<Input id="description" name="description" maxlength={200} />
+			</div>
+
+			<div class="flex gap-6 text-sm">
+				<label class="flex items-center gap-2">
+					<input type="hidden" name="localized" value="false" />
+					<input
+						type="checkbox"
+						name="localized"
+						value="true"
+						checked
+						class="h-4 w-4 rounded border-input"
+					/>
+					Localized
+				</label>
+				<label class="flex items-center gap-2">
+					<input type="hidden" name="draftPublish" value="false" />
+					<input
+						type="checkbox"
+						name="draftPublish"
+						value="true"
+						checked
+						class="h-4 w-4 rounded border-input"
+					/>
+					Draft / publish workflow
+				</label>
+			</div>
+
+			<div class="flex justify-end">
+				<Button type="submit" disabled={submitting}>
+					<Plus class="mr-2 h-4 w-4" />
+					{submitting ? 'Creating…' : 'Create'}
+				</Button>
+			</div>
+		</form>
+	</section>
+
+	<section>
+		<div class="mb-3 flex items-baseline justify-between">
+			<h2
+				class="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+			>
+				Existing ({data.collections.length})
+			</h2>
+			<p class="text-xs text-muted-foreground">
+				Promoted columns: {data.promotionBudget.used} / {data.promotionBudget
+					.max}
+				{#if data.promotionBudget.remaining <= 5}
+					<span class="ml-1 text-amber-600">— near D1's column limit</span>
+				{/if}
+			</p>
+		</div>
+
+		{#if data.collections.length === 0}
+			<div
+				class="rounded-lg border border-dashed border-border p-8 text-center"
+			>
+				<p class="text-sm text-muted-foreground">
+					No content types yet. Create one above.
+				</p>
+			</div>
+		{:else}
+			<div class="overflow-hidden rounded-lg border border-border">
+				<table class="w-full text-sm">
+					<thead
+						class="bg-muted/50 text-left text-xs uppercase text-muted-foreground"
+					>
+						<tr>
+							<th class="px-4 py-2">API id</th>
+							<th class="px-4 py-2">Kind</th>
+							<th class="px-4 py-2 text-right">Fields</th>
+							<th class="px-4 py-2 text-right">Entries</th>
+							<th class="px-4 py-2">Flags</th>
+							<th class="w-40 px-4 py-2"></th>
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-border">
+						{#each data.collections as c (c.id)}
+							{@const Icon = KIND_ICON[c.kind] ?? Layers}
+							<tr>
+								<td class="px-4 py-3">
+									<div class="flex items-center gap-2">
+										<Icon class="h-4 w-4 text-muted-foreground" />
+										<code class="font-mono font-medium">{c.apiId}</code>
+									</div>
+									{#if c.description}
+										<div class="mt-0.5 text-xs text-muted-foreground">
+											{c.description}
+										</div>
+									{/if}
+								</td>
+								<td class="px-4 py-3 text-xs text-muted-foreground">
+									{c.kind}
+								</td>
+								<td class="px-4 py-3 text-right tabular-nums">
+									{c.fieldCount}
+									{#if c.promotedCount > 0}
+										<span
+											class="text-muted-foreground"
+											title="{c.promotedCount} promoted to indexed columns"
+										>
+											({c.promotedCount}★)
+										</span>
+									{/if}
+								</td>
+								<td class="px-4 py-3 text-right tabular-nums">
+									{c.entryCount}
+								</td>
+								<td class="px-4 py-3">
+									<div class="flex flex-wrap gap-1">
+										{#if c.localized}<Badge variant="outline">i18n</Badge>{/if}
+										{#if c.draftPublish}<Badge variant="outline">draft</Badge
+											>{/if}
+										{#if c.system}<Badge>system</Badge>{/if}
+									</div>
+								</td>
+								<td class="px-4 py-3">
+									<div class="flex items-center justify-end gap-1">
+										<Button
+											href={resolve('/(admin)/admin/content/[collection]', {
+												collection: c.apiId,
+											})}
+											variant="ghost"
+											size="sm"
+										>
+											Manage
+										</Button>
+										{#if !c.system}
+											{#if confirmFor === c.apiId}
+												<form
+													method="POST"
+													action="?/deleteCollection"
+													use:enhance={() => {
+														return async ({ update }) => {
+															confirmFor = null;
+															await update();
+														};
+													}}
+													class="flex items-center gap-1"
+												>
+													<input type="hidden" name="apiId" value={c.apiId} />
+													<Input
+														name="confirm"
+														placeholder={c.apiId}
+														class="h-8 w-28 text-xs"
+														required
+													/>
+													<Button
+														type="submit"
+														variant="ghost"
+														size="sm"
+														class="text-destructive"
+													>
+														Confirm
+													</Button>
+												</form>
+											{:else}
+												<Button
+													variant="ghost"
+													size="sm"
+													class="text-destructive"
+													onclick={() => (confirmFor = c.apiId)}
+												>
+													Delete
+												</Button>
+											{/if}
+										{/if}
+									</div>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</section>
+</div>

--- a/src/routes/(admin)/admin/content/[collection]/+page.server.ts
+++ b/src/routes/(admin)/admin/content/[collection]/+page.server.ts
@@ -1,0 +1,212 @@
+/**
+ * /admin/content/[collection] — field schema + entry list — Phase 4.
+ *
+ * Two jobs on one screen: define the type's fields, and list its
+ * entries. Kept together because they're the same mental task early on
+ * ("what is a Product, and what Products exist?").
+ */
+import { error, fail, redirect } from "@sveltejs/kit";
+import { hasRole } from "$lib/server/auth/permissions";
+import { logAudit } from "$lib/server/audit";
+import { drizzle } from "drizzle-orm/d1";
+import { desc, eq } from "drizzle-orm";
+import { createRegistryQuery } from "$lib/server/content/registry";
+import {
+  entries,
+  FIELD_TYPES,
+  type FieldType,
+} from "$lib/server/content/registry/schema";
+import { RegistryError } from "$lib/server/content/registry/types";
+import type { Actions, PageServerLoad } from "./$types";
+
+/** Entries shown before paging; the list is a management aid, not a feed. */
+const ENTRY_PAGE_SIZE = 50;
+
+export const load: PageServerLoad = async ({ params, locals, platform }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const registry = createRegistryQuery(env);
+  const collection = await registry.service.getCollection(params.collection);
+  if (!collection)
+    throw error(404, `Unknown content type "${params.collection}"`);
+
+  const db = drizzle(env.DB);
+  const rows = await db
+    .select({
+      id: entries.id,
+      slug: entries.slug,
+      status: entries.status,
+      updatedAt: entries.updatedAt,
+    })
+    .from(entries)
+    .where(eq(entries.collectionId, collection.id))
+    .orderBy(desc(entries.updatedAt))
+    .limit(ENTRY_PAGE_SIZE)
+    .all();
+
+  // Only admins may change the schema; editors manage entries. Surfaced
+  // to the UI so it can hide the field form rather than letting an
+  // editor submit something the action will reject.
+  const canEditSchema = hasRole(locals.user, "admin");
+
+  return {
+    collection: {
+      apiId: collection.apiId,
+      kind: collection.kind,
+      localized: collection.localized,
+      system: collection.system,
+      fields: collection.fields.map((f) => ({
+        id: f.id,
+        apiId: f.apiId,
+        type: f.type,
+        required: f.required,
+        localized: f.localized,
+        unique: f.unique,
+        promoted: f.promoted,
+        position: f.position,
+        configJson: f.configJson,
+      })),
+    },
+    entries: rows,
+    entryPageSize: ENTRY_PAGE_SIZE,
+    fieldTypes: FIELD_TYPES,
+    canEditSchema,
+    /** Targets a relation/component field can point at. */
+    collectionChoices: (await registry.service.listCollections()).map((c) => ({
+      apiId: c.apiId,
+      kind: c.kind,
+    })),
+  };
+};
+
+export const actions: Actions = {
+  addField: async ({ params, request, locals, platform }) => {
+    if (!locals.user) throw redirect(302, "/admin/login");
+    if (!hasRole(locals.user, "admin"))
+      return fail(403, { error: "Forbidden" });
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const fd = await request.formData();
+    const apiId = String(fd.get("apiId") ?? "").trim();
+    const type = String(fd.get("type") ?? "") as FieldType;
+    if (!FIELD_TYPES.includes(type)) {
+      return fail(400, { error: `Unknown field type "${type}"` });
+    }
+
+    // Per-type config is assembled here rather than accepting raw JSON
+    // from the form — a hand-written configJson is the easiest way to
+    // create a field the reader can't interpret.
+    let config: Record<string, unknown> = {};
+    if (type === "enum") {
+      const options = String(fd.get("options") ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      config = { options };
+    } else if (type === "relation") {
+      config = {
+        target: String(fd.get("target") ?? "").trim(),
+        cardinality: fd.get("cardinality") === "many" ? "many" : "one",
+      };
+    } else if (type === "component") {
+      config = {
+        allowed: String(fd.get("allowed") ?? "")
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        cardinality: fd.get("cardinality") === "one" ? "one" : "many",
+      };
+    } else if (type === "media") {
+      config = {
+        cardinality: fd.get("cardinality") === "many" ? "many" : "one",
+      };
+    }
+
+    try {
+      const registry = createRegistryQuery(env);
+      const field = await registry.service.addField(params.collection, {
+        apiId,
+        type,
+        required: fd.get("required") === "true",
+        localized: fd.get("localized") === "true",
+        unique: fd.get("unique") === "true",
+        promoted: fd.get("promoted") === "true",
+        config,
+        position: Number(fd.get("position") ?? 0) || 0,
+      });
+      await logAudit(env.DB, locals.user.id, "collection.update", field.id, {
+        collection: params.collection,
+        addedField: apiId,
+        type,
+      });
+      return { success: true, message: `Added field "${apiId}"` };
+    } catch (err) {
+      return fail(400, {
+        error:
+          err instanceof RegistryError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "Failed to add field",
+      });
+    }
+  },
+
+  removeField: async ({ params, request, locals, platform }) => {
+    if (!locals.user) throw redirect(302, "/admin/login");
+    if (!hasRole(locals.user, "admin"))
+      return fail(403, { error: "Forbidden" });
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const fd = await request.formData();
+    const apiId = String(fd.get("apiId") ?? "").trim();
+    if (!apiId) return fail(400, { error: "Missing field apiId" });
+
+    try {
+      const registry = createRegistryQuery(env);
+      await registry.service.removeField(params.collection, apiId);
+      await logAudit(env.DB, locals.user.id, "collection.update", apiId, {
+        collection: params.collection,
+        removedField: apiId,
+      });
+      // Values stay in each entry's document (see removeField) — say so,
+      // because "deleted" would imply the content is gone.
+      return {
+        success: true,
+        message: `Removed "${apiId}" from the schema. Stored values are kept and reappear if you re-add it.`,
+      };
+    } catch (err) {
+      return fail(400, {
+        error: err instanceof Error ? err.message : "Failed to remove field",
+      });
+    }
+  },
+
+  deleteEntry: async ({ request, locals, platform }) => {
+    if (!locals.user) throw redirect(302, "/admin/login");
+    if (!hasRole(locals.user, "editor"))
+      return fail(403, { error: "Forbidden" });
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const fd = await request.formData();
+    const id = String(fd.get("id") ?? "").trim();
+    if (!id) return fail(400, { error: "Missing entry id" });
+
+    try {
+      const registry = createRegistryQuery(env);
+      await registry.service.deleteEntry(id);
+      await logAudit(env.DB, locals.user.id, "entry.delete", id, {});
+      return { success: true, message: "Entry deleted" };
+    } catch (err) {
+      return fail(400, {
+        error: err instanceof Error ? err.message : "Failed to delete entry",
+      });
+    }
+  },
+};

--- a/src/routes/(admin)/admin/content/[collection]/+page.svelte
+++ b/src/routes/(admin)/admin/content/[collection]/+page.svelte
@@ -1,0 +1,396 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import { ArrowLeft, Plus, Star } from 'lucide-svelte';
+	import { Badge, Button, Input, Label } from '$lib/components/ui';
+	import type { PageData, ActionData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+	let newType = $state('text');
+	let submitting = $state(false);
+
+	const c = $derived(data.collection);
+
+	/** Which extra config inputs the chosen field type needs. */
+	const needsOptions = $derived(newType === 'enum');
+	const needsTarget = $derived(newType === 'relation');
+	const needsAllowed = $derived(newType === 'component');
+	const needsCardinality = $derived(
+		newType === 'relation' || newType === 'component' || newType === 'media'
+	);
+	/** Only document scalars can be promoted to an indexed column. */
+	const canPromote = $derived(
+		!['relation', 'component', 'json', 'richtext', 'media'].includes(newType)
+	);
+
+	const componentTargets = $derived(
+		data.collectionChoices.filter((x) => x.kind === 'component')
+	);
+	const relationTargets = $derived(
+		data.collectionChoices.filter((x) => x.kind !== 'component')
+	);
+</script>
+
+<div class="max-w-5xl space-y-6 p-6">
+	<header class="space-y-2">
+		<Button
+			href={resolve('/(admin)/admin/content')}
+			variant="ghost"
+			size="sm"
+			class="-ml-2"
+		>
+			<ArrowLeft class="mr-1 h-4 w-4" /> Content types
+		</Button>
+		<div class="flex items-center gap-3">
+			<h1 class="font-mono text-2xl font-semibold">{c.apiId}</h1>
+			<Badge variant="outline">{c.kind}</Badge>
+			{#if c.localized}<Badge variant="outline">i18n</Badge>{/if}
+		</div>
+	</header>
+
+	{#if form?.error}
+		<div
+			class="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+		>
+			{form.error}
+		</div>
+	{/if}
+	{#if form?.success && form.message}
+		<div
+			class="rounded-md border border-green-600/50 bg-green-600/10 p-3 text-sm text-green-700"
+		>
+			{form.message}
+		</div>
+	{/if}
+
+	<!-- ── Fields ───────────────────────────────────────────── -->
+	<section class="space-y-3">
+		<h2
+			class="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+		>
+			Fields ({c.fields.length})
+		</h2>
+
+		{#if c.fields.length > 0}
+			<div class="overflow-hidden rounded-lg border border-border">
+				<table class="w-full text-sm">
+					<thead
+						class="bg-muted/50 text-left text-xs uppercase text-muted-foreground"
+					>
+						<tr>
+							<th class="px-4 py-2">API id</th>
+							<th class="px-4 py-2">Type</th>
+							<th class="px-4 py-2">Flags</th>
+							{#if data.canEditSchema}<th class="w-20 px-4 py-2"></th>{/if}
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-border">
+						{#each c.fields as f (f.id)}
+							<tr>
+								<td class="px-4 py-2.5">
+									<code class="font-mono">{f.apiId}</code>
+								</td>
+								<td class="px-4 py-2.5 text-xs text-muted-foreground">
+									{f.type}
+								</td>
+								<td class="px-4 py-2.5">
+									<div class="flex flex-wrap gap-1">
+										{#if f.required}<Badge variant="outline">required</Badge
+											>{/if}
+										{#if f.localized}<Badge variant="outline">i18n</Badge>{/if}
+										{#if f.unique}<Badge variant="outline">unique</Badge>{/if}
+										{#if f.promoted}
+											<Badge title="Indexed generated column">
+												<Star class="mr-1 h-3 w-3" />indexed
+											</Badge>
+										{/if}
+									</div>
+								</td>
+								{#if data.canEditSchema}
+									<td class="px-4 py-2.5 text-right">
+										<form method="POST" action="?/removeField" use:enhance>
+											<input type="hidden" name="apiId" value={f.apiId} />
+											<Button
+												type="submit"
+												variant="ghost"
+												size="sm"
+												class="text-destructive"
+											>
+												Remove
+											</Button>
+										</form>
+									</td>
+								{/if}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			<p class="text-sm text-muted-foreground">
+				No fields yet — add one below before creating entries.
+			</p>
+		{/if}
+
+		{#if data.canEditSchema}
+			<details class="rounded-lg border border-border p-4">
+				<summary class="cursor-pointer text-sm font-medium">Add a field</summary>
+				<form
+					method="POST"
+					action="?/addField"
+					use:enhance={() => {
+						submitting = true;
+						return async ({ update }) => {
+							await update({ reset: true });
+							submitting = false;
+						};
+					}}
+					class="mt-4 space-y-3"
+				>
+					<div class="grid grid-cols-3 gap-3">
+						<div class="space-y-1">
+							<Label for="apiId" class="text-xs">API id</Label>
+							<Input id="apiId" name="apiId" required maxlength={63} />
+						</div>
+						<div class="space-y-1">
+							<Label for="type" class="text-xs">Type</Label>
+							<select
+								id="type"
+								name="type"
+								bind:value={newType}
+								class="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm"
+							>
+								{#each data.fieldTypes as t (t)}
+									<option value={t}>{t}</option>
+								{/each}
+							</select>
+						</div>
+						<div class="space-y-1">
+							<Label for="position" class="text-xs">Position</Label>
+							<Input id="position" name="position" type="number" value="0" />
+						</div>
+					</div>
+
+					{#if needsOptions}
+						<div class="space-y-1">
+							<Label for="options" class="text-xs">
+								Options (comma-separated)
+							</Label>
+							<Input
+								id="options"
+								name="options"
+								required
+								placeholder="draft, review, live"
+							/>
+						</div>
+					{/if}
+
+					{#if needsTarget}
+						<div class="space-y-1">
+							<Label for="target" class="text-xs">Target content type</Label>
+							<select
+								id="target"
+								name="target"
+								required
+								class="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm"
+							>
+								{#each relationTargets as t (t.apiId)}
+									<option value={t.apiId}>{t.apiId}</option>
+								{/each}
+							</select>
+						</div>
+					{/if}
+
+					{#if needsAllowed}
+						<div class="space-y-1">
+							<Label for="allowed" class="text-xs">
+								Allowed components (comma-separated)
+							</Label>
+							<Input
+								id="allowed"
+								name="allowed"
+								required
+								placeholder={componentTargets.map((t) => t.apiId).join(', ') ||
+									'create a component type first'}
+							/>
+							<p class="text-xs text-muted-foreground">
+								Must be component-kind types. Several makes it a dynamic zone.
+							</p>
+						</div>
+					{/if}
+
+					{#if needsCardinality}
+						<div class="space-y-1">
+							<Label for="cardinality" class="text-xs">Cardinality</Label>
+							<select
+								id="cardinality"
+								name="cardinality"
+								class="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm"
+							>
+								<option value="one">one</option>
+								<option value="many">many (ordered)</option>
+							</select>
+						</div>
+					{/if}
+
+					<div class="flex flex-wrap gap-5 text-sm">
+						<label class="flex items-center gap-2">
+							<input type="hidden" name="required" value="false" />
+							<input
+								type="checkbox"
+								name="required"
+								value="true"
+								class="h-4 w-4 rounded border-input"
+							/>
+							Required
+						</label>
+						{#if c.localized}
+							<label class="flex items-center gap-2">
+								<input type="hidden" name="localized" value="false" />
+								<input
+									type="checkbox"
+									name="localized"
+									value="true"
+									class="h-4 w-4 rounded border-input"
+								/>
+								Per-locale
+							</label>
+						{/if}
+						<label class="flex items-center gap-2">
+							<input type="hidden" name="unique" value="false" />
+							<input
+								type="checkbox"
+								name="unique"
+								value="true"
+								class="h-4 w-4 rounded border-input"
+							/>
+							Unique
+						</label>
+						{#if canPromote}
+							<label class="flex items-center gap-2">
+								<input type="hidden" name="promoted" value="false" />
+								<input
+									type="checkbox"
+									name="promoted"
+									value="true"
+									class="h-4 w-4 rounded border-input"
+								/>
+								Indexed
+								<span class="text-xs text-muted-foreground">
+									(needed to filter/sort by it — spends part of D1's
+									100-column budget)
+								</span>
+							</label>
+						{/if}
+					</div>
+
+					<div class="flex justify-end">
+						<Button type="submit" disabled={submitting}>
+							<Plus class="mr-2 h-4 w-4" />
+							{submitting ? 'Adding…' : 'Add field'}
+						</Button>
+					</div>
+				</form>
+			</details>
+		{/if}
+	</section>
+
+	<!-- ── Entries ──────────────────────────────────────────── -->
+	<section class="space-y-3">
+		<div class="flex items-baseline justify-between">
+			<h2
+				class="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+			>
+				Entries
+			</h2>
+			{#if c.fields.length > 0}
+				<Button
+					href={resolve('/(admin)/admin/content/[collection]/[id]', {
+						collection: c.apiId,
+						id: 'new',
+					})}
+					size="sm"
+				>
+					<Plus class="mr-2 h-4 w-4" /> New entry
+				</Button>
+			{/if}
+		</div>
+
+		{#if data.entries.length === 0}
+			<div
+				class="rounded-lg border border-dashed border-border p-8 text-center"
+			>
+				<p class="text-sm text-muted-foreground">
+					{c.fields.length === 0
+						? 'Add a field first, then create entries.'
+						: 'No entries yet.'}
+				</p>
+			</div>
+		{:else}
+			<div class="overflow-hidden rounded-lg border border-border">
+				<table class="w-full text-sm">
+					<thead
+						class="bg-muted/50 text-left text-xs uppercase text-muted-foreground"
+					>
+						<tr>
+							<th class="px-4 py-2">Slug</th>
+							<th class="px-4 py-2">Status</th>
+							<th class="px-4 py-2">Updated</th>
+							<th class="w-32 px-4 py-2"></th>
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-border">
+						{#each data.entries as e (e.id)}
+							<tr>
+								<td class="px-4 py-2.5">
+									<code class="font-mono text-xs">
+										{e.slug ?? e.id}
+									</code>
+								</td>
+								<td class="px-4 py-2.5">
+									<Badge variant={e.status === 'published' ? 'default' : 'outline'}>
+										{e.status}
+									</Badge>
+								</td>
+								<td class="px-4 py-2.5 text-xs text-muted-foreground">
+									{e.updatedAt.slice(0, 16).replace('T', ' ')}
+								</td>
+								<td class="px-4 py-2.5">
+									<div class="flex items-center justify-end gap-1">
+										<Button
+											href={resolve(
+												'/(admin)/admin/content/[collection]/[id]',
+												{ collection: c.apiId, id: e.id },
+											)}
+											variant="ghost"
+											size="sm"
+										>
+											Edit
+										</Button>
+										<form method="POST" action="?/deleteEntry" use:enhance>
+											<input type="hidden" name="id" value={e.id} />
+											<Button
+												type="submit"
+												variant="ghost"
+												size="sm"
+												class="text-destructive"
+											>
+												Delete
+											</Button>
+										</form>
+									</div>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+			{#if data.entries.length === data.entryPageSize}
+				<p class="text-xs text-muted-foreground">
+					Showing the {data.entryPageSize} most recently updated. Paging lands
+					with the list-view work.
+				</p>
+			{/if}
+		{/if}
+	</section>
+</div>

--- a/src/routes/(admin)/admin/content/[collection]/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/content/[collection]/[id]/+page.server.ts
@@ -1,0 +1,343 @@
+/**
+ * /admin/content/[collection]/[id] — registry-driven entry editor.
+ *
+ * Phase 4 (#68 §F). The form is generated from `collection_fields`, so a
+ * content type created by inserting registry rows is immediately
+ * editable — no per-type form component. This is what replaces
+ * `ArticleForm.svelte` / `PageForm.svelte` for user-defined types.
+ *
+ * `id === "new"` renders an empty form; anything else loads that entry.
+ * One route rather than two because the field rendering, validation and
+ * save path are identical — only the initial values differ.
+ */
+import { error, fail, redirect } from "@sveltejs/kit";
+import { hasRole } from "$lib/server/auth/permissions";
+import { logAudit } from "$lib/server/audit";
+import { drizzle } from "drizzle-orm/d1";
+import { asc, eq, inArray } from "drizzle-orm";
+import { createRegistryQuery } from "$lib/server/content/registry";
+import {
+  entries,
+  entryLocalizations,
+  entryRelations,
+  entryVersions,
+} from "$lib/server/content/registry/schema";
+import { RegistryError } from "$lib/server/content/registry/types";
+import { RELATIONAL_FIELD_TYPES } from "$lib/server/content/registry/types";
+import { parseFieldName } from "$lib/components/admin/registry/field-map";
+import type { Actions, PageServerLoad } from "./$types";
+
+const NEW = "new";
+
+/** Cap on entries offered in a relation picker before it needs search. */
+const RELATION_CHOICE_LIMIT = 200;
+
+export const load: PageServerLoad = async ({ params, locals, platform }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const registry = createRegistryQuery(env);
+  const collection = await registry.service.getCollection(params.collection);
+  if (!collection) {
+    throw error(404, `Unknown content type "${params.collection}"`);
+  }
+
+  const isNew = params.id === NEW;
+  const db = drizzle(env.DB);
+
+  let entry: typeof entries.$inferSelect | null = null;
+  let document: Record<string, unknown> = {};
+  const localized: Record<string, Record<string, unknown>> = {};
+  const relations: Record<string, string[]> = {};
+
+  if (!isNew) {
+    entry =
+      (await db
+        .select()
+        .from(entries)
+        .where(eq(entries.id, params.id))
+        .limit(1)
+        .get()) ?? null;
+    if (!entry) throw error(404, "Entry not found");
+    // An entry id is globally unique, so a mismatched collection in the
+    // URL means a stale or hand-edited link — 404 rather than silently
+    // editing it under the wrong schema.
+    if (entry.collectionId !== collection.id) {
+      throw error(404, `Entry does not belong to "${collection.apiId}"`);
+    }
+
+    document = safeParse(entry.dataJson);
+
+    const locRows = await db
+      .select()
+      .from(entryLocalizations)
+      .where(eq(entryLocalizations.entryId, entry.id))
+      .all();
+    for (const row of locRows) {
+      localized[row.locale] = safeParse(row.dataJson);
+    }
+
+    const relRows = await db
+      .select()
+      .from(entryRelations)
+      .where(eq(entryRelations.entryId, entry.id))
+      .orderBy(asc(entryRelations.position))
+      .all();
+    for (const row of relRows) {
+      const list = relations[row.fieldApiId] ?? [];
+      list.push(row.targetEntryId);
+      relations[row.fieldApiId] = list;
+    }
+  }
+
+  // Pick-lists for relation/component fields. Loaded in ONE query for
+  // every target collection this type points at, rather than per field.
+  const targetApiIds = new Set<string>();
+  for (const field of collection.fields) {
+    if (!RELATIONAL_FIELD_TYPES.has(field.type)) continue;
+    const cfg = safeParse(field.configJson ?? "{}");
+    if (typeof cfg.target === "string") targetApiIds.add(cfg.target);
+    if (Array.isArray(cfg.allowed)) {
+      for (const a of cfg.allowed) {
+        if (typeof a === "string") targetApiIds.add(a);
+      }
+    }
+  }
+
+  const relationChoices: Record<string, { id: string; label: string }[]> = {};
+  if (targetApiIds.size > 0) {
+    const all = await registry.service.listCollections();
+    const wanted = all.filter((c) => targetApiIds.has(c.apiId));
+    if (wanted.length > 0) {
+      const rows = await db
+        .select({
+          id: entries.id,
+          slug: entries.slug,
+          collectionId: entries.collectionId,
+        })
+        .from(entries)
+        .where(
+          inArray(
+            entries.collectionId,
+            wanted.map((c) => c.id),
+          ),
+        )
+        .limit(RELATION_CHOICE_LIMIT)
+        .all();
+      const apiIdById = new Map(wanted.map((c) => [c.id, c.apiId]));
+      for (const field of collection.fields) {
+        if (!RELATIONAL_FIELD_TYPES.has(field.type)) continue;
+        const cfg = safeParse(field.configJson ?? "{}");
+        const allowed = new Set<string>(
+          typeof cfg.target === "string"
+            ? [cfg.target]
+            : Array.isArray(cfg.allowed)
+              ? (cfg.allowed as string[])
+              : [],
+        );
+        relationChoices[field.apiId] = rows
+          .filter((r) => allowed.has(apiIdById.get(r.collectionId) ?? ""))
+          .map((r) => ({ id: r.id, label: r.slug ?? r.id }));
+      }
+    }
+  }
+
+  const supportedLocales = (env.SUPPORTED_LOCALES ?? "en,th")
+    .split(",")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  // Version count only — snapshots can be large and the editor doesn't
+  // render them, so loading the JSON would be wasted bytes.
+  const versionCount = entry
+    ? (
+        await db
+          .select({ id: entryVersions.id })
+          .from(entryVersions)
+          .where(eq(entryVersions.entryId, entry.id))
+          .all()
+      ).length
+    : 0;
+
+  return {
+    isNew,
+    collection: {
+      apiId: collection.apiId,
+      kind: collection.kind,
+      localized: collection.localized,
+      draftPublish: collection.draftPublish,
+      fields: collection.fields,
+    },
+    entry: entry
+      ? {
+          id: entry.id,
+          slug: entry.slug,
+          status: entry.status,
+          publishedAt: entry.publishedAt,
+          updatedAt: entry.updatedAt,
+        }
+      : null,
+    values: { document, localized, relations },
+    relationChoices,
+    supportedLocales,
+    defaultLocale: env.DEFAULT_LOCALE ?? supportedLocales[0] ?? "en",
+    versionCount,
+  };
+};
+
+export const actions: Actions = {
+  save: async ({ params, request, locals, platform }) => {
+    if (!locals.user) throw redirect(302, "/admin/login");
+    if (!hasRole(locals.user, "editor"))
+      return fail(403, { error: "Forbidden" });
+    const env = platform?.env;
+    if (!env) return fail(503, { error: "Platform not ready" });
+
+    const fd = await request.formData();
+    const registry = createRegistryQuery(env);
+    const collection = await registry.service.getCollection(params.collection);
+    if (!collection) return fail(404, { error: "Unknown content type" });
+
+    const fieldsByApiId = new Map(collection.fields.map((f) => [f.apiId, f]));
+
+    // Reassemble the namespaced form keys (f./l.<locale>./r.) into the
+    // shape upsertEntry expects. Unknown keys are ignored rather than
+    // rejected — the form also carries slug/status/action fields.
+    const document: Record<string, unknown> = {};
+    const localizations: Record<string, Record<string, unknown>> = {};
+    const relations: Record<string, string[]> = {};
+
+    for (const [key, raw] of fd.entries()) {
+      const parsed = parseFieldName(key);
+      if (!parsed) continue;
+      const field = fieldsByApiId.get(parsed.apiId);
+      if (!field) continue;
+
+      if (parsed.kind === "relation") {
+        // A <select multiple> posts one entry per selection; a hidden
+        // input posts a comma-joined string. Handle both.
+        const all = fd.getAll(key).flatMap((v) =>
+          String(v)
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+        );
+        relations[parsed.apiId] = Array.from(new Set(all));
+        continue;
+      }
+
+      // A checkbox posts its hidden "false" companion AND "true" when
+      // checked, so take the LAST value — the checkbox is rendered after
+      // the hidden input.
+      const values = fd.getAll(key);
+      const value = String(values[values.length - 1] ?? raw);
+
+      if (parsed.kind === "doc") {
+        document[parsed.apiId] = coerceForField(field.type, value);
+      } else {
+        const bucket = localizations[parsed.locale] ?? {};
+        bucket[parsed.apiId] = coerceForField(field.type, value);
+        localizations[parsed.locale] = bucket;
+      }
+    }
+
+    const slugRaw = String(fd.get("slug") ?? "").trim();
+    const statusRaw = String(fd.get("status") ?? "");
+    const status =
+      statusRaw === "published" ||
+      statusRaw === "archived" ||
+      statusRaw === "draft"
+        ? statusRaw
+        : undefined;
+
+    try {
+      const saved = await registry.service.upsertEntry(params.collection, {
+        id: params.id === NEW ? undefined : params.id,
+        slug: slugRaw || undefined,
+        status,
+        data: document,
+        localizations,
+        relations,
+        createdBy: locals.user.id,
+      });
+      await logAudit(
+        env.DB,
+        locals.user.id,
+        params.id === NEW ? "entry.create" : "entry.update",
+        saved.id,
+        { collection: params.collection },
+      );
+
+      // Redirect after create so the URL stops saying "new" — otherwise a
+      // refresh would create a second entry.
+      if (params.id === NEW) {
+        throw redirect(
+          303,
+          `/admin/content/${params.collection}/${saved.id}?created=1`,
+        );
+      }
+      return { success: true, message: "Saved" };
+    } catch (err) {
+      // A thrown redirect is control flow, not an error — rethrow it or
+      // the create path silently reports failure after succeeding.
+      if (isRedirect(err)) throw err;
+      return fail(400, {
+        error:
+          err instanceof RegistryError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "Failed to save",
+      });
+    }
+  },
+};
+
+/** SvelteKit signals redirects by throwing; distinguish from real errors. */
+function isRedirect(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    "location" in err
+  );
+}
+
+/**
+ * Form values are always strings. Convert to the shape the registry
+ * validator expects; it does the real checking, so this only needs to
+ * get the TYPE right.
+ */
+function coerceForField(type: string, value: string): unknown {
+  if (value === "") return undefined;
+  switch (type) {
+    case "number":
+      return Number(value);
+    case "boolean":
+      return value === "true";
+    case "json":
+      try {
+        return JSON.parse(value);
+      } catch {
+        // Hand back the raw string so the validator reports "not
+        // JSON-serializable" against the user's actual input rather than
+        // this function swallowing it.
+        return value;
+      }
+    default:
+      return value;
+  }
+}
+
+function safeParse(json: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/routes/(admin)/admin/content/[collection]/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/content/[collection]/[id]/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+	/**
+	 * Registry-driven entry editor — Phase 4 (#68 §F).
+	 *
+	 * Every input here is generated from `collection_fields`. Nothing in
+	 * this file knows what an "article" or a "product" is, which is the
+	 * point: a content type added by inserting registry rows gets a
+	 * working editor with no new code.
+	 */
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import { ArrowLeft, Save, History } from 'lucide-svelte';
+	import { Badge, Button, Input, Label } from '$lib/components/ui';
+	import RegistryField from '$lib/components/admin/registry/RegistryField.svelte';
+	import type { PageData, ActionData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+	let submitting = $state(false);
+	let activeLocale = $state(data.defaultLocale);
+
+	const c = $derived(data.collection);
+	const sharedFields = $derived(c.fields.filter((f) => !f.localized));
+	const localizedFields = $derived(c.fields.filter((f) => f.localized));
+	const justCreated = $derived(page.url.searchParams.get('created') === '1');
+
+	function docValue(apiId: string): unknown {
+		return data.values.document[apiId];
+	}
+	function locValue(locale: string, apiId: string): unknown {
+		return data.values.localized[locale]?.[apiId];
+	}
+</script>
+
+<div class="max-w-3xl space-y-6 p-6">
+	<header class="space-y-2">
+		<Button
+			href={resolve('/(admin)/admin/content/[collection]', {
+				collection: c.apiId,
+			})}
+			variant="ghost"
+			size="sm"
+			class="-ml-2"
+		>
+			<ArrowLeft class="mr-1 h-4 w-4" /> {c.apiId}
+		</Button>
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-semibold">
+				{data.isNew ? 'New entry' : (data.entry?.slug ?? 'Entry')}
+			</h1>
+			{#if data.entry}
+				<Badge variant={data.entry.status === 'published' ? 'default' : 'outline'}>
+					{data.entry.status}
+				</Badge>
+			{/if}
+			{#if data.versionCount > 0}
+				<span
+					class="flex items-center gap-1 text-xs text-muted-foreground"
+					title="Snapshots taken on each save"
+				>
+					<History class="h-3 w-3" />
+					{data.versionCount}
+					{data.versionCount === 1 ? 'version' : 'versions'}
+				</span>
+			{/if}
+		</div>
+	</header>
+
+	{#if justCreated}
+		<div
+			class="rounded-md border border-green-600/50 bg-green-600/10 p-3 text-sm text-green-700"
+		>
+			Entry created.
+		</div>
+	{/if}
+	{#if form?.error}
+		<div
+			class="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+		>
+			{form.error}
+		</div>
+	{/if}
+	{#if form?.success && form.message}
+		<div
+			class="rounded-md border border-green-600/50 bg-green-600/10 p-3 text-sm text-green-700"
+		>
+			{form.message}
+		</div>
+	{/if}
+
+	{#if c.fields.length === 0}
+		<div class="rounded-lg border border-dashed border-border p-8 text-center">
+			<p class="text-sm text-muted-foreground">
+				This type has no fields yet. Add fields before creating entries.
+			</p>
+		</div>
+	{:else}
+		<form
+			method="POST"
+			action="?/save"
+			use:enhance={() => {
+				submitting = true;
+				return async ({ update }) => {
+					await update({ reset: false });
+					submitting = false;
+				};
+			}}
+			class="space-y-6"
+		>
+			<!-- ── Entry-level fields ────────────────────────── -->
+			<section class="grid grid-cols-2 gap-3 rounded-lg border border-border p-4">
+				<div class="space-y-1">
+					<Label for="slug" class="text-xs">Slug</Label>
+					<Input
+						id="slug"
+						name="slug"
+						value={data.entry?.slug ?? ''}
+						placeholder={c.kind === 'component'
+							? 'not used for components'
+							: 'auto-derived from title/name'}
+						disabled={c.kind === 'component'}
+					/>
+					<p class="text-xs text-muted-foreground">
+						Shared across locales. Leave blank to derive it.
+					</p>
+				</div>
+				{#if c.draftPublish}
+					<div class="space-y-1">
+						<Label for="status" class="text-xs">Status</Label>
+						<select
+							id="status"
+							name="status"
+							class="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm"
+						>
+							{#each ['draft', 'published', 'archived'] as s (s)}
+								<option value={s} selected={(data.entry?.status ?? 'draft') === s}>
+									{s}
+								</option>
+							{/each}
+						</select>
+					</div>
+				{/if}
+			</section>
+
+			<!-- ── Shared (non-localized) fields ─────────────── -->
+			{#if sharedFields.length > 0}
+				<section class="space-y-4 rounded-lg border border-border p-4">
+					<h2
+						class="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+					>
+						Fields
+					</h2>
+					{#each sharedFields as field (field.id)}
+						<RegistryField
+							{field}
+							value={data.values.relations[field.apiId] ??
+								docValue(field.apiId)}
+							uiLocale={data.defaultLocale}
+							relationChoices={data.relationChoices[field.apiId] ?? []}
+						/>
+					{/each}
+				</section>
+			{/if}
+
+			<!-- ── Localized fields, one tab per locale ──────── -->
+			{#if localizedFields.length > 0}
+				<section class="space-y-4 rounded-lg border border-border p-4">
+					<div class="flex items-center justify-between">
+						<h2
+							class="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+						>
+							Translations
+						</h2>
+						<div class="flex gap-1">
+							{#each data.supportedLocales as locale (locale)}
+								<Button
+									type="button"
+									variant={activeLocale === locale ? 'default' : 'ghost'}
+									size="sm"
+									onclick={() => (activeLocale = locale)}
+								>
+									{locale}
+								</Button>
+							{/each}
+						</div>
+					</div>
+
+					<!--
+						Every locale's inputs stay MOUNTED, just visually hidden —
+						they must all post, or switching tabs before save would
+						silently drop the other locales' edits.
+					-->
+					{#each data.supportedLocales as locale (locale)}
+						<div
+							class="space-y-4"
+							class:hidden={activeLocale !== locale}
+							aria-hidden={activeLocale !== locale}
+						>
+							{#each localizedFields as field (field.id)}
+								<RegistryField
+									{field}
+									{locale}
+									value={locValue(locale, field.apiId)}
+									uiLocale={data.defaultLocale}
+								/>
+							{/each}
+						</div>
+					{/each}
+
+					{#if data.supportedLocales.length > 1}
+						<p class="text-xs text-muted-foreground">
+							Required translations are only enforced for
+							<code>{data.defaultLocale}</code> — a partially translated entry
+							is a normal editorial state.
+						</p>
+					{/if}
+				</section>
+			{/if}
+
+			<div class="flex items-center justify-between">
+				<p class="text-xs text-muted-foreground">
+					{#if data.entry}
+						Last updated {data.entry.updatedAt.slice(0, 16).replace('T', ' ')}
+					{/if}
+				</p>
+				<Button type="submit" disabled={submitting}>
+					<Save class="mr-2 h-4 w-4" />
+					{submitting ? 'Saving…' : data.isNew ? 'Create' : 'Save'}
+				</Button>
+			</div>
+		</form>
+	{/if}
+</div>


### PR DESCRIPTION
Phase 4 of #68 §F — **the last phase**. Content types created by inserting registry rows are now editable in the admin with **no per-type form component**, which is what completes the "add a content type without a deploy" claim end to end.

## What ships

```
/admin/content                      list + create content types
/admin/content/[collection]         field schema + entry list
/admin/content/[collection]/[id]    registry-driven entry editor (id=new to create)
```

The editor is generated from `collection_fields` through a field-type → component map. Nothing in it knows what an "article" or a "product" is — this is what replaces `ArticleForm.svelte` / `PageForm.svelte` for user-defined types.

`FIELD_EDITORS` is typed `Record<FieldType, …>`, so adding a `FieldType` without adding an editor is a **compile error** rather than a field that silently renders nothing.

## Bug found in review — `unique` was silently unenforced

`reindexEntry` skipped promoted fields, on the reasoning that a promoted field has a real generated column and doesn't need an index row to be *filterable*. But `assertUniqueFields` reads that same index — so **`unique` was never checked on any promoted field**.

That hits exactly the fields most likely to declare both flags: a SKU or reference code is the canonical case for `unique` **and** `promoted`.

Verified rather than reasoned about — a duplicate `ref_code` on a unique+promoted field was **accepted**. Promoted fields are now still indexed when they declare `unique`, keeping enforcement in one place rather than forking on `promoted`.

## Verified against real SQLite

Definition-of-done items walked through the **same service methods the admin actions call**:

```
✓ define a type + 3 fields (2 promoted), no code changes
✓ create an entry, published, slug derived
✓ EN + TH stored: {"title":"Alpha study"} / {"title":"กรณีศึกษาอัลฟา"}
✓ duplicate on unique+promoted field rejected   ← the bug above
✓ missing required localized field rejected on create
```

Plus: all 14 field types have an editor; form-name encoding round-trips across the doc / localized / relation namespaces; malformed keys are rejected rather than mis-parsed; an underscored apiId survives the `l.<locale>.<apiId>` split.

Phase 2/3 seeds re-run clean, so the reindex change is not a regression. `pnpm check` clean (3 pre-existing paraglide errors), `pnpm lint` exit 0, `pnpm build` passes.

## Design decisions worth reviewing

- **Schema edits are admin-only; entries are editor-level.** Defining a type changes what the public API exposes, so it gets `/admin/settings`-grade permission. The UI hides the field form for editors rather than letting them submit something the action rejects.
- **Deleting a collection requires retyping its apiId** — it cascades to every entry.
- **Per-type field config is assembled server-side** from discrete inputs rather than accepting raw `configJson`; a hand-written config is the easiest way to create a field the reader can't interpret.
- **All locales stay mounted**, visually hidden rather than unmounted — otherwise switching tabs before save silently drops the other locales' edits.
- **Checkboxes post a hidden `false` companion.** Without it, "unchecked" is indistinguishable from "not submitted" and a boolean could never be cleared.
- **Create redirects to the real id** so a refresh can't create a second entry.
- **Removing a field keeps stored values** (matching `removeField`), and the message says so — "deleted" would imply the content is gone.
- Relation pick-lists load in one query across every target collection, not one per field.

## Roadmap status

| Phase | State |
|---|---|
| 1 — `find()`/`populate` query layer | ✅ #90 |
| 2 — collection registry | ✅ #91 |
| 3 — typed spec/attribute layer | ✅ #94 |
| **4 — registry-driven admin UI** | **this PR** |

With this merged, all five definition-of-done items are met: a brand-new user can define a multi-level related content type set + a component + typed spec attributes, create entries and link relations, fetch a fully-populated nested graph in one request, render a datasheet / compare / facet by a measurement attribute, and do all of it in ≥2 locales — without code changes.

## Known limits

- Media fields accept an id directly; wiring the existing `MediaPicker` into registry forms is follow-up.
- A dynamic zone allowing several component types resolves against the first for the pick-list — per-edge type selection needs a nested block editor.
- Entry list shows the 50 most recently updated; paging is follow-up.
- `entry_versions` snapshots are written on every save and the count is surfaced, but there is no restore UI yet.

## Note on deploying this

CI deploy is still blocked by #95 (`CLOUDFLARE_API_TOKEN` returns `7403 — not authorized`). Merging lands the code on `main`; the Worker won't go live until that token is fixed. Migration-wise this phase adds **no** new migration — it's UI over the Phase 2/3 schema, which is already applied to staging D1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)