### PR TITLE
fix(admin): nav registry must not depend on module init order

### DIFF
--- a/src/lib/components/admin/sidebar-nav.ts
+++ b/src/lib/components/admin/sidebar-nav.ts
@@ -52,7 +52,33 @@ export type NavGroup = {
  * on each call — do NOT hold onto the reference across plugin
  * registrations, or you'll miss late-registering plugins.
  */
-const registry = new Map<string, { title: () => string; items: NavItem[] }>();
+type RegistryEntry = { title: () => string; items: NavItem[] };
+
+/**
+ * Lazily-initialized so registration cannot depend on module evaluation
+ * ORDER.
+ *
+ * This file imports `$lib/plugins/registrations` at the bottom as a
+ * side effect, so plugin `registerNavGroup()` calls run during this
+ * module's own initialization. A bundler is free to hoist those calls
+ * above a top-level `const registry = new Map()`, at which point every
+ * request throws:
+ *
+ *   TypeError: Cannot read properties of undefined (reading 'get')
+ *       at registerNavGroup (sidebar-nav.js)
+ *
+ * That is not hypothetical — it took the demo deployment down with a
+ * Worker 1101 on every route, including /api/health, after an unrelated
+ * icon import shifted the import graph enough to change the order.
+ *
+ * Reading through this accessor makes the order irrelevant: whoever
+ * touches the registry first creates it.
+ */
+let _registry: Map<string, RegistryEntry> | undefined;
+function registry(): Map<string, RegistryEntry> {
+  if (!_registry) _registry = new Map<string, RegistryEntry>();
+  return _registry;
+}
 
 /**
  * Register a new nav group. Idempotent on id — a second call with the
@@ -61,7 +87,7 @@ const registry = new Map<string, { title: () => string; items: NavItem[] }>();
  * `registerNavItem()` instead.
  */
 export function registerNavGroup(group: NavGroup): void {
-  const existing = registry.get(group.id);
+  const existing = registry().get(group.id);
   if (existing) {
     existing.title = group.title;
     // Merge items — new ones appended, preserving core order.
@@ -72,7 +98,7 @@ export function registerNavGroup(group: NavGroup): void {
     }
     return;
   }
-  registry.set(group.id, {
+  registry().set(group.id, {
     title: group.title,
     items: [...group.items],
   });
@@ -88,7 +114,7 @@ export function registerNavGroup(group: NavGroup): void {
  * plugin boot.
  */
 export function registerNavItem(groupId: string, item: NavItem): void {
-  const group = registry.get(groupId);
+  const group = registry().get(groupId);
   if (!group) return;
   if (group.items.some((i) => i.href === item.href)) return;
   group.items.push(item);
@@ -100,7 +126,7 @@ export function registerNavItem(groupId: string, item: NavItem): void {
  * dependencies change). Returns groups in registration order.
  */
 export function listNavGroups(): ReadonlyArray<NavGroup> {
-  return Array.from(registry.entries()).map(([id, { title, items }]) => ({
+  return Array.from(registry().entries()).map(([id, { title, items }]) => ({
     id,
     title,
     items: [...items] as ReadonlyArray<NavItem>,


### PR DESCRIPTION
The demo deployment went down with a **Worker 1101 on every route** — including `/api/health` — immediately after the v3.6 sync:

```
TypeError: Cannot read properties of undefined (reading 'get')
    at registerNavGroup (sidebar-nav.js:907)
```

## Cause

`sidebar-nav.ts` imports `$lib/plugins/registrations` at the **bottom** as a side effect, so plugin `registerNavGroup()` calls execute during this module's own initialization. The registry was a top-level `const registry = new Map()`, and the bundler is free to hoist those plugin calls above it — at which point `registry` is `undefined` and every request throws.

**This was latent, not new.** Adding a single `Database` icon import for the Phase 4 nav entry shifted the import graph just enough to change evaluation order and expose it. Nothing about the nav entry was wrong; any future import could have triggered the same thing.

## Why nothing caught it

`pnpm check`, `pnpm build` **and** the Deploy workflow all passed with the broken bundle. A module-init crash is invisible to type-checking, bundling, and a deploy that only verifies upload succeeded. Only an actual HTTP request surfaces it — and the demo's smoke test accepts 503 as healthy (correctly, since that's the "config required" page), so a 500 was the one thing that would slip through.

## Fix

Read the registry through a lazy accessor, so whoever touches it first creates it and order stops mattering.

Verified in the built output — the eager `new Map()` is gone:

```js
let _registry;
function registry() {
  if (!_registry) _registry = new Map();
  return _registry;
}
```

And verified **serving**, not just compiling:

| Route | Before | After |
|---|---|---|
| `/api/health` | 500 | 503 |
| `/admin/login` | 500 | 503 |
| `/` | 500 | 503 |

503 is Khao Pad's own "configuration required" page for a missing `BETTER_AUTH_SECRET` in local dev — i.e. the app is running. The `TypeError` does not appear in the log at all.

## Follow-up worth considering

The demo's smoke test treats 503 as healthy, which is right for an unconfigured Worker but means a hard 500 on a configured one would also need catching. Adding an explicit "not 5xx when secrets are set" assertion would have caught this in CI. Out of scope here, but noting it since this outage was silent for ~20 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)