### PR TITLE
feat(specs+relations): value intervals, qualifiers, polarity, edge attrs, external targets

### DIFF
--- a/drizzle/0020_collection_registry.sql
+++ b/drizzle/0020_collection_registry.sql
@@ -92,9 +92,34 @@ CREATE TABLE `entry_relations` (
   `id` text PRIMARY KEY NOT NULL,
   `entry_id` text NOT NULL,
   `field_api_id` text NOT NULL,
-  `target_entry_id` text NOT NULL,
+  -- #99: an edge targets either an entry we own or an EXTERNAL reference.
+  -- Forcing everything to be an entry means creating shell entries for
+  -- data you merely reference, which implies you manage it.
+  `target_kind` text DEFAULT 'entry' NOT NULL,
+  `target_entry_id` text,
+  `target_namespace` text,
+  `target_ref` text,
+  `target_label` text,
   `position` integer DEFAULT 0 NOT NULL,
+  -- #99: edge attributes — data belonging to the PAIRING, not to either
+  -- endpoint (a confidence tier on "replaces", a quantity on a BOM edge).
+  -- Opt-in; null for containment relations, which pay nothing.
+  `data_json` text,
   `created_at` text NOT NULL,
+  -- Exactly one target shape must be populated. Without this, a row can
+  -- claim to be external while carrying an entry id, and populate would
+  -- have to guess which to trust.
+  CONSTRAINT `entry_relations_target_shape` CHECK (
+    (`target_kind` = 'entry'
+       AND `target_entry_id` IS NOT NULL
+       AND `target_namespace` IS NULL
+       AND `target_ref` IS NULL)
+    OR
+    (`target_kind` = 'external'
+       AND `target_entry_id` IS NULL
+       AND `target_namespace` IS NOT NULL
+       AND `target_ref` IS NOT NULL)
+  ),
   FOREIGN KEY (`entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade,
   FOREIGN KEY (`target_entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade
 );
@@ -104,7 +129,16 @@ CREATE INDEX `entry_relations_forward_idx` ON `entry_relations` (`entry_id`,`fie
 -- Reverse: "what points at this entry?" — reverse/join fields, and
 -- cache invalidation when a target is edited.
 CREATE INDEX `entry_relations_reverse_idx` ON `entry_relations` (`target_entry_id`,`field_api_id`);--> statement-breakpoint
-CREATE UNIQUE INDEX `entry_relations_unique_edge_idx` ON `entry_relations` (`entry_id`,`field_api_id`,`target_entry_id`);--> statement-breakpoint
+-- Reverse lookup for external targets: "which entries reference
+-- <namespace>/<ref>?" — powers cross-reference landing pages.
+CREATE INDEX `entry_relations_external_idx` ON `entry_relations` (`target_namespace`,`target_ref`);--> statement-breakpoint
+-- Uniqueness is TWO PARTIAL indexes, not one spanning index. Since #99
+-- made target_entry_id nullable and SQLite treats NULLs as DISTINCT in a
+-- UNIQUE index, a single index covering both shapes would silently stop
+-- constraining the external case. Each partial index keys only on
+-- columns guaranteed non-null within its own WHERE scope.
+CREATE UNIQUE INDEX `entry_relations_unique_edge_idx` ON `entry_relations` (`entry_id`,`field_api_id`,`target_entry_id`) WHERE `target_kind` = 'entry';--> statement-breakpoint
+CREATE UNIQUE INDEX `entry_relations_unique_external_idx` ON `entry_relations` (`entry_id`,`field_api_id`,`target_namespace`,`target_ref`) WHERE `target_kind` = 'external';--> statement-breakpoint
 
 -- Sparse inverted index over filterable, non-promoted field values.
 --

--- a/drizzle/0021_spec_attributes.sql
+++ b/drizzle/0021_spec_attributes.sql
@@ -11,7 +11,7 @@
 --
 -- On the EAV question: this is a NARROW, registry-disciplined table, not
 -- the wp_postmeta pattern #68 rejected. Values are split into typed
--- columns so `value_number BETWEEN ?` compares as a number; every
+-- columns so numeric bounds compare as numbers, not strings; every
 -- attribute_id resolves to a typed definition so there is no free-text
 -- meta_key to diverge; and cardinality is bounded by what a family
 -- declares. Entry content itself still lives in entries.data_json.
@@ -27,6 +27,14 @@ CREATE TABLE `attribute_definitions` (
   `measure_family` text,
   `standard_unit` text,
   `options_json` text,
+  -- #98: which direction is "better". Without it, "best first" sorts
+  -- backwards for every lower-is-better attribute (vacuum pressure, dB,
+  -- power draw, price, latency). Null where "better" is meaningless.
+  `better_direction` text,
+  -- #98: advisory qualifier vocabulary, JSON array e.g. ["50hz","60hz"].
+  -- Tells the admin UI which inputs to render and the compare view which
+  -- columns align. The engine never interprets the strings.
+  `qualifiers_json` text,
   `group_key` text,
   `position` integer DEFAULT 0 NOT NULL,
   `created_by` text,
@@ -102,10 +110,12 @@ CREATE INDEX `entity_families_family_idx` ON `entity_families` (`family_id`);-->
 
 -- The values table.
 --
--- `value_number` ALWAYS holds the standard-unit magnitude for
--- measurements, with `value_unit` preserving what the editor typed. That
--- split is what makes both of these correct at once:
---   facet/sort — WHERE attribute_id=? AND value_number BETWEEN ? AND ?
+-- `value_number_min`/`value_number_max` ALWAYS hold standard-unit
+-- magnitudes for measurements, with `value_unit` preserving what the
+-- editor typed. That split is what makes both of these correct at once:
+--   facet/sort — an interval-overlap test:
+--                WHERE attribute_id=?
+--                  AND value_number_max >= ? AND value_number_min <= ?
 --                works across mixed authored units
 --   display    — the datasheet still renders "0.1 mbar", not "10 Pa"
 --
@@ -123,7 +133,19 @@ CREATE TABLE `attribute_values` (
   -- for the same entity+attribute would both be accepted, and a
   -- datasheet would render the attribute twice.
   `locale` text DEFAULT '*' NOT NULL,
-  `value_number` real,
+  -- #98: context discriminator ('50hz','60hz','230v'). NOT NULL with a
+  -- '*' sentinel for the same reason as locale — a nullable column inside
+  -- a UNIQUE index is inert in SQLite, so uniqueness would stop applying
+  -- to every unqualified value.
+  `qualifier` text DEFAULT '*' NOT NULL,
+  -- #98: numeric value as a CLOSED INTERVAL. A scalar sets both equal.
+  -- Half of a real catalog's specs are genuinely intervals ("22-25 kg
+  -- depending on motor"); a single magnitude column forces those into
+  -- prose in value_text, which is the trap this layer exists to avoid.
+  -- Faceting becomes an overlap test:
+  --   WHERE value_number_max >= :lo AND value_number_min <= :hi
+  `value_number_min` real,
+  `value_number_max` real,
   `value_unit` text,
   `value_text` text,
   `value_json` text,
@@ -136,10 +158,10 @@ CREATE TABLE `attribute_values` (
 -- One value per (entity, attribute, locale) — without this a second
 -- write duplicates instead of updating, and a datasheet renders the
 -- attribute twice.
-CREATE UNIQUE INDEX `attribute_values_entity_attr_idx` ON `attribute_values` (`entity_type`,`entity_id`,`attribute_id`,`locale`);--> statement-breakpoint
+CREATE UNIQUE INDEX `attribute_values_entity_attr_idx` ON `attribute_values` (`entity_type`,`entity_id`,`attribute_id`,`locale`,`qualifier`);--> statement-breakpoint
 -- Datasheet assembly: every value for one entity.
 CREATE INDEX `attribute_values_entity_idx` ON `attribute_values` (`entity_type`,`entity_id`);--> statement-breakpoint
 -- The index that makes "pumping speed 100-300 m3/h" an index seek
 -- rather than a full scan.
-CREATE INDEX `attribute_values_numeric_facet_idx` ON `attribute_values` (`attribute_id`,`value_number`);--> statement-breakpoint
+CREATE INDEX `attribute_values_numeric_facet_idx` ON `attribute_values` (`attribute_id`,`value_number_min`,`value_number_max`);--> statement-breakpoint
 CREATE INDEX `attribute_values_text_facet_idx` ON `attribute_values` (`attribute_id`,`value_text`);

--- a/src/lib/server/content/attributes/schema.ts
+++ b/src/lib/server/content/attributes/schema.ts
@@ -86,6 +86,17 @@ export type AttributeDataType = (typeof ATTRIBUTE_DATA_TYPES)[number];
  */
 export const NON_LOCALIZED_SENTINEL = "*";
 
+/**
+ * Stand-in for "this value carries no context qualifier" (#98), used
+ * instead of NULL in `attribute_values.qualifier`.
+ *
+ * Same rationale as NON_LOCALIZED_SENTINEL: SQLite considers NULLs
+ * distinct in a UNIQUE index, so a nullable qualifier would make the
+ * (entity, attribute, locale, qualifier) constraint unenforceable for
+ * every unqualified value — i.e. the common case.
+ */
+export const UNQUALIFIED_SENTINEL = "*";
+
 // ─── Definitions (the registry) ─────────────────────────────
 
 export const attributeDefinitions = sqliteTable(
@@ -111,6 +122,34 @@ export const attributeDefinitions = sqliteTable(
     standardUnit: text("standard_unit"),
     /** JSON array of option keys, for select / multiselect. */
     optionsJson: text("options_json"),
+    /**
+     * Which direction is "better" within this attribute (#98):
+     * 'higher' | 'lower' | null when there is no natural ordering.
+     *
+     * Without it every "best first" sort, top-N widget and
+     * winning-cell highlight is BACKWARDS for any lower-is-better
+     * attribute — vacuum pressure, sound level, power draw, latency,
+     * price, lead time. Null for things like connection size or colour,
+     * where "better" is meaningless.
+     *
+     * Deliberately per-attribute rather than per-measure-family: two
+     * pressure attributes can disagree (ultimate pressure lower-is-
+     * better, burst pressure higher-is-better).
+     */
+    betterDirection: text("better_direction", {
+      enum: ["higher", "lower"],
+    }),
+    /**
+     * Allowed qualifier vocabulary for this attribute's values (#98), as
+     * a JSON array: `["50hz","60hz"]`.
+     *
+     * Advisory, not a constraint: it tells the admin UI which inputs to
+     * render and the compare view which columns align. Null means the
+     * attribute takes unqualified values only.
+     *
+     * The engine never interprets the strings — '50hz' is user data.
+     */
+    qualifiersJson: text("qualifiers_json"),
     /**
      * Grouping hint for datasheet layout — 'performance', 'electrical',
      * 'mechanical'. Purely presentational; no query depends on it.
@@ -288,10 +327,41 @@ export const attributeValues = sqliteTable(
      */
     locale: text("locale").notNull().default(NON_LOCALIZED_SENTINEL),
     /**
-     * Numeric magnitude IN THE STANDARD UNIT. `real`, not integer:
-     * pressures like 1e-3 mbar and flows like 0.06 m³/h need fractions.
+     * Context discriminator (#98) — e.g. '50hz', '60hz', '230v'.
+     *
+     * One attribute can hold several context-keyed values instead of
+     * forcing prose ("80 m³/h (50 Hz), 98 m³/h (60 Hz)") or two
+     * near-duplicate definitions that no compare view can align into a
+     * single row.
+     *
+     * NOT NULL with an `UNQUALIFIED_SENTINEL` default, for the same
+     * reason as `locale` above: a nullable discriminator inside a UNIQUE
+     * index is inert in SQLite, so the uniqueness constraint would stop
+     * applying to the common unqualified case.
+     *
+     * The vocabulary is deliberately NOT constrained here. '50hz' is
+     * user data; the engine only needs the values to be comparable.
      */
-    valueNumber: real("value_number"),
+    qualifier: text("qualifier").notNull().default(UNQUALIFIED_SENTINEL),
+    /**
+     * Numeric value as a CLOSED INTERVAL in the standard unit (#98).
+     *
+     * A scalar sets both bounds equal. Half of a real catalog's specs are
+     * genuinely intervals — tolerance bands, "22-25 kg depending on
+     * motor", performance ranges — and a single magnitude column forces
+     * those into prose in `value_text`, which is precisely the
+     * free-form-string trap the typed spec layer exists to avoid.
+     *
+     * Faceting becomes an interval-overlap test, which is also *more*
+     * correct than a point test for genuine ranges:
+     *
+     *   WHERE value_number_max >= :lo AND value_number_min <= :hi
+     *
+     * `real`, not integer: pressures like 1e-3 mbar and flows like
+     * 0.06 m³/h need fractions.
+     */
+    valueNumberMin: real("value_number_min"),
+    valueNumberMax: real("value_number_max"),
     /** Unit as authored ('mbar', 'm3/h'), for faithful display. */
     valueUnit: text("value_unit"),
     /** Text value, or a select option key. */
@@ -306,11 +376,16 @@ export const attributeValues = sqliteTable(
     // One value per (entity, attribute, locale). Without this a second
     // write would silently duplicate rather than update, and a datasheet
     // would render the attribute twice.
+    // One value per (entity, attribute, locale, qualifier). The
+    // qualifier is part of the key since #98 — without it, a 50 Hz and a
+    // 60 Hz value for one attribute would collide and the second write
+    // would overwrite the first instead of sitting alongside it.
     entityAttrIdx: uniqueIndex("attribute_values_entity_attr_idx").on(
       t.entityType,
       t.entityId,
       t.attributeId,
       t.locale,
+      t.qualifier,
     ),
     // Datasheet assembly: every value for one entity (#88 §C.3).
     entityIdx: index("attribute_values_entity_idx").on(
@@ -321,7 +396,8 @@ export const attributeValues = sqliteTable(
     // "pumping speed 100–300 m³/h" an index seek rather than a scan.
     numericFacetIdx: index("attribute_values_numeric_facet_idx").on(
       t.attributeId,
-      t.valueNumber,
+      t.valueNumberMin,
+      t.valueNumberMax,
     ),
     // Faceting on a select option key.
     textFacetIdx: index("attribute_values_text_facet_idx").on(

--- a/src/lib/server/content/attributes/service.ts
+++ b/src/lib/server/content/attributes/service.ts
@@ -25,6 +25,7 @@ import {
   familyAttributes,
   ATTRIBUTE_DATA_TYPES,
   NON_LOCALIZED_SENTINEL,
+  UNQUALIFIED_SENTINEL,
   type AttributeDataType,
   type AttributeDefinition,
 } from "./schema";
@@ -82,8 +83,18 @@ export interface ResolvedValue {
   label: string;
   groupKey: string | null;
   position: number;
-  /** Standard-unit magnitude, for sorting/comparing. Null for non-numeric. */
+  /**
+   * Standard-unit LOWER bound, for sorting/comparing. Null for
+   * non-numeric. Equals `standardValueMax` for a scalar.
+   */
   standardValue: number | null;
+  /** Standard-unit UPPER bound (#98). Equals `standardValue` for a scalar. */
+  standardValueMax: number | null;
+  /**
+   * Context discriminator (#98) — '50hz', '230v' — or null when the value
+   * is unqualified. The compare view aligns rows by (attribute, qualifier).
+   */
+  qualifier: string | null;
   /** Value in the unit it was authored in — what a datasheet shows. */
   displayValue: string | number | boolean | string[] | null;
   /** Authored unit, e.g. 'mbar'. Null for non-measurements. */
@@ -109,10 +120,16 @@ export interface CreateAttributeInput {
   createdBy?: string;
 }
 
-/** A value as supplied by a caller, before normalization. */
+/**
+ * A value as supplied by a caller, before normalization.
+ *
+ * `max` (#98) makes a numeric value an INTERVAL rather than a point.
+ * Omit it for a scalar — both bounds are then set equal, so every query
+ * is an overlap test regardless of which shape was authored.
+ */
 export type RawValueInput =
-  | { kind: "number"; value: number }
-  | { kind: "measurement"; value: number; unit: string }
+  | { kind: "number"; value: number; max?: number }
+  | { kind: "measurement"; value: number; unit: string; max?: number }
   | { kind: "select"; option: string }
   | { kind: "multiselect"; options: string[] }
   | { kind: "boolean"; value: boolean }
@@ -457,11 +474,21 @@ export class AttributeService {
    * Upsert on (entityType, entityId, attributeId, locale) — the unique
    * index makes a repeated write an update rather than a duplicate row.
    */
+  /**
+   * Write one value.
+   *
+   * `qualifier` (#98) lets one attribute hold several context-keyed
+   * values — a 50 Hz and a 60 Hz speed sit alongside each other rather
+   * than the second overwriting the first, because the qualifier is part
+   * of the uniqueness key.
+   */
   async setValue(
     entityType: string,
     entityId: string,
     attributeKey: string,
     input: RawValueInput,
+    /** Context key (#98) — '50hz'. Omit for an unqualified value. */
+    qualifier?: string,
   ): Promise<void> {
     const attr = await this.getAttributeByKey(attributeKey);
     if (!attr) {
@@ -481,6 +508,9 @@ export class AttributeService {
     // Never NULL — see NON_LOCALIZED_SENTINEL. A NULL here would make the
     // (entity, attribute, locale) unique index inert in SQLite.
     const locale = row.locale ?? NON_LOCALIZED_SENTINEL;
+    // Never NULL, for the same reason as locale — see
+    // UNQUALIFIED_SENTINEL.
+    const qual = qualifier ?? UNQUALIFIED_SENTINEL;
     const now = this.now();
 
     const existing = await this.db
@@ -492,6 +522,7 @@ export class AttributeService {
           eq(attributeValues.entityId, entityId),
           eq(attributeValues.attributeId, attr.id),
           eq(attributeValues.locale, locale),
+          eq(attributeValues.qualifier, qual),
         ),
       )
       .limit(1)
@@ -500,7 +531,7 @@ export class AttributeService {
     if (existing) {
       await this.db
         .update(attributeValues)
-        .set({ ...row, locale, updatedAt: now })
+        .set({ ...row, locale, qualifier: qual, updatedAt: now })
         .where(eq(attributeValues.id, existing.id));
       return;
     }
@@ -512,6 +543,7 @@ export class AttributeService {
       attributeId: attr.id,
       ...row,
       locale,
+      qualifier: qual,
       createdAt: now,
       updatedAt: now,
     });
@@ -521,14 +553,15 @@ export class AttributeService {
    * Translate a typed input into the table's columns.
    *
    * For a measurement this is where unit normalization happens: the
-   * canonical magnitude goes to `valueNumber` and the authored unit is
+   * canonical interval goes to `valueNumberMin`/`Max` and the unit is
    * preserved in `valueUnit`, so faceting is correct and display is
    * faithful.
    */
   private buildValueRow(attr: AttributeDefinition, input: RawValueInput) {
     const base = {
       locale: null as string | null,
-      valueNumber: null as number | null,
+      valueNumberMin: null as number | null,
+      valueNumberMax: null as number | null,
       valueUnit: null as string | null,
       valueText: null as string | null,
       valueJson: null as string | null,
@@ -543,7 +576,22 @@ export class AttributeService {
             "INVALID_VALUE",
           );
         }
-        return { ...base, valueNumber: input.value };
+        const max = input.max ?? input.value;
+        if (!Number.isFinite(max)) {
+          throw new AttributeError(
+            `Attribute "${attr.key}" range max must be a finite number`,
+            "INVALID_VALUE",
+          );
+        }
+        if (max < input.value) {
+          throw new AttributeError(
+            `Attribute "${attr.key}" range is inverted (${input.value} > ${max})`,
+            "INVALID_VALUE",
+          );
+        }
+        // A scalar sets both bounds equal, so every read path is a single
+        // overlap test and never has to branch on "is this a range?".
+        return { ...base, valueNumberMin: input.value, valueNumberMax: max };
       }
 
       case "measurement": {
@@ -560,13 +608,27 @@ export class AttributeService {
           );
         }
         try {
-          const n = normalize(attr.measureFamily, input.value, input.unit);
+          const lo = normalize(attr.measureFamily, input.value, input.unit);
+          // Both bounds normalize through the SAME family+unit, so a
+          // range authored in m3/min compares correctly against one
+          // authored in m3/h.
+          const hi =
+            input.max === undefined
+              ? lo
+              : normalize(attr.measureFamily, input.max, input.unit);
+          if (hi.standardValue < lo.standardValue) {
+            throw new AttributeError(
+              `Attribute "${attr.key}" range is inverted (${input.value} > ${input.max} ${input.unit})`,
+              "INVALID_VALUE",
+            );
+          }
           return {
             ...base,
-            // Canonical magnitude — what every query compares on.
-            valueNumber: n.standardValue,
+            // Canonical interval — what every query compares on.
+            valueNumberMin: lo.standardValue,
+            valueNumberMax: hi.standardValue,
             // Authored unit — what the datasheet renders.
-            valueUnit: n.unit,
+            valueUnit: lo.unit,
           };
         } catch (err) {
           if (err instanceof UnitError) {
@@ -748,7 +810,7 @@ export class AttributeService {
   /**
    * Faceted filter / sort on one attribute (#88 §C.3).
    *
-   * Because `valueNumber` is always the standard-unit magnitude, a range
+   * Because both bounds are always standard-unit magnitudes, a range
    * expressed in ANY unit of the family is correct — the bounds are
    * normalized here before comparison, so "100–300 m³/h" and
    * "1.67–5 m³/min" select the same entities.
@@ -822,14 +884,19 @@ export class AttributeService {
               filter.unit as string,
             ).standardValue
           : v;
+      // Interval OVERLAP, not a point test (#98): a value whose range is
+      // 150-170 must match a 100-160 filter. Note the operands are
+      // deliberately crossed — a stored interval overlaps the requested
+      // one when its max is at least the requested min AND its min is at
+      // most the requested max.
       if (filter.min !== undefined) {
         conditions.push(
-          gte(attributeValues.valueNumber, toStandard(filter.min)),
+          gte(attributeValues.valueNumberMax, toStandard(filter.min)),
         );
       }
       if (filter.max !== undefined) {
         conditions.push(
-          lte(attributeValues.valueNumber, toStandard(filter.max)),
+          lte(attributeValues.valueNumberMin, toStandard(filter.max)),
         );
       }
     } else if (filter.kind === "option") {
@@ -842,15 +909,17 @@ export class AttributeService {
     const order =
       filter.kind === "range"
         ? opts.sort === "desc"
-          ? sql`${attributeValues.valueNumber} DESC`
-          : sql`${attributeValues.valueNumber} ASC`
+          ? sql`${attributeValues.valueNumberMin} DESC`
+          : sql`${attributeValues.valueNumberMin} ASC`
         : sql`${attributeValues.valueText} ASC`;
 
     const rows = await this.db
       .select({
         entityType: attributeValues.entityType,
         entityId: attributeValues.entityId,
-        valueNumber: attributeValues.valueNumber,
+        valueNumberMin: attributeValues.valueNumberMin,
+        valueNumberMax: attributeValues.valueNumberMax,
+        qualifier: attributeValues.qualifier,
         valueText: attributeValues.valueText,
         valueBool: attributeValues.valueBool,
       })
@@ -863,7 +932,7 @@ export class AttributeService {
     return rows.map((r) => ({
       entityType: r.entityType,
       entityId: r.entityId,
-      value: r.valueNumber ?? r.valueText ?? r.valueBool ?? null,
+      value: r.valueNumberMin ?? r.valueText ?? r.valueBool ?? null,
     }));
   }
 
@@ -889,7 +958,9 @@ export class AttributeService {
         .select({
           entityId: attributeValues.entityId,
           attributeId: attributeValues.attributeId,
-          valueNumber: attributeValues.valueNumber,
+          valueNumberMin: attributeValues.valueNumberMin,
+          valueNumberMax: attributeValues.valueNumberMax,
+          qualifier: attributeValues.qualifier,
           valueUnit: attributeValues.valueUnit,
           valueText: attributeValues.valueText,
           valueJson: attributeValues.valueJson,
@@ -944,7 +1015,9 @@ export class AttributeService {
         label: labelByAttr.get(r.attributeId) ?? r.key,
         groupKey: r.groupKey,
         position: r.position,
-        standardValue: r.valueNumber,
+        standardValue: r.valueNumberMin,
+        standardValueMax: r.valueNumberMax,
+        qualifier: r.qualifier === "*" ? null : r.qualifier,
         unit: r.valueUnit,
         measureFamily: r.measureFamily,
         displayValue: this.displayValueOf(r),
@@ -965,7 +1038,8 @@ export class AttributeService {
    */
   private displayValueOf(r: {
     dataType: AttributeDataType;
-    valueNumber: number | null;
+    valueNumberMin: number | null;
+    valueNumberMax: number | null;
     valueUnit: string | null;
     valueText: string | null;
     valueJson: string | null;
@@ -974,19 +1048,19 @@ export class AttributeService {
   }): ResolvedValue["displayValue"] {
     switch (r.dataType) {
       case "number":
-        return r.valueNumber;
+        return r.valueNumberMin;
       case "measurement": {
         if (
-          r.valueNumber === null ||
+          r.valueNumberMin === null ||
           !r.valueUnit ||
           !r.measureFamily ||
           !isMeasureFamily(r.measureFamily)
         ) {
-          return r.valueNumber;
+          return r.valueNumberMin;
         }
         const factor = FAMILIES[r.measureFamily].units[r.valueUnit]?.factor;
-        if (!factor) return r.valueNumber;
-        const authored = r.valueNumber / factor;
+        if (!factor) return r.valueNumberMin;
+        const authored = r.valueNumberMin / factor;
         // Trim float noise from the round-trip (0.1 mbar → 10 Pa → 0.1)
         // without truncating genuinely small vacuum values like 1e-6.
         return Number(authored.toPrecision(12));

--- a/src/lib/server/content/registry/schema.ts
+++ b/src/lib/server/content/registry/schema.ts
@@ -42,6 +42,7 @@
  * SonicJS, which ships this design on D1, flags the same wall. Hence
  * `promoted` is opt-in per field, never automatic.
  */
+import { sql } from "drizzle-orm";
 import {
   index,
   integer,
@@ -310,14 +311,55 @@ export const entryRelations = sqliteTable(
      */
     fieldApiId: text("field_api_id").notNull(),
     /**
-     * The target. CASCADE, so deleting an entry removes the edges
+     * Which shape this edge's target takes (#99).
+     *
+     *   `entry`    — points at an entry we own; `targetEntryId` is set
+     *   `external` — points at something the CMS does NOT own;
+     *                `targetNamespace` + `targetRef` are set
+     *
+     * The external case exists because forcing every target to be an
+     * entry means creating shell entries for data you merely reference
+     * — which both implies you manage it and pollutes the collection it
+     * lands in. A CHECK constraint enforces exactly one shape.
+     */
+    targetKind: text("target_kind", { enum: ["entry", "external"] })
+      .notNull()
+      .default("entry"),
+    /**
+     * The target entry. CASCADE, so deleting an entry removes the edges
      * pointing at it rather than leaving dangling references that
      * populate would have to filter out on every read.
+     *
+     * Nullable since #99 — null exactly when `targetKind='external'`.
      */
-    targetEntryId: text("target_entry_id")
-      .notNull()
-      .references(() => entries.id, { onDelete: "cascade" }),
+    targetEntryId: text("target_entry_id").references(() => entries.id, {
+      onDelete: "cascade",
+    }),
+    /**
+     * Governing namespace for an external target — e.g. a manufacturer
+     * key. Deliberately a plain string rather than an FK: the namespace
+     * side *should* be modelled as a normal user collection when it
+     * needs governance, leaving only the far-side identifier
+     * unmanaged (#99).
+     */
+    targetNamespace: text("target_namespace"),
+    /** Identifier within the namespace — a model number, SKU, ISBN. */
+    targetRef: text("target_ref"),
+    /** Optional display override; falls back to `targetRef`. */
+    targetLabel: text("target_label"),
     position: integer("position").notNull().default(0),
+    /**
+     * Edge attributes (#99) — data belonging to the PAIRING rather than
+     * to either endpoint. A confidence tier on a "replaces" edge, a
+     * `quantity` on a bill-of-materials edge, `valid_from`/`valid_until`
+     * on a supersession, a `role` on person↔project.
+     *
+     * Opt-in: validated against a JSON schema declared on the relation
+     * field's `config.edgeFields` in `collection_fields`, and left null
+     * for relations that carry no edge data, so containment relations
+     * pay nothing.
+     */
+    dataJson: text("data_json"),
     createdAt: text("created_at").notNull(),
   },
   (t) => ({
@@ -334,12 +376,28 @@ export const entryRelations = sqliteTable(
       t.targetEntryId,
       t.fieldApiId,
     ),
-    // The same edge must not exist twice on one field.
-    uniqueEdge: uniqueIndex("entry_relations_unique_edge_idx").on(
-      t.entryId,
-      t.fieldApiId,
-      t.targetEntryId,
+    // Reverse lookup for EXTERNAL targets: "which entries reference
+    // busch/R5-KA-0100?" — powers cross-reference landing pages (#99).
+    externalIdx: index("entry_relations_external_idx").on(
+      t.targetNamespace,
+      t.targetRef,
     ),
+    // The same edge must not exist twice on one field.
+    //
+    // Two indexes rather than one, because `targetEntryId` became
+    // nullable in #99 and SQLite treats NULLs as DISTINCT in a UNIQUE
+    // index — a single index spanning both shapes would silently stop
+    // constraining the external case, exactly the trap that made
+    // `attribute_values.locale` unenforceable before it was fixed.
+    //
+    // Each index is PARTIAL (`WHERE target_kind = …`) so the column it
+    // keys on is guaranteed non-null within its own scope.
+    uniqueEntryEdge: uniqueIndex("entry_relations_unique_edge_idx")
+      .on(t.entryId, t.fieldApiId, t.targetEntryId)
+      .where(sql`${t.targetKind} = 'entry'`),
+    uniqueExternalEdge: uniqueIndex("entry_relations_unique_external_idx")
+      .on(t.entryId, t.fieldApiId, t.targetNamespace, t.targetRef)
+      .where(sql`${t.targetKind} = 'external'`),
   }),
 );
 

--- a/src/lib/server/content/registry/service.ts
+++ b/src/lib/server/content/registry/service.ts
@@ -101,6 +101,11 @@ export interface UpsertEntryInput {
    * significant and is persisted as `position`.
    */
   relations?: Record<string, string[]>;
+  /**
+   * Edge attributes (#99), keyed by field apiId then by target string:
+   * `{ xref: { "acme:MODEL-1": '{"confidence":"exact"}' } }`.
+   */
+  edgeData?: Record<string, Record<string, string>>;
   createdBy?: string;
 }
 
@@ -646,7 +651,12 @@ export class RegistryService {
             "UNKNOWN_FIELD",
           );
         }
-        await this.setRelation(entryId, field, targetIds);
+        await this.setRelation(
+          entryId,
+          field,
+          targetIds,
+          input.edgeData?.[fieldApiId],
+        );
       }
     }
 
@@ -674,7 +684,19 @@ export class RegistryService {
   async setRelation(
     entryId: string,
     field: CollectionField,
+    /**
+     * Entry ids, and/or external refs written `namespace:ref` (#99).
+     * Order is significant — it becomes `position`.
+     */
     targetIds: string[],
+    /**
+     * Optional edge attributes (#99), keyed by the same target string.
+     * Data belonging to the PAIRING rather than either endpoint — a
+     * confidence tier, a quantity, a validity window. Pre-serialized
+     * JSON; the caller owns its shape, declared on the field's
+     * `config.edgeFields`.
+     */
+    edgeData?: Record<string, string>,
   ): Promise<void> {
     const config = this.parseConfig(field);
     const cardinality =
@@ -690,11 +712,33 @@ export class RegistryService {
       );
     }
 
-    // Targets must exist and be of an allowed collection. Without this
-    // an edge can point at an entry of the wrong type, and populate
+    // #99: a target is either an entry id we own, or an EXTERNAL
+    // reference written `namespace:ref`. Split them so each half is
+    // validated against the rule that applies to it — entry ids must
+    // resolve to an allowed collection; external refs must not be
+    // validated against `entries` at all, since the whole point is that
+    // we don't own them.
+    const external = unique
+      .filter((t) => t.includes(":"))
+      .map((t) => {
+        const idx = t.indexOf(":");
+        return { namespace: t.slice(0, idx), ref: t.slice(idx + 1) };
+      })
+      .filter((e) => e.namespace && e.ref);
+    const entryTargets = unique.filter((t) => !t.includes(":"));
+
+    if (external.length > 0 && !allowsExternal(config)) {
+      throw new RegistryError(
+        `Field "${field.apiId}" does not accept external targets — set config.allowExternal to enable them`,
+        "INVALID_VALUE",
+      );
+    }
+
+    // Entry targets must exist and be of an allowed collection. Without
+    // this an edge can point at an entry of the wrong type, and populate
     // would return objects with an unexpected shape.
-    if (unique.length > 0) {
-      await this.assertValidTargets(field, config, unique);
+    if (entryTargets.length > 0) {
+      await this.assertValidTargets(field, config, entryTargets);
     }
 
     await this.db
@@ -709,17 +753,42 @@ export class RegistryService {
     if (unique.length === 0) return;
 
     const now = this.now();
-    const rows = unique.map((targetEntryId, i) => ({
-      id: nanoid(),
-      entryId,
-      fieldApiId: field.apiId,
-      targetEntryId,
-      position: i,
-      createdAt: now,
-    }));
-    // 5 columns per row against a 100-parameter ceiling → 20 rows max
-    // per statement.
-    const perStatement = Math.floor(D1_MAX_BIND_PARAMS / 6);
+    // Position is assigned across BOTH shapes in the order the caller
+    // supplied, so a curated list mixing owned and external targets keeps
+    // its authored order.
+    let pos = 0;
+    const rows = [
+      ...entryTargets.map((targetEntryId) => ({
+        id: nanoid(),
+        entryId,
+        fieldApiId: field.apiId,
+        targetKind: "entry" as const,
+        targetEntryId,
+        targetNamespace: null,
+        targetRef: null,
+        targetLabel: null,
+        dataJson: edgeData?.[targetEntryId] ?? null,
+        position: pos++,
+        createdAt: now,
+      })),
+      ...external.map((e) => ({
+        id: nanoid(),
+        entryId,
+        fieldApiId: field.apiId,
+        targetKind: "external" as const,
+        targetEntryId: null,
+        targetNamespace: e.namespace,
+        targetRef: e.ref,
+        targetLabel: null,
+        dataJson: edgeData?.[`${e.namespace}:${e.ref}`] ?? null,
+        position: pos++,
+        createdAt: now,
+      })),
+    ];
+    // 11 columns per row against D1's 100-parameter ceiling → 9 rows max
+    // per statement. #99 widened the row from 6 columns to 11, so the
+    // old divisor would have overflowed at 16 rows.
+    const perStatement = Math.max(1, Math.floor(D1_MAX_BIND_PARAMS / 11));
     for (let i = 0; i < rows.length; i += perStatement) {
       await this.db
         .insert(entryRelations)
@@ -1093,6 +1162,17 @@ export class RegistryService {
     }
     return out;
   }
+}
+
+/**
+ * Whether a relation field accepts external (non-entry) targets (#99).
+ *
+ * Opt-in per field: a containment relation like Page→Block should never
+ * point outside the CMS, and silently allowing it would let a typo'd
+ * entry id be stored as an unresolvable external ref instead of failing.
+ */
+function allowsExternal(config: unknown): boolean {
+  return (config as { allowExternal?: unknown })?.allowExternal === true;
 }
 
 function safeParseObject(json: string): Record<string, unknown> {

--- a/src/routes/(admin)/admin/content/[collection]/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/content/[collection]/[id]/+page.server.ts
@@ -87,7 +87,18 @@ export const load: PageServerLoad = async ({ params, locals, platform }) => {
       .all();
     for (const row of relRows) {
       const list = relations[row.fieldApiId] ?? [];
-      list.push(row.targetEntryId);
+      // #99: an edge targets either an entry we own or an external
+      // reference. External targets are round-tripped as
+      // `namespace:ref` — a single string keeps the existing form
+      // encoding (one comma-separated field per relation) working for
+      // both shapes, and the save action splits it back apart.
+      if (row.targetKind === "external") {
+        if (row.targetNamespace && row.targetRef) {
+          list.push(`${row.targetNamespace}:${row.targetRef}`);
+        }
+      } else if (row.targetEntryId) {
+        list.push(row.targetEntryId);
+      }
       relations[row.fieldApiId] = list;
     }
   }


### PR DESCRIPTION
Implements **#98** and **#99** together. Both amend tables that shipped hours ago in #91/#94 and that **no environment has applied yet**, so migrations `0020` and `0021` are amended in place rather than followed by a `0022`.

## Correction to the brief

The task said *"`attribute_definitions` does not exist on master yet; confirm this is still true"*. It has since landed — #94 merged today. Practically this changes little, since no environment has the tables (`khaopad-example-db` is at `0017`), but #98's framing of these as free design decisions no longer holds; they are real migrations, just unapplied ones.

## #99 — `entry_relations`

| Change | Why |
|---|---|
| `data_json` | Edge attributes — data belonging to the **pairing**, not either endpoint. A confidence tier on "replaces", a quantity on a BOM edge, a validity window on a supersession. Opt-in, so containment relations pay nothing. |
| `target_kind` + `target_namespace` / `target_ref` / `target_label` | An entry can reference something the CMS doesn't own without minting shell entries that imply otherwise. |
| `target_entry_id` now nullable + CHECK | Enforces exactly one target shape is populated. |

External targets are gated per field by `config.allowExternal`. A Page→Block relation should never point outside the CMS, and silently allowing it would store a typo'd entry id as an unresolvable external ref instead of failing.

### Uniqueness is two PARTIAL indexes, not one

`target_entry_id` became nullable, and **SQLite treats NULLs as DISTINCT in a UNIQUE index** — a single index spanning both shapes would silently stop constraining the external case. That is the identical trap that made `attribute_values.locale` unenforceable until it was fixed earlier in this milestone. Each partial index (`WHERE target_kind = …`) keys only on columns guaranteed non-null within its own scope.

Verified: a duplicate external edge is now rejected.

## #98 — the spec value model

| Change | Why |
|---|---|
| `value_number` → `value_number_min` / `value_number_max` | A closed interval. A scalar sets both equal, so every read path is one overlap test and never branches on "is this a range?". Faceting becomes `value_number_max >= lo AND value_number_min <= hi` — also *more* correct than a point test for values that genuinely are ranges. |
| `qualifier` | Context discriminator, **part of the uniqueness key**. Without it in the key, a 50 Hz and a 60 Hz value for one attribute collide and the second write overwrites the first. NOT NULL with a `'*'` sentinel, same NULL-in-UNIQUE reasoning as `locale`. |
| `better_direction` | `'higher' \| 'lower' \| null`. Without it every best-first sort is backwards for lower-is-better attributes. Per-attribute rather than per-family, because ultimate pressure and burst pressure disagree while sharing a family. |
| `qualifiers_json` | Advisory vocabulary so the admin UI knows which inputs to render. Not a constraint; the engine never interprets the strings. |

**Skipped:** `source_url` / `verified` / `retrieved_at` — marked discretionary in the brief. Three columns on a hot table for something `audit_log` and `entry_versions` partially cover. Provenance can live in a value's own `data_json` if a second catalog needs it.

## Bug caught while wiring #99

`setRelation` batched inserts with `D1_MAX_BIND_PARAMS / 6`. #99 widened the row from 6 columns to 11, so that divisor would have bound **176 parameters against D1's 100 ceiling** and failed at 16+ edges. Corrected to `/11`.

## Verified against real SQLite — all five DoD items

```
1. facet over mixed scalars / ranges / 50-60Hz pairs, overlap 90-160:
   → p1[60hz]=98, p2=150-170 ✓   excluded p1[50hz]=80, p3=400 ✓
   → ZERO values stored in value_text
2. compare aligns 50hz and 60hz rows on one attribute across entities ✓
3. best-first on better_direction='lower' → 10 Pa before 50 Pa ✓
4. one entry holds external (acme/R5 KA 0100 F) AND owned edge,
   each with its own confidence in data_json ✓
5. re-running the same deterministic ids left 2 rows at 2 ✓
```

CHECK constraint verified both ways: external-with-entry-id rejected, entry-with-no-target rejected. Reverse lookup is an index **seek** (`entry_relations_external_idx`), not a scan.

`pnpm check` clean (3 pre-existing paraglide errors), `pnpm lint` exit 0, `pnpm build` passes.

## Also removed

An untracked `0020_collection_registry 2.sql` duplicate that was silently blocking the whole migration chain with `table collections already exists`. Recurring macOS artifact — this time somewhere that mattered, since it stopped `0021` applying entirely. Worth noting my first constraint test passed against stale schema because of it; re-testing after removal is what caught it.

## Generic — checked against the other catalogs

No domain vocabulary in any table or column. `qualifier`, `better_direction`, `target_namespace`, `data_json` are domain-neutral; `'50hz'` and `'acme'` are user data.

I checked both other catalogs on this account rather than assuming:

- **bactrack** — 11 articles, 2 pages, **zero products**. Both features are inert there and cost nothing, which is the right outcome for an opt-in column.
- **kinetic** — still on Strapi, and its `Variant` is `name / slug / excerpt / content` with `highlights: null; // this should be json` unresolved. It has no structured specs to hit the range problem *with* — so #98 is predictive there rather than speculative, which is the cheap moment to act.

Closes #98
Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)