### PR TITLE
fix(ci): compile Paraglide in deploy job; gate D1 step on token scope (closes #51)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,9 +141,30 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      # Each GitHub job gets a FRESH runner, so the gate job's compile
+      # output does not carry over — and src/lib/paraglide is gitignored.
+      # Without this, `pnpm build` here fails on missing imports from
+      # $lib/paraglide/messages. Reported in #51; still live until now.
+      - name: Compile Paraglide messages
+        run: pnpm exec paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
+
       - run: pnpm build
 
+      # ⚠ Requires a token with `D1 — Edit`, which the conventional
+      # org-wide CLOUDFLARE_API_TOKEN does NOT have: that token is created
+      # from the "Edit Cloudflare Workers" template, granting only
+      # `Workers Scripts — Edit`. The symptom is a 7403 on THIS step while
+      # the deploy step against the same account succeeds, and the error
+      # text never mentions permissions — see #51, which diagnosed it.
+      #
+      # Opt-in so a fork is not blocked by a token it cannot change:
+      # set the repo variable RUN_D1_MIGRATIONS=true once your token has
+      # D1 — Edit. Otherwise apply migrations out of band:
+      #
+      #   npx wrangler d1 migrations apply <db> --remote --env <env>
       - name: Apply D1 migrations (${{ needs.resolve-env.outputs.environment }})
+        if: vars.RUN_D1_MIGRATIONS == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Reapplies both fixes from #51 on top of current main. That PR conflicts (#93, #101 and #103 all touched `deploy.yml`), so rather than untangle a three-month-old branch I have carried its two findings forward and will close it as superseded — the diagnosis in it was correct and deserves the credit.

## 1. The deploy job built without compiling Paraglide

```yaml
- run: pnpm install --frozen-lockfile
- run: pnpm build          # ← no compile step
```

Each GitHub job gets a **fresh runner**, so the gate job's compile output does not carry over, and `src/lib/paraglide` is gitignored. Any real deploy fails on missing `$lib/paraglide/messages` imports.

Latent rather than breaking today only because this workflow is dispatch-only and production ships from khaopad-example — but it is the reference pipeline people copy when scaffolding, so a broken one is worth fixing.

## 2. The D1 migration step needs a scope the org token does not have

This is the recurring `7403`. The org-wide `CLOUDFLARE_API_TOKEN` is created from the **"Edit Cloudflare Workers"** template, which grants `Workers Scripts — Edit` and nothing for D1.

What makes it a trap: the migration step fails with a bare 7403 while the **deploy step against the very same account succeeds**, and the error text never mentions permissions. I misdiagnosed this myself as a missing or unset secret and filed #95 asking for a new token — wrong on both counts, since the org secrets were present the whole time and #51 had already diagnosed it correctly in May.

Gated behind a repo variable instead of removed:

```yaml
- name: Apply D1 migrations (...)
  if: vars.RUN_D1_MIGRATIONS == 'true'
```

A fork whose token lacks the scope is not blocked; one whose token has it sets the variable and opts in. The comment in the file records both the required permission and the out-of-band command. **Only the D1 step is conditional — the deploy step is deliberately left ungated.**

## Verification

Prettier clean; step order asserted programmatically (compile < build < D1-gated < deploy-ungated). `pnpm run lint` 0, `pnpm run check` 0 errors.

Closes #51. Also resolves the open question in #95, which I will close with a pointer here.