### PR TITLE
test: vitest baseline, fix check/lint config drift, harden smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Test
+        run: pnpm run test
+
       - name: Build
         run: pnpm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Test
+        run: pnpm run test
+
       - name: Build
         run: pnpm run build
 
@@ -178,16 +181,35 @@ jobs:
           fi
           echo "Probing $URL ..."
           # Retry for up to ~60s — Worker propagation is fast but not instant.
+          #
+          # 503 is accepted because it is Khao Pad's own "configuration
+          # required" screen: the Worker IS running, just pointed at
+          # unconfigured bindings. That is the correct reading for a fresh
+          # fork before secrets are set.
+          #
+          # A 500 is NOT accepted, and is not retried into a timeout. A
+          # module-init crash returns 500 on every route forever, so
+          # retrying it just delays the failure by a minute and buries the
+          # cause. This distinction matters: a nav-registry init bug once
+          # shipped green through check, build AND deploy, and stayed live
+          # because the only runtime signal was treated as retryable.
+          final=""
           for i in 1 2 3 4 5 6; do
             code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
             echo "  attempt $i → HTTP $code"
-            # 2xx/3xx is healthy. 503 is the Khao Pad "config required" screen —
-            # still counts as the Worker running, just pointed at unconfigured bindings.
+            final="$code"
             if [[ "$code" =~ ^(2|3)..$ ]] || [[ "$code" == "503" ]]; then
               echo "✔ Worker responded ($code)"
               exit 0
             fi
+            # Fail immediately on a hard server error — it will not heal.
+            if [[ "$code" =~ ^5..$ ]] && [[ "$code" != "503" ]]; then
+              echo "::error::$URL returned HTTP $code — the Worker is deployed but throwing."
+              echo "A 5xx other than 503 usually means an exception during module"
+              echo "initialization or request handling. Check: npx wrangler tail"
+              exit 1
+            fi
             sleep 10
           done
-          echo "::error::Smoke test failed — $URL never returned a healthy status."
+          echo "::error::Smoke test failed — $URL never returned a healthy status (last: HTTP ${final})."
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,14 @@ node_modules
 package-lock.json
 yarn.lock
 .svelte-kit
+# Paraglide compiler output. BOTH paths: the compiler used to emit to
+# src/lib/paraglide and now also emits to src/paraglide. Listing both here
+# matters beyond git — eslint.config.js derives its ignores from this file
+# via includeIgnoreFile(), and src/paraglide/ has only its OWN generated
+# .gitignore, which that helper does not read. A missing entry here means
+# ESLint lints hundreds of generated files.
 src/lib/paraglide
+src/paraglide
 build
 .wrangler
 .env

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -46,6 +48,7 @@
     "@sveltejs/adapter-auto": "^4.0.0",
     "@tailwindcss/typography": "^0.5.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@types/node": "^26.1.2",
     "autoprefixer": "^10.4.0",
     "drizzle-kit": "^0.28.0",
     "eslint": "^10.2.0",
@@ -60,6 +63,7 @@
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.2",
     "vite": "~5.4.21",
+    "vitest": "^2",
     "wrangler": "^3.100.0"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
         version: 2.16.0
       '@sveltejs/adapter-cloudflare':
         specifier: ^5.0.0
-        version: 5.1.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0)))(wrangler@3.114.17(@cloudflare/workers-types@4.20260417.1))
+        version: 5.1.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(wrangler@3.114.17(@cloudflare/workers-types@4.20260417.1))
       '@sveltejs/kit':
         specifier: ^2.57.1
-        version: 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0))
+        version: 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0))
+        version: 4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       better-auth:
         specifier: ^1.5.0
-        version: 1.6.5(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0)))(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+        version: 1.6.5(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vitest@2.1.9(@types/node@26.1.2)(lightningcss@1.32.0))
       bits-ui:
         specifier: ^1.0.0
         version: 1.8.0(svelte@5.55.4(@typescript-eslint/types@8.58.2))
@@ -66,13 +66,16 @@ importers:
         version: 10.0.1(eslint@10.2.0(jiti@2.6.1))
       '@sveltejs/adapter-auto':
         specifier: ^4.0.0
-        version: 4.0.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0)))
+        version: 4.0.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))
       '@tailwindcss/typography':
         specifier: ^0.5.0
         version: 0.5.19(tailwindcss@4.2.2)
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.2(vite@5.4.21(lightningcss@1.32.0))
+        version: 4.2.2(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
       autoprefixer:
         specifier: ^10.4.0
         version: 10.5.0(postcss@8.5.10)
@@ -114,7 +117,10 @@ importers:
         version: 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ~5.4.21
-        version: 5.4.21(lightningcss@1.32.0)
+        version: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^2
+        version: 2.1.9(@types/node@26.1.2)(lightningcss@1.32.0)
       wrangler:
         specifier: ^3.100.0
         version: 3.114.17(@cloudflare/workers-types@4.20260417.1)
@@ -1651,6 +1657,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1713,6 +1722,35 @@ packages:
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1744,6 +1782,10 @@ packages:
 
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   autoprefixer@10.5.0:
     resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
@@ -1856,8 +1898,20 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1932,6 +1986,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2052,6 +2110,9 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -2181,6 +2242,9 @@ packages:
   estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2188,6 +2252,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2415,6 +2483,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lucide-svelte@0.460.1:
     resolution: {integrity: sha512-guJjJSeWlKivsEG51Xg41egunBMJcobhDmkLv/NYTXmXyCEwxMf1A+HX7RvDEKiXbXYgtLImih67tI08MSUOkA==}
     peerDependencies:
@@ -2506,8 +2577,15 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2635,6 +2713,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
@@ -2662,8 +2743,14 @@ packages:
     peerDependencies:
       kysely: '*'
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktracey@2.2.0:
     resolution: {integrity: sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -2721,9 +2808,27 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2762,6 +2867,9 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
@@ -2794,6 +2902,11 @@ packages:
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   vite@5.4.21:
@@ -2835,12 +2948,42 @@ packages:
       vite:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3739,24 +3882,24 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0)))':
+  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))':
     dependencies:
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       import-meta-resolve: 4.2.0
 
-  '@sveltejs/adapter-cloudflare@5.1.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0)))(wrangler@3.114.17(@cloudflare/workers-types@4.20260417.1))':
+  '@sveltejs/adapter-cloudflare@5.1.0(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(wrangler@3.114.17(@cloudflare/workers-types@4.20260417.1))':
     dependencies:
       '@cloudflare/workers-types': 4.20260417.1
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       esbuild: 0.24.2
       worktop: 0.8.0-next.18
       wrangler: 3.114.17(@cloudflare/workers-types@4.20260417.1)
 
-  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0))':
+  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -3768,30 +3911,30 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)
-      vite: 5.4.21(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       debug: 4.4.3
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)
-      vite: 5.4.21(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0))':
+  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)
-      vite: 5.4.21(lightningcss@1.32.0)
-      vitefu: 1.1.3(vite@5.4.21(lightningcss@1.32.0))
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
+      vitefu: 1.1.3(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -3865,12 +4008,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@5.4.21(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.2.2(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 5.4.21(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
 
   '@types/cookie@0.6.0': {}
 
@@ -3879,6 +4022,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/trusted-types@2.0.7': {}
 
@@ -3973,6 +4120,46 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3998,6 +4185,8 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
+  assertion-error@2.0.1: {}
+
   autoprefixer@10.5.0(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
@@ -4013,7 +4202,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
-  better-auth@1.6.5(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0)))(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(svelte@5.55.4(@typescript-eslint/types@8.58.2)):
+  better-auth@1.6.5(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(drizzle-kit@0.28.1)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vitest@2.1.9(@types/node@26.1.2)(lightningcss@1.32.0)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.36.4(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(kysely@0.28.16))
@@ -4033,10 +4222,11 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
       drizzle-kit: 0.28.1
       drizzle-orm: 0.36.4(@cloudflare/workers-types@4.20260417.1)(@opentelemetry/api@1.9.1)(kysely@0.28.16)
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)
+      vitest: 2.1.9(@types/node@26.1.2)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -4078,7 +4268,19 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001788: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -4137,6 +4339,8 @@ snapshots:
 
   dedent@1.5.1: {}
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -4168,6 +4372,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  es-module-lexer@1.7.0: {}
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -4450,9 +4656,15 @@ snapshots:
 
   estree-walker@0.6.1: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -4619,6 +4831,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  loupe@3.2.1: {}
+
   lucide-svelte@0.460.1(svelte@5.55.4(@typescript-eslint/types@8.58.2)):
     dependencies:
       svelte: 5.55.4(@typescript-eslint/types@8.58.2)
@@ -4699,7 +4913,11 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -4850,6 +5068,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
@@ -4877,10 +5097,14 @@ snapshots:
       '@sqlite.org/sqlite-wasm': 3.48.0-build4
       kysely: 0.28.16
 
+  stackback@0.0.2: {}
+
   stacktracey@2.2.0:
     dependencies:
       as-table: 1.0.55
       get-source: 2.0.12
+
+  std-env@3.10.0: {}
 
   stoppable@1.1.0: {}
 
@@ -4955,10 +5179,20 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   totalist@3.0.1: {}
 
@@ -4993,6 +5227,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
+
+  undici-types@8.3.0: {}
 
   undici@5.29.0:
     dependencies:
@@ -5031,24 +5267,83 @@ snapshots:
 
   uuid@13.0.0: {}
 
-  vite@5.4.21(lightningcss@1.32.0):
+  vite-node@2.1.9(@types/node@26.1.2)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.10
       rollup: 4.60.1
     optionalDependencies:
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitefu@1.1.3(vite@5.4.21(lightningcss@1.32.0)):
+  vitefu@1.1.3(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)):
     optionalDependencies:
-      vite: 5.4.21(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
+
+  vitest@2.1.9(@types/node@26.1.2)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@26.1.2)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@26.1.2)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   webpack-virtual-modules@0.6.2: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/lib/components/admin/registry/field-map.test.ts
+++ b/src/lib/components/admin/registry/field-map.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { FIELD_TYPES } from "$lib/server/content/registry/schema";
+import {
+  FIELD_EDITORS,
+  fieldName,
+  isRelational,
+  parseFieldName,
+} from "./field-map";
+
+/**
+ * The registry-driven editor (Phase 4) encodes every field into one
+ * namespaced FormData key, and the save action parses them back. If that
+ * encoding is lossy or ambiguous, edits are silently dropped — the worst
+ * failure mode for a CMS, because the UI reports success.
+ *
+ * Previously verified by a throwaway script; kept here so it stays true.
+ */
+
+describe("editor coverage", () => {
+  it("maps every field type to an editor", () => {
+    // FIELD_EDITORS is typed Record<FieldType, …> so a missing entry is a
+    // compile error — but the type only guards the keys, not that the
+    // runtime object was fully populated (e.g. after a bad merge).
+    for (const type of FIELD_TYPES) {
+      expect(FIELD_EDITORS[type], `no editor for "${type}"`).toBeDefined();
+      expect(FIELD_EDITORS[type].editor).toBeTypeOf("string");
+    }
+  });
+
+  it("marks exactly the relational types as relational", () => {
+    // These post ids into entry_relations rather than scalars into the
+    // document; treating one as the other writes to the wrong table.
+    const relational = FIELD_TYPES.filter((t) => isRelational(t));
+    expect(relational.sort()).toEqual(["component", "relation"]);
+  });
+});
+
+describe("form-name round-trip", () => {
+  it("round-trips a non-localized document field", () => {
+    expect(parseFieldName(fieldName("text", "sku"))).toEqual({
+      kind: "doc",
+      apiId: "sku",
+    });
+  });
+
+  it("round-trips a localized field", () => {
+    expect(parseFieldName(fieldName("text", "title", "en"))).toEqual({
+      kind: "localized",
+      locale: "en",
+      apiId: "title",
+    });
+  });
+
+  it("round-trips a relation field", () => {
+    expect(parseFieldName(fieldName("relation", "variants"))).toEqual({
+      kind: "relation",
+      apiId: "variants",
+    });
+  });
+
+  it("ignores locale for relational fields", () => {
+    // Relations live in entry_relations, which has no locale column —
+    // namespacing one in would produce a key the parser routes to the
+    // wrong branch.
+    expect(fieldName("relation", "variants", "en")).toBe("r.variants");
+  });
+
+  it("survives an apiId containing underscores", () => {
+    // `l.<locale>.<apiId>` splits on the FIRST dot after the prefix.
+    // apiIds cannot contain dots (API_ID_PATTERN) but very much can
+    // contain underscores, so this is the realistic edge case.
+    expect(parseFieldName("l.th.motor_power")).toEqual({
+      kind: "localized",
+      locale: "th",
+      apiId: "motor_power",
+    });
+  });
+
+  it("round-trips every field type at least once", () => {
+    for (const type of FIELD_TYPES) {
+      const parsed = parseFieldName(fieldName(type, "some_field"));
+      expect(parsed, `round-trip failed for "${type}"`).not.toBeNull();
+      expect(parsed?.apiId).toBe("some_field");
+    }
+  });
+});
+
+describe("malformed keys", () => {
+  it("rejects rather than mis-parsing", () => {
+    // Returning a plausible-but-wrong parse is worse than null: the save
+    // action would write the value under the wrong field.
+    for (const bad of [
+      "x.foo", // unknown namespace
+      "f.", // empty apiId
+      "r.", // empty apiId
+      "l.", // no locale, no apiId
+      "l.en", // locale but no apiId
+      "l..title", // empty locale
+      "", // empty
+      "slug", // an unnamespaced form field
+      "status",
+    ]) {
+      expect(
+        parseFieldName(bad),
+        `accepted malformed key ${JSON.stringify(bad)}`,
+      ).toBeNull();
+    }
+  });
+});

--- a/src/lib/components/admin/sidebar-nav.node.test.ts
+++ b/src/lib/components/admin/sidebar-nav.node.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Regression guard for the outage that took the demo down on EVERY route
+ * with a Worker 1101:
+ *
+ *   TypeError: Cannot read properties of undefined (reading 'get')
+ *       at registerNavGroup (sidebar-nav.js)
+ *
+ * ## The bug
+ *
+ * `sidebar-nav.ts` imports `$lib/plugins/registrations` at the bottom as
+ * a side effect, so plugin `registerNavGroup()` calls execute during that
+ * module's OWN evaluation. The registry was a top-level
+ * `const registry = new Map()`, and the bundler hoisted those calls above
+ * it.
+ *
+ * ## Why this asserts on SOURCE rather than importing the module
+ *
+ * Two reasons, both honest limitations rather than convenience:
+ *
+ * 1. Importing it pulls in `lucide-svelte`, which needs Svelte-aware
+ *    resolution. Adding that plugin would drag SvelteKit build context
+ *    into unit tests for no gain.
+ * 2. More importantly, importing would NOT reproduce the bug. Vitest's
+ *    esbuild pipeline orders modules differently from the production
+ *    Rollup build — which is precisely why `check`, `build` AND a green
+ *    deploy all missed it.
+ *
+ * So the durable guard is structural: assert the registry is never
+ * eagerly constructed at module scope. That property is what makes
+ * evaluation order irrelevant.
+ */
+const SOURCE = new URL("./sidebar-nav.ts", import.meta.url).pathname;
+
+describe("sidebar-nav module initialization", () => {
+  const source: string = readFileSync(SOURCE, "utf8");
+
+  it("does not construct the registry at module scope", () => {
+    // This exact shape is what broke: any plugin registration hoisted
+    // above it throws.
+    expect(source).not.toMatch(/^const registry\s*=\s*new Map/m);
+  });
+
+  it("reads the registry through an accessor so order cannot matter", () => {
+    expect(source).toMatch(/function registry\(\)/);
+    expect(source).toMatch(/if \(!_registry\)/);
+  });
+
+  it("routes every registry access through the accessor", () => {
+    // A single missed call site reintroduces the crash for one path only,
+    // which is worse than the original because it fails conditionally.
+    const offenders: string[] = source
+      .split("\n")
+      .map((line: string, i: number): string =>
+        /\bregistry\.(get|set|entries|has|delete)\b/.test(line) &&
+        !line.includes("registry().")
+          ? `${i + 1}: ${line.trim()}`
+          : "",
+      )
+      .filter((s: string): boolean => s !== "");
+    expect(offenders).toEqual([]);
+  });
+
+  it("still imports plugin registrations as a side effect", () => {
+    // That import is what makes ordering fragile. If it is ever removed,
+    // these guards become dead weight and should be reconsidered rather
+    // than left as cargo cult.
+    expect(source).toMatch(/import ["']\$lib\/plugins\/registrations["']/);
+  });
+});

--- a/src/lib/server/content/attributes/units.test.ts
+++ b/src/lib/server/content/attributes/units.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  FAMILIES,
+  denormalize,
+  isMeasureFamily,
+  normalize,
+  resolveUnit,
+  UnitError,
+} from "./units";
+
+/**
+ * Unit conversion is the load-bearing claim of the whole spec layer
+ * (#88): faceting and comparison are only correct because every
+ * measurement is normalized to one canonical number on write.
+ *
+ * These were previously verified by throwaway scripts that were then
+ * deleted, which made the verification unrepeatable. They belong here.
+ *
+ * ## What these tests can and cannot prove
+ *
+ * They prove the conversion arithmetic and the round-trip. They do NOT
+ * prove that a facet query returns the right rows — that needs real
+ * SQLite and belongs in an integration suite. The comments below mark
+ * where that boundary is.
+ */
+
+describe("measure families", () => {
+  it("declares a standard unit that is itself a known unit", () => {
+    // A standard unit absent from its own family's table would make every
+    // normalize() into that family throw at runtime. resolveUnit returns
+    // the canonical unit KEY (or null), not a factor.
+    for (const [name, family] of Object.entries(FAMILIES)) {
+      expect(
+        resolveUnit(name as never, family.standardUnit),
+        `${name}.standardUnit "${family.standardUnit}" is not in its own unit table`,
+      ).toBe(family.standardUnit);
+    }
+  });
+
+  it("normalizes a standard-unit value to itself", () => {
+    // The standard unit must be an identity conversion. Any scaling here
+    // would silently shift every stored value in that family.
+    for (const [name, family] of Object.entries(FAMILIES)) {
+      const n = normalize(name as never, 42, family.standardUnit);
+      expect(n.standardValue, `${name} standard unit must be identity`).toBe(
+        42,
+      );
+    }
+  });
+
+  it("excludes temperature", () => {
+    // Deliberate: °C→K is an OFFSET, not a scale. A factor table cannot
+    // express it, and including it would produce silently wrong numbers
+    // rather than an error.
+    expect(isMeasureFamily("temperature")).toBe(false);
+  });
+});
+
+describe("normalize", () => {
+  it("converts #88's own worked example: 533 g vs 0.6 kg", () => {
+    // From the issue: these must compare correctly despite different
+    // authored units. 0.6 kg is the heavier of the two.
+    const a = normalize("mass", 533, "g").standardValue;
+    const b = normalize("mass", 0.6, "kg").standardValue;
+    expect(a).toBe(533);
+    expect(b).toBe(600);
+    expect(b).toBeGreaterThan(a);
+  });
+
+  it("converts #88's pressure example: 0.1 mbar = 10 Pa", () => {
+    expect(normalize("pressure", 0.1, "mbar").standardValue).toBeCloseTo(10, 9);
+  });
+
+  it("distinguishes mbar from MPa — case matters", () => {
+    // The case trap: milli- and mega- differ only by capitalization, and
+    // conflating them is a factor-of-10^9 error.
+    const milli = normalize("pressure", 1, "mbar").standardValue;
+    const mega = normalize("pressure", 1, "MPa").standardValue;
+    expect(milli).toBeCloseTo(100, 9);
+    expect(mega).toBe(1_000_000);
+  });
+
+  it("preserves the authored unit for display", () => {
+    // Faceting uses standardValue; the datasheet must still render what
+    // the editor typed.
+    expect(normalize("flow", 100, "m3/min").unit).toBe("m3/min");
+  });
+
+  it("rejects an unknown unit rather than guessing", () => {
+    // Silently defaulting to factor 1 would store a wrong number that no
+    // later query could detect.
+    expect(() => normalize("pressure", 1, "furlongs")).toThrow(UnitError);
+  });
+
+  it("handles zero and negative values", () => {
+    expect(normalize("pressure", 0, "mbar").standardValue).toBe(0);
+    // Negative gauge pressure is physically meaningful; conversion must
+    // not clamp it.
+    expect(normalize("pressure", -1, "mbar").standardValue).toBeCloseTo(
+      -100,
+      9,
+    );
+  });
+});
+
+describe("round-trip", () => {
+  it("returns the authored number for every family's non-standard units", () => {
+    // This is what makes the display promise honest: a value authored as
+    // "15 hp" must render as 15 hp, not 11185.5 W.
+    for (const [familyName, family] of Object.entries(FAMILIES)) {
+      for (const unit of Object.keys(family.units)) {
+        for (const authored of [1, 0.5, 63, 12.5, 1e-3]) {
+          const stored = normalize(
+            familyName as never,
+            authored,
+            unit,
+          ).standardValue;
+          const back = denormalize(familyName as never, stored, unit);
+          expect(
+            back,
+            `${familyName}: ${authored} ${unit} round-tripped to ${back}`,
+          ).toBeCloseTo(authored, 6);
+        }
+      }
+    }
+  });
+
+  it("round-trips the exact values the Phase 3 seed authors", () => {
+    // Regression lock on the demo fixture's numbers, so a factor change
+    // that breaks them fails here rather than on a rendered datasheet.
+    const cases: [Parameters<typeof normalize>[0], number, string][] = [
+      ["flow", 100, "m3/min"],
+      ["pressure", 1, "Torr"],
+      ["power", 15, "hp"],
+      ["length", 2, "in"],
+      ["mass", 12.5, "kg"],
+    ];
+    for (const [family, value, unit] of cases) {
+      const stored = normalize(family, value, unit).standardValue;
+      expect(denormalize(family, stored, unit)).toBeCloseTo(value, 9);
+    }
+  });
+});
+
+describe("interval comparison (#98)", () => {
+  /**
+   * These assert the ARITHMETIC that makes interval overlap correct
+   * across mixed authored units. They do not execute SQL — the actual
+   * `value_number_max >= lo AND value_number_min <= hi` predicate needs
+   * real SQLite and is verified in the migration walkthrough.
+   */
+  it("makes a range authored in one unit comparable to a scalar in another", () => {
+    // 100 m3/min = 6000 m3/h, so it must NOT overlap a 90-160 m3/h band
+    // even though its authored number (100) sits inside that band. This
+    // is the case that gets silently backwards without normalization.
+    const authoredInMinutes = normalize("flow", 100, "m3/min").standardValue;
+    const lo = normalize("flow", 90, "m3/h").standardValue;
+    const hi = normalize("flow", 160, "m3/h").standardValue;
+    expect(authoredInMinutes).toBe(6000);
+    const overlaps = authoredInMinutes >= lo && authoredInMinutes <= hi;
+    expect(overlaps).toBe(false);
+  });
+
+  it("ranks lower-is-better values correctly after normalization", () => {
+    // 0.1 mbar is a BETTER vacuum than 1 Torr, but its authored number is
+    // smaller — comparing authored numbers gets the ordering right here
+    // by luck and wrong in general. Normalized, the relationship is
+    // unambiguous.
+    const mbar = normalize("pressure", 0.1, "mbar").standardValue;
+    const torr = normalize("pressure", 1, "Torr").standardValue;
+    expect(mbar).toBeLessThan(torr);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,15 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
-  "exclude": ["src/lib/paraglide/**"],
+  "exclude": [
+    // Paraglide compiler OUTPUT — generated, gitignored, and not ours to
+    // fix. Both paths are listed because the compiler used to emit to
+    // src/lib/paraglide/ and now emits to src/paraglide/; a stale
+    // single-path exclude is exactly why `pnpm check` reported 3 errors
+    // in generated code (#62), and why the same drift broke the lint
+    // gate in .prettierignore.
+    "src/lib/paraglide/**",
+    "src/paraglide/**"
+  ],
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Test config — deliberately SEPARATE from vite.config.ts.
+ *
+ * The app config loads the SvelteKit and Paraglide plugins, which expect
+ * a full SvelteKit build context. Unit tests here exercise plain
+ * TypeScript modules (services, unit conversion, form encoding), so
+ * pulling those plugins in would only add failure modes.
+ *
+ * Tests that need a real D1 or a running Worker belong in a separate
+ * integration project once one exists; see the note in
+ * `src/lib/server/content/attributes/units.test.ts` about what unit
+ * tests can and cannot prove here.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirror svelte.config.js so imports resolve identically. Kept in
+      // sync by hand — there is no shared source for these yet.
+      $lib: new URL("./src/lib", import.meta.url).pathname,
+      $plugins: new URL("./src/plugins", import.meta.url).pathname,
+    },
+  },
+  test: {
+    include: ["src/**/*.{test,spec}.{js,ts}"],
+    // Generated output and build artefacts are never worth testing.
+    exclude: [
+      "node_modules/**",
+      ".svelte-kit/**",
+      "src/lib/paraglide/**",
+      "src/paraglide/**",
+    ],
+    environment: "node",
+    // Node built-ins (node:fs) are used by structural tests that read
+    // source files. The app tsconfig targets the browser, so those tests
+    // live under a `*.node.test.ts` name and get @types/node via this
+    // config rather than polluting the app's global types.
+    // Fail loudly rather than silently passing on zero tests — a config
+    // change that stops matching any file should break CI, not go green.
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
Closes #62, closes #63. Also fixes the CI gap that let today's outage ship silently.

## #63 — there was no `pnpm test` at all

Every verification in this milestone came from throwaway scripts that were then deleted, making them unrepeatable. **26 tests** now cover the three failure classes that actually escaped:

| Suite | Tests | Covers |
|---|---|---|
| `units.test.ts` | 13 | The load-bearing claim of the spec layer |
| `field-map.test.ts` | 9 | Phase 4 form encoding |
| `sidebar-nav.node.test.ts` | 4 | The module-init crash |

**`units.test.ts`** locks in #88's own worked examples (533 g vs 0.6 kg, 0.1 mbar = 10 Pa), the mbar/MPa case trap, zero and negative values, a round-trip for *every unit in every family*, and the exact numbers the Phase 3 seed authors. Plus the #98 case that goes silently backwards without normalization: `100 m3/min` must **not** match a 90–160 m3/h band even though its authored number sits inside it.

**`field-map.test.ts`** covers all three key namespaces, every field type, an underscored apiId through the `l.<locale>.<apiId>` split, and 9 malformed keys that must return `null` rather than mis-parse. A lossy encoding silently drops edits while the UI reports success — the worst failure mode for a CMS.

**`sidebar-nav.node.test.ts`** asserts on **source**, not by importing. That's deliberate and documented in the file: importing would *not* reproduce the bug, because Vitest's esbuild pipeline orders modules differently from the production Rollup build — which is exactly why `check`, `build` **and** a green deploy all missed it.

I verified the guard actually works rather than assuming: reintroducing the bug fails 3 tests, restoring passes all 26.

`passWithNoTests: false`, so a config change that stops matching files breaks CI instead of going green.

## #62 — `pnpm check` reported 3 errors in generated code

`tsconfig.json` excluded `src/lib/paraglide/**` but the compiler emits to `src/paraglide/`. Same stale-path bug as `.prettierignore`.

Now **0 errors** — so a real new error is visible instead of hiding in noise everyone had learned to ignore. (Worth noting the demo repo already had 0 errors purely because of its different output path.)

## A third instance of the same drift

Adding tests surfaced it: ESLint derives its ignores from `.gitignore` via `includeIgnoreFile()`, and `src/paraglide/` is only covered by its own **generated** `.gitignore`, which that helper doesn't read. So ESLint was linting hundreds of generated files as soon as anything else changed.

That's **three configs** — `.prettierignore`, `tsconfig.json`, `.gitignore` — broken by one output-path move. Each now carries a comment explaining why both paths are listed.

## Smoke test: a crash is no longer treated as retryable

The probe accepted 503 (correctly — that's Khao Pad's own "config required" screen, meaning the Worker *is* running) but **retried 500 for 60s** then failed with a generic message. A module-init crash returns 500 forever, so that only delayed the failure and buried the cause.

Now 2xx/3xx/503 pass; any other 5xx **fails immediately** with a pointer to `wrangler tail`. Verified by simulation:

```
200 -> PASS        500 -> FAIL-FAST
308 -> PASS        502 -> FAIL-FAST
503 -> PASS        404 -> FAIL-TIMEOUT
```

Today's outage would have been caught.

`pnpm test` runs in both `ci.yml` and `deploy.yml`, **before** build — tests are faster and catch logic errors, so failures surface in seconds rather than after a full bundle.

## Gate

`check` 0 errors · 26 tests pass · `lint` exit 0 · `build` passes.

## Deliberately not included

- #63 also asks for an integration test of the plugin acceptance path (`@khaopad/plugin-hello` installs → migration runs → route responds → sidebar entry appears). That needs a real D1 and a running Worker, which is a separate harness. I've left the issue's remaining checkboxes for it rather than claiming them.
- The tests here are unit-level by design. Every claim about actual SQL behaviour in this milestone was verified against real SQLite by hand; that verification still isn't automated, and the `units.test.ts` header says so explicitly rather than implying more coverage than exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)