### PR TITLE
feat(admin): manage integration credentials from /admin/settings/secrets

### DIFF
--- a/drizzle/0022_managed_secrets.sql
+++ b/drizzle/0022_managed_secrets.sql
@@ -1,0 +1,14 @@
+-- Admin-managed secrets, encrypted at rest.
+--
+-- Values are `v1:<base64(iv || ciphertext)>` (AES-GCM, key derived from
+-- BETTER_AUTH_SECRET via HKDF). Plaintext never reaches this table.
+--
+-- Separate from `site_settings` on purpose: that table is read wholesale
+-- and its values flow into page data, which is exactly the path a payment
+-- key must never travel.
+CREATE TABLE `managed_secrets` (
+  `key` text PRIMARY KEY NOT NULL,
+  `value_encrypted` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `updated_by` text
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1785513300000,
       "tag": "0021_spec_attributes",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1785599700000,
+      "tag": "0022_managed_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/admin/sidebar-nav.ts
+++ b/src/lib/components/admin/sidebar-nav.ts
@@ -233,6 +233,14 @@ registerNavGroup({
       roles: ["super_admin", "admin"],
     },
     {
+      href: "/admin/settings/secrets",
+      label: () => "Credentials",
+      icon: KeyRound,
+      // super_admin only — these keys create charges and issue refunds.
+      // Deliberately narrower than site settings, which admits `admin`.
+      roles: ["super_admin"],
+    },
+    {
       href: "/admin/settings",
       label: m.cms_settings,
       icon: Settings,

--- a/src/lib/server/auth/permissions.test.ts
+++ b/src/lib/server/auth/permissions.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { canManageSecrets, canManageSettings } from "./permissions";
+import type { AuthUser } from "./types";
+
+const user = (role: AuthUser["role"]) => ({ id: "u1", role }) as AuthUser;
+
+describe("canManageSecrets", () => {
+  it("allows only super_admin", () => {
+    expect(canManageSecrets(user("super_admin"))).toBe(true);
+    expect(canManageSecrets(user("admin"))).toBe(false);
+    expect(canManageSecrets(user("editor"))).toBe(false);
+    expect(canManageSecrets(user("author"))).toBe(false);
+  });
+
+  it("denies an unauthenticated user", () => {
+    expect(canManageSecrets(null)).toBe(false);
+  });
+
+  it("is strictly narrower than canManageSettings", () => {
+    // The whole point of a separate helper. If these ever converge, an
+    // `admin` silently gains the ability to read/replace live payment
+    // credentials — so assert the divergence, not just each value.
+    expect(canManageSettings(user("admin"))).toBe(true);
+    expect(canManageSecrets(user("admin"))).toBe(false);
+  });
+});

--- a/src/lib/server/auth/permissions.ts
+++ b/src/lib/server/auth/permissions.ts
@@ -26,6 +26,18 @@ export function canManageSettings(user: AuthUser | null): boolean {
   return hasRole(user, "admin");
 }
 
+/**
+ * Check if user can manage integration credentials (super_admin ONLY).
+ *
+ * Deliberately stricter than `canManageSettings`, which admits `admin`.
+ * These values create charges and issue refunds against a live payment
+ * account: a site title is reversible, a leaked Beam key is not. Where
+ * the two differ, credentials belong with the narrower role.
+ */
+export function canManageSecrets(user: AuthUser | null): boolean {
+  return hasRole(user, "super_admin");
+}
+
 /** Check if user can manage categories/tags (editor+) */
 export function canManageTaxonomy(user: AuthUser | null): boolean {
   return hasRole(user, "editor");

--- a/src/lib/server/content/schema.integration.node.test.ts
+++ b/src/lib/server/content/schema.integration.node.test.ts
@@ -95,6 +95,25 @@ describe("migrations", () => {
       .all() as { name: string }[];
     expect(tables.length).toBe(10);
   });
+
+  it("creates managed_secrets with the expected shape", () => {
+    const cols = db.prepare(`PRAGMA table_info(managed_secrets)`).all() as {
+      name: string;
+      notnull: number;
+      pk: number;
+    }[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+
+    expect(byName.get("key")?.pk).toBe(1);
+    expect(byName.get("value_encrypted")?.notnull).toBe(1);
+    expect(byName.get("updated_at")?.notnull).toBe(1);
+    expect(byName.has("updated_by")).toBe(true);
+
+    // There must be no column that could hold a plaintext value — the
+    // whole security property is that this table only ever holds
+    // ciphertext.
+    expect(byName.has("value")).toBe(false);
+  });
 });
 
 describe("entry_relations target shape (#99)", () => {

--- a/src/lib/server/secrets/crypto.test.ts
+++ b/src/lib/server/secrets/crypto.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { encryptSecret, decryptSecret, maskSecret } from "./crypto";
+
+const MASTER = "test-master-secret-do-not-use-in-production";
+
+describe("secret encryption", () => {
+  it("round-trips a value", async () => {
+    const plaintext = "sk_live_abcdef1234567890";
+    const encrypted = await encryptSecret(plaintext, MASTER);
+    expect(await decryptSecret(encrypted, MASTER)).toBe(plaintext);
+  });
+
+  it("never stores the plaintext in the ciphertext", async () => {
+    // The whole point of the feature. If this fails, a D1 dump leaks keys.
+    const plaintext = "sk_live_abcdef1234567890";
+    const encrypted = await encryptSecret(plaintext, MASTER);
+    expect(encrypted).not.toContain(plaintext);
+    expect(encrypted).not.toContain("abcdef");
+  });
+
+  it("uses a fresh IV per call, so equal plaintexts differ", async () => {
+    // IV reuse under one key breaks BOTH confidentiality and authentication
+    // in GCM. Identical ciphertexts would prove the IV is static.
+    const a = await encryptSecret("same-value", MASTER);
+    const b = await encryptSecret("same-value", MASTER);
+    expect(a).not.toBe(b);
+    expect(await decryptSecret(a, MASTER)).toBe("same-value");
+    expect(await decryptSecret(b, MASTER)).toBe("same-value");
+  });
+
+  it("returns null for a different master secret", async () => {
+    // The BETTER_AUTH_SECRET-rotated case. Must fail closed, not return
+    // garbage that gets handed to a payment provider.
+    const encrypted = await encryptSecret("value", MASTER);
+    expect(await decryptSecret(encrypted, "a-different-secret")).toBeNull();
+  });
+
+  it("returns null for tampered ciphertext", async () => {
+    // GCM is authenticated: a single flipped bit must fail the tag check.
+    // Tamper at the byte level and re-encode, so this tests real tampering
+    // rather than merely malformed base64 (which would pass vacuously).
+    const encrypted = await encryptSecret("value", MASTER);
+    const raw = Uint8Array.from(atob(encrypted.slice(3)), (c) =>
+      c.charCodeAt(0),
+    );
+    raw[raw.length - 5] ^= 0x01;
+    const tampered = "v1:" + btoa(String.fromCharCode(...raw));
+    // Still structurally valid — proving the rejection is cryptographic.
+    expect(atob(tampered.slice(3)).length).toBe(raw.length);
+    expect(await decryptSecret(tampered, MASTER)).toBeNull();
+  });
+
+  it("returns null for an unprefixed (legacy/plaintext) value", async () => {
+    expect(await decryptSecret("sk_live_raw_plaintext", MASTER)).toBeNull();
+  });
+
+  it("returns null for a truncated payload", async () => {
+    expect(await decryptSecret("v1:AAAA", MASTER)).toBeNull();
+  });
+
+  it("refuses to encrypt without a master secret", async () => {
+    await expect(encryptSecret("value", "")).rejects.toThrow(
+      /BETTER_AUTH_SECRET/,
+    );
+  });
+
+  it("carries a version prefix so a future re-key can migrate", async () => {
+    expect(await encryptSecret("value", MASTER)).toMatch(/^v1:/);
+  });
+
+  it("round-trips unicode and long values", async () => {
+    const plaintext = "ключ-🔑-ทดสอบ-" + "x".repeat(500);
+    const encrypted = await encryptSecret(plaintext, MASTER);
+    expect(await decryptSecret(encrypted, MASTER)).toBe(plaintext);
+  });
+});
+
+describe("maskSecret", () => {
+  it("reveals only the last 4 characters", async () => {
+    expect(maskSecret("sk_live_abcdef1234")).toBe("••••••••1234");
+  });
+
+  it("fully masks short values", async () => {
+    // Revealing 4 of 6 characters is worse than revealing none.
+    expect(maskSecret("short")).toBe("••••••••");
+    expect(maskSecret("12345678")).toBe("••••••••");
+  });
+
+  it("never returns the input for a sensitive-length value", async () => {
+    const secret = "sk_live_verysecretvalue";
+    expect(maskSecret(secret)).not.toBe(secret);
+    expect(maskSecret(secret).length).toBeLessThan(secret.length);
+  });
+});

--- a/src/lib/server/secrets/crypto.ts
+++ b/src/lib/server/secrets/crypto.ts
@@ -1,0 +1,146 @@
+/**
+ * Envelope encryption for admin-managed secrets.
+ *
+ * Secrets configured through /admin/settings/secrets are stored in D1.
+ * D1 content reaches more places than a Cloudflare secret does — backups,
+ * `wrangler d1 execute`, a stray `SELECT *` in a log, a future read-only
+ * analytics binding. Storing a live payment key as plaintext there widens
+ * the blast radius from "Cloudflare account access" to "any read of the
+ * database". So values are encrypted at rest.
+ *
+ * ## Key derivation
+ *
+ * The wrapping key is derived from BETTER_AUTH_SECRET via HKDF-SHA256.
+ * That secret stays a Cloudflare secret and is deliberately NOT movable
+ * into the settings portal (it is consumed in `authHook` before a session
+ * exists, so DB-storing it would be circular). Deriving from it means the
+ * decryption key never lives in the same store as the ciphertext.
+ *
+ * A distinct `info` string scopes the derivation, so this key can never
+ * collide with any other use of BETTER_AUTH_SECRET.
+ *
+ * ## Rotation
+ *
+ * Rotating BETTER_AUTH_SECRET makes every stored secret undecryptable.
+ * That is the intended trade — it fails closed, loudly, rather than
+ * silently serving a wrong key to a payment provider. Re-enter the
+ * secrets through the admin UI after rotating (env vars still override,
+ * so you are never locked out; see `resolve.ts`).
+ */
+
+const KEY_INFO = "khaopad:secrets:v1";
+const AES_GCM_IV_BYTES = 12; // 96 bits — the value NIST specifies for GCM
+const CIPHERTEXT_PREFIX = "v1:";
+
+/**
+ * Derive the AES-GCM wrapping key from BETTER_AUTH_SECRET.
+ *
+ * HKDF rather than using the raw secret as key material: BETTER_AUTH_SECRET
+ * is an arbitrary-length, arbitrary-entropy string, and AES-GCM needs
+ * exactly 256 uniformly-random bits.
+ */
+async function deriveKey(masterSecret: string): Promise<CryptoKey> {
+  if (!masterSecret) {
+    throw new Error(
+      "Cannot encrypt secrets: BETTER_AUTH_SECRET is not set. " +
+        "It is the key-derivation root for admin-managed secrets.",
+    );
+  }
+  const material = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(masterSecret),
+    "HKDF",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      // Salt is empty by design: HKDF tolerates this (RFC 5869 §3.1) and a
+      // per-row salt would have to live beside the ciphertext anyway. The
+      // security here rests on BETTER_AUTH_SECRET, not on the salt.
+      salt: new Uint8Array(0),
+      info: new TextEncoder().encode(KEY_INFO),
+    },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypt a secret for storage. Output is `v1:<base64(iv || ciphertext)>`.
+ *
+ * The version prefix is what makes a future re-key survivable: a `v2:`
+ * reader can recognise and migrate `v1:` rows instead of guessing.
+ *
+ * A fresh random IV per call is mandatory for GCM — reusing an IV under
+ * the same key breaks confidentiality AND authentication, not just
+ * confidentiality.
+ */
+export async function encryptSecret(
+  plaintext: string,
+  masterSecret: string,
+): Promise<string> {
+  const key = await deriveKey(masterSecret);
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  const packed = new Uint8Array(iv.length + ciphertext.byteLength);
+  packed.set(iv, 0);
+  packed.set(new Uint8Array(ciphertext), iv.length);
+  return CIPHERTEXT_PREFIX + btoa(String.fromCharCode(...packed));
+}
+
+/**
+ * Decrypt a stored secret. Returns null when the value cannot be
+ * decrypted — wrong key (BETTER_AUTH_SECRET rotated), corrupted row, or
+ * a tampered ciphertext (GCM authentication failure).
+ *
+ * Null rather than throw: a single unreadable secret should degrade that
+ * one integration, not take down every request that touches settings.
+ * Callers treat null as "not configured".
+ */
+export async function decryptSecret(
+  stored: string,
+  masterSecret: string,
+): Promise<string | null> {
+  if (!stored.startsWith(CIPHERTEXT_PREFIX)) return null;
+  try {
+    const key = await deriveKey(masterSecret);
+    const raw = Uint8Array.from(
+      atob(stored.slice(CIPHERTEXT_PREFIX.length)),
+      (c) => c.charCodeAt(0),
+    );
+    if (raw.length <= AES_GCM_IV_BYTES) return null;
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: raw.subarray(0, AES_GCM_IV_BYTES) },
+      key,
+      raw.subarray(AES_GCM_IV_BYTES),
+    );
+    return new TextDecoder().decode(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Masked form for display: last 4 characters only.
+ *
+ * The admin UI must NEVER round-trip a plaintext secret to the browser —
+ * that would put live payment keys into page source, browser history,
+ * extensions, and any proxy in the path. Fields are write-only; this is
+ * the only thing the UI ever shows of an existing value.
+ *
+ * Short values are fully masked rather than partially revealed, since
+ * revealing 4 of 6 characters is worse than revealing none.
+ */
+export function maskSecret(plaintext: string): string {
+  if (plaintext.length <= 8) return "••••••••";
+  return "••••••••" + plaintext.slice(-4);
+}

--- a/src/lib/server/secrets/registry.test.ts
+++ b/src/lib/server/secrets/registry.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { MANAGED_SECRETS, isManagedSecret, secretsByGroup } from "./registry";
+
+describe("managed secret registry", () => {
+  it("never admits BETTER_AUTH_SECRET", () => {
+    // Two independent reasons this must stay a Cloudflare secret:
+    //  1. It is read in authHook BEFORE a session exists — storing it
+    //     behind a session-gated admin page is circular.
+    //  2. It signs session cookies, so read access = forge any login.
+    // It is also the key-derivation root for encrypting this very table.
+    expect(isManagedSecret("BETTER_AUTH_SECRET")).toBe(false);
+    expect(MANAGED_SECRETS.some((s) => s.key === "BETTER_AUTH_SECRET")).toBe(
+      false,
+    );
+  });
+
+  it("never admits deploy-time Cloudflare credentials", () => {
+    // These create the Worker, so they cannot live inside it.
+    expect(isManagedSecret("CLOUDFLARE_API_TOKEN")).toBe(false);
+    expect(isManagedSecret("CLOUDFLARE_ACCOUNT_ID")).toBe(false);
+  });
+
+  it("rejects arbitrary keys", () => {
+    // The write path guards on this. Without it a crafted form POST could
+    // write any key, including one shadowing a refused env var.
+    expect(isManagedSecret("")).toBe(false);
+    expect(isManagedSecret("DATABASE_URL")).toBe(false);
+    expect(isManagedSecret("beam_api_key")).toBe(false); // case-sensitive
+  });
+
+  it("accepts exactly the four intended keys", () => {
+    const keys = MANAGED_SECRETS.map((s) => s.key).sort();
+    expect(keys).toEqual([
+      "BEAM_API_KEY",
+      "BEAM_MERCHANT_ID",
+      "BEAM_WEBHOOK_SECRET",
+      "RESEND_API_KEY",
+    ]);
+  });
+
+  it("marks every credential sensitive except the merchant identifier", () => {
+    // A wrong value here means a live key renders in full on the page.
+    for (const def of MANAGED_SECRETS) {
+      const expected = def.key !== "BEAM_MERCHANT_ID";
+      expect(def.sensitive, `${def.key}.sensitive`).toBe(expected);
+    }
+  });
+
+  it("gives every entry a label, help text and group", () => {
+    for (const def of MANAGED_SECRETS) {
+      expect(def.label.length, `${def.key}.label`).toBeGreaterThan(0);
+      expect(def.help.length, `${def.key}.help`).toBeGreaterThan(0);
+      expect(def.group.length, `${def.key}.group`).toBeGreaterThan(0);
+    }
+  });
+
+  it("groups without losing or duplicating entries", () => {
+    const grouped = [...secretsByGroup().values()].flat();
+    expect(grouped.length).toBe(MANAGED_SECRETS.length);
+    expect(new Set(grouped.map((d) => d.key)).size).toBe(
+      MANAGED_SECRETS.length,
+    );
+  });
+
+  it("has no duplicate keys", () => {
+    const keys = MANAGED_SECRETS.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/src/lib/server/secrets/registry.ts
+++ b/src/lib/server/secrets/registry.ts
@@ -1,0 +1,100 @@
+/**
+ * Registry of secrets manageable from /admin/settings/secrets.
+ *
+ * ## What may live here
+ *
+ * A secret qualifies ONLY if it is read during a request that already has
+ * `platform.env.DB` and has already resolved a session. That is what makes
+ * a DB round-trip possible at the point of use.
+ *
+ * ## What may NOT, and why
+ *
+ * `BETTER_AUTH_SECRET` is deliberately excluded and must stay a Cloudflare
+ * secret. Two independent reasons:
+ *
+ *  1. **Circular.** It is consumed in `authHook` (hooks.server.ts) to
+ *     resolve the session on every request — before we know who the user
+ *     is. Reading it from a table gated behind an authenticated admin page
+ *     would require a session to fetch the secret that validates sessions.
+ *
+ *  2. **Privilege escalation.** It signs session cookies. Anything that can
+ *     read it can mint a session for any user, including super_admin. A
+ *     settings page that exposed it would turn "admin panel read" into
+ *     "full account takeover".
+ *
+ * It is additionally the key-derivation root for encrypting everything in
+ * this registry (see crypto.ts), so storing it beside the ciphertext it
+ * protects would defeat the encryption entirely.
+ *
+ * `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are likewise excluded:
+ * they are deploy-time credentials used to create the Worker, so they
+ * cannot live inside it.
+ */
+
+export type SecretDef = {
+  /** Storage key, matching the env var name it overrides. */
+  key: string;
+  /** Human label for the admin form. */
+  label: string;
+  /** What it does and where to obtain it. */
+  help: string;
+  /**
+   * Non-secret identifiers are shown in full rather than masked — masking
+   * a value that is not confidential just makes it hard to verify.
+   */
+  sensitive: boolean;
+  group: string;
+};
+
+export const MANAGED_SECRETS: readonly SecretDef[] = [
+  {
+    key: "BEAM_MERCHANT_ID",
+    label: "Beam merchant ID",
+    help: "Your BeamCheckout merchant identifier, e.g. codustry-xxxxxx. An identifier, not a credential — shown in full so you can confirm it.",
+    sensitive: false,
+    group: "Payments — BeamCheckout",
+  },
+  {
+    key: "BEAM_API_KEY",
+    label: "Beam secret key",
+    help: "Server-side API key used to create charges and issue refunds. Beam dashboard → Developers → API keys.",
+    sensitive: true,
+    group: "Payments — BeamCheckout",
+  },
+  {
+    key: "BEAM_WEBHOOK_SECRET",
+    label: "Beam webhook secret",
+    help: "Verifies the HMAC signature on inbound Beam webhooks. Getting this wrong means paid orders are never confirmed.",
+    sensitive: true,
+    group: "Payments — BeamCheckout",
+  },
+  {
+    key: "RESEND_API_KEY",
+    label: "Resend API key",
+    help: "Sends order receipts and abandoned-cart email. Leave unset to disable transactional email — the shop degrades quietly rather than failing.",
+    sensitive: true,
+    group: "Email — Resend",
+  },
+] as const;
+
+const MANAGED_KEYS = new Set(MANAGED_SECRETS.map((s) => s.key));
+
+/**
+ * Guard for the write path. Without this, a crafted form POST could write
+ * an arbitrary key into the secrets table — including one that shadows an
+ * env var this registry deliberately refuses to manage.
+ */
+export function isManagedSecret(key: string): boolean {
+  return MANAGED_KEYS.has(key);
+}
+
+/** Registry entries grouped for rendering, preserving declaration order. */
+export function secretsByGroup(): Map<string, SecretDef[]> {
+  const groups = new Map<string, SecretDef[]>();
+  for (const def of MANAGED_SECRETS) {
+    const list = groups.get(def.group);
+    if (list) list.push(def);
+    else groups.set(def.group, [def]);
+  }
+  return groups;
+}

--- a/src/lib/server/secrets/schema.ts
+++ b/src/lib/server/secrets/schema.ts
@@ -1,0 +1,34 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * Admin-managed secrets, encrypted at rest.
+ *
+ * Deliberately NOT reusing `site_settings`, even though it is also a
+ * key/value table. Three reasons:
+ *
+ *  1. `site_settings` is read wholesale (`SELECT *` in the D1 provider)
+ *     and its values flow into page data. Secrets must never travel that
+ *     path — a single future `settings` prop on a layout would leak every
+ *     payment key to the browser.
+ *  2. Different value semantics: everything here is ciphertext, so a
+ *     caller that forgets to decrypt gets obvious garbage rather than a
+ *     plausible-looking wrong value.
+ *  3. Separate tables make the audit story legible — `updated_by` is
+ *     meaningful for a credential change and noise for a site title.
+ */
+export const managedSecrets = sqliteTable("managed_secrets", {
+  /** Matches the env var name this value overrides, e.g. BEAM_API_KEY. */
+  key: text("key").primaryKey(),
+  /**
+   * `v1:<base64(iv || ciphertext)>` — AES-GCM, key derived from
+   * BETTER_AUTH_SECRET. Never a plaintext value. The `v1:` prefix exists
+   * so a future re-key can recognise and migrate old rows rather than
+   * guessing at the format.
+   */
+  valueEncrypted: text("value_encrypted").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  /** User id of the admin who last set it — credential changes need attribution. */
+  updatedBy: text("updated_by"),
+});
+
+export type ManagedSecret = typeof managedSecrets.$inferSelect;

--- a/src/lib/server/secrets/service.integration.node.test.ts
+++ b/src/lib/server/secrets/service.integration.node.test.ts
@@ -1,0 +1,269 @@
+import Database from "better-sqlite3";
+import { readFileSync, readdirSync } from "node:fs";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getSecret,
+  getSecrets,
+  listSecretStatus,
+  setSecret,
+  deleteSecret,
+} from "./service";
+
+/**
+ * Service tests against REAL SQLite with the REAL migrations applied.
+ *
+ * Unit-testing the crypto proves the primitives; this proves the behaviour
+ * that actually protects credentials — masking, env precedence, and the
+ * refusal to store unmanaged keys — against a database that really has the
+ * `managed_secrets` table created by `drizzle/0022_managed_secrets.sql`.
+ */
+const MIGRATIONS_DIR = new URL("../../../../drizzle", import.meta.url).pathname;
+const MASTER = "integration-test-master-secret";
+
+/** Minimal D1Database shim over better-sqlite3, enough for Drizzle's d1 driver. */
+function d1Shim(db: Database.Database): D1Database {
+  const run = (sql: string, params: unknown[]) => {
+    // D1 accepts `?1`-style numbered placeholders (used throughout this
+    // codebase) but better-sqlite3 rejects them when bound positionally.
+    // Rewrite to bare `?` so the SAME SQL string that ships to D1 is what
+    // these tests execute — otherwise the test would validate a query the
+    // application never runs.
+    const stmt = db.prepare(sql.replace(/\?\d+/g, "?"));
+    if (/^\s*(select|pragma)/i.test(sql)) {
+      const results = stmt.all(...params);
+      return { results, success: true, meta: {} };
+    }
+    const info = stmt.run(...params);
+    return { results: [], success: true, meta: { changes: info.changes } };
+  };
+  const makeStmt = (sql: string, params: unknown[] = []): D1PreparedStatement =>
+    ({
+      bind: (...p: unknown[]) => makeStmt(sql, p),
+      all: async () => run(sql, params),
+      run: async () => run(sql, params),
+      first: async (col?: string) => {
+        const r = run(sql, params).results as Record<string, unknown>[];
+        const row = r[0] ?? null;
+        return col && row ? row[col] : row;
+      },
+      raw: async () =>
+        (run(sql, params).results as Record<string, unknown>[]).map((r) =>
+          Object.values(r),
+        ),
+    }) as unknown as D1PreparedStatement;
+
+  return {
+    prepare: (sql: string) => makeStmt(sql),
+    batch: async (stmts: D1PreparedStatement[]) =>
+      Promise.all(stmts.map((s) => s.run())),
+    exec: async (sql: string) => {
+      db.exec(sql);
+      return { count: 0, duration: 0 };
+    },
+    dump: async () => new ArrayBuffer(0),
+  } as unknown as D1Database;
+}
+
+let sqlite: Database.Database;
+let env: Record<string, unknown> & { DB: D1Database };
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  for (const file of readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()) {
+    const sql = readFileSync(`${MIGRATIONS_DIR}/${file}`, "utf8");
+    for (const stmt of sql.split("--> statement-breakpoint")) {
+      if (stmt.trim()) sqlite.exec(stmt);
+    }
+  }
+  env = { DB: d1Shim(sqlite), BETTER_AUTH_SECRET: MASTER };
+});
+
+describe("secret storage", () => {
+  it("stores and retrieves a value", async () => {
+    await setSecret(env, "BEAM_API_KEY", "sk_live_secret123456", "user1");
+    expect(await getSecret(env, "BEAM_API_KEY")).toBe("sk_live_secret123456");
+  });
+
+  it("stores ONLY ciphertext in the database", async () => {
+    // The core security property. If this fails, a D1 dump leaks keys.
+    const plaintext = "sk_live_verysecret9876";
+    await setSecret(env, "BEAM_API_KEY", plaintext, "user1");
+
+    const row = sqlite
+      .prepare(`SELECT value_encrypted FROM managed_secrets WHERE key = ?`)
+      .get("BEAM_API_KEY") as { value_encrypted: string };
+
+    expect(row.value_encrypted).not.toContain(plaintext);
+    expect(row.value_encrypted).not.toContain("verysecret");
+    expect(row.value_encrypted).toMatch(/^v1:/);
+  });
+
+  it("replaces on re-save rather than duplicating", async () => {
+    await setSecret(env, "BEAM_API_KEY", "first-value-here", "user1");
+    await setSecret(env, "BEAM_API_KEY", "second-value-here", "user2");
+
+    const count = sqlite
+      .prepare(`SELECT COUNT(*) c FROM managed_secrets WHERE key = ?`)
+      .get("BEAM_API_KEY") as { c: number };
+    expect(count.c).toBe(1);
+    expect(await getSecret(env, "BEAM_API_KEY")).toBe("second-value-here");
+  });
+
+  it("records who changed it", async () => {
+    await setSecret(env, "BEAM_API_KEY", "value-goes-here", "admin-42");
+    const row = sqlite
+      .prepare(`SELECT updated_by FROM managed_secrets WHERE key = ?`)
+      .get("BEAM_API_KEY") as { updated_by: string };
+    expect(row.updated_by).toBe("admin-42");
+  });
+
+  it("refuses to store an unmanaged key", async () => {
+    // Guards the write path against a crafted form POST.
+    await expect(
+      setSecret(env, "BETTER_AUTH_SECRET", "hijack", "attacker"),
+    ).rejects.toThrow(/unmanaged/i);
+    await expect(
+      setSecret(env, "DATABASE_URL", "hijack", "attacker"),
+    ).rejects.toThrow(/unmanaged/i);
+  });
+
+  it("refuses to delete an unmanaged key", async () => {
+    await expect(deleteSecret(env, "BETTER_AUTH_SECRET")).rejects.toThrow(
+      /unmanaged/i,
+    );
+  });
+
+  it("refuses to store without a master secret", async () => {
+    const noMaster = { DB: env.DB } as typeof env;
+    await expect(
+      setSecret(noMaster, "BEAM_API_KEY", "value", "u"),
+    ).rejects.toThrow(/BETTER_AUTH_SECRET/);
+  });
+
+  it("deletes a stored value", async () => {
+    await setSecret(env, "BEAM_API_KEY", "value-to-delete", "u");
+    await deleteSecret(env, "BEAM_API_KEY");
+    expect(await getSecret(env, "BEAM_API_KEY")).toBeNull();
+  });
+});
+
+describe("env precedence", () => {
+  it("env wins over a stored value", async () => {
+    // Load-bearing: lets a leaked key be rotated with `wrangler secret put`
+    // without needing a working admin panel.
+    await setSecret(env, "BEAM_API_KEY", "database-value", "u");
+    const withEnv = { ...env, BEAM_API_KEY: "env-value" };
+    expect(await getSecret(withEnv, "BEAM_API_KEY")).toBe("env-value");
+  });
+
+  it("ignores an empty-string env var and falls through to the database", async () => {
+    // An unset Cloudflare var can surface as "" — treating that as set
+    // would silently disable a correctly-configured DB credential.
+    //
+    // Note this is belt-and-braces: `envValue` filters empty strings AND
+    // every caller branches on truthiness, so either alone suffices. The
+    // test asserts the observable behaviour, which is what matters.
+    await setSecret(env, "BEAM_API_KEY", "database-value", "u");
+    const withEmpty = { ...env, BEAM_API_KEY: "" };
+    expect(await getSecret(withEmpty, "BEAM_API_KEY")).toBe("database-value");
+
+    // Whitespace is NOT treated as empty — a value of " " is a real (if
+    // wrong) configuration, and silently ignoring it would mask a typo
+    // rather than surfacing it.
+    const withSpace = { ...env, BEAM_API_KEY: " " };
+    expect(await getSecret(withSpace, "BEAM_API_KEY")).toBe(" ");
+  });
+
+  it("listSecretStatus also treats an empty env var as unset", async () => {
+    // Separate path from getSecret — a regression here would show
+    // "Set in Cloudflare" for a variable that is effectively absent,
+    // and hide the input that would let an admin fix it.
+    await setSecret(env, "BEAM_API_KEY", "database-value", "u");
+    const withEmpty = { ...env, BEAM_API_KEY: "" };
+    const beam = (await listSecretStatus(withEmpty)).find(
+      (s) => s.key === "BEAM_API_KEY",
+    )!;
+    expect(beam.source).toBe("database");
+  });
+
+  it("batch resolve mixes env and database sources correctly", async () => {
+    await setSecret(env, "BEAM_WEBHOOK_SECRET", "db-webhook-secret", "u");
+    const mixed = { ...env, BEAM_API_KEY: "env-api-key" };
+    const out = await getSecrets(mixed, [
+      "BEAM_API_KEY",
+      "BEAM_WEBHOOK_SECRET",
+      "RESEND_API_KEY",
+    ]);
+    expect(out.BEAM_API_KEY).toBe("env-api-key");
+    expect(out.BEAM_WEBHOOK_SECRET).toBe("db-webhook-secret");
+    expect(out.RESEND_API_KEY).toBeNull();
+  });
+
+  it("returns null rather than throwing when the master secret is absent", async () => {
+    await setSecret(env, "BEAM_API_KEY", "stored-value", "u");
+    const noMaster = { DB: env.DB } as typeof env;
+    // Degrades one integration; must not throw on every request.
+    expect(await getSecret(noMaster, "BEAM_API_KEY")).toBeNull();
+  });
+});
+
+describe("status listing (what the admin page receives)", () => {
+  it("NEVER returns the plaintext of a sensitive secret", async () => {
+    // The single most important assertion here. A regression would put a
+    // live payment key into page source, history, and every proxy in path.
+    const plaintext = "sk_live_topsecret4321";
+    await setSecret(env, "BEAM_API_KEY", plaintext, "u");
+
+    const statuses = await listSecretStatus(env);
+    const serialised = JSON.stringify(statuses);
+
+    expect(serialised).not.toContain(plaintext);
+    expect(serialised).not.toContain("topsecret");
+
+    const beam = statuses.find((s) => s.key === "BEAM_API_KEY")!;
+    expect(beam.preview).toBe("••••••••4321");
+    expect(beam.configured).toBe(true);
+    expect(beam.source).toBe("database");
+  });
+
+  it("masks an env-sourced sensitive value too", async () => {
+    const withEnv = { ...env, BEAM_API_KEY: "sk_live_fromenv98765" };
+    const statuses = await listSecretStatus(withEnv);
+    expect(JSON.stringify(statuses)).not.toContain("sk_live_fromenv98765");
+    const beam = statuses.find((s) => s.key === "BEAM_API_KEY")!;
+    expect(beam.source).toBe("env");
+    expect(beam.preview).toBe("••••••••8765");
+  });
+
+  it("shows the non-sensitive merchant id in full", async () => {
+    // Masking a public identifier just makes it unverifiable.
+    await setSecret(env, "BEAM_MERCHANT_ID", "codustry-ova1t0", "u");
+    const statuses = await listSecretStatus(env);
+    const merchant = statuses.find((s) => s.key === "BEAM_MERCHANT_ID")!;
+    expect(merchant.preview).toBe("codustry-ova1t0");
+  });
+
+  it("reports every registry key, including unset ones", async () => {
+    const statuses = await listSecretStatus(env);
+    expect(statuses.length).toBe(4);
+    for (const s of statuses) {
+      expect(s.configured).toBe(false);
+      expect(s.source).toBe("unset");
+      expect(s.preview).toBeNull();
+    }
+  });
+
+  it("flags a row that cannot be decrypted after key rotation", async () => {
+    await setSecret(env, "BEAM_API_KEY", "value-from-before", "u");
+    // Simulate BETTER_AUTH_SECRET rotation.
+    const rotated = { ...env, BETTER_AUTH_SECRET: "a-completely-new-secret" };
+
+    const statuses = await listSecretStatus(rotated);
+    const beam = statuses.find((s) => s.key === "BEAM_API_KEY")!;
+    expect(beam.undecryptable).toBe(true);
+    expect(beam.configured).toBe(false);
+    expect(beam.preview).toBeNull();
+  });
+});

--- a/src/lib/server/secrets/service.ts
+++ b/src/lib/server/secrets/service.ts
@@ -1,0 +1,231 @@
+/**
+ * Read/write admin-managed secrets.
+ *
+ * ## Precedence: env ALWAYS wins over the database
+ *
+ * This is deliberate and load-bearing in three situations:
+ *
+ *  - **Rotation under compromise.** If a key leaks you can push a new one
+ *    with `wrangler secret put` and it takes effect immediately, without
+ *    needing a working admin panel (which may be exactly what is
+ *    compromised).
+ *  - **Existing deployments.** Sites already configured via env keep
+ *    working untouched after this feature ships. Nothing to migrate.
+ *  - **Environment separation.** A staging Worker can override production
+ *    values inherited from a shared database.
+ *
+ * The cost is that a value set in env cannot be changed from the UI. The
+ * settings page states this explicitly rather than silently ignoring input.
+ */
+
+import { drizzle } from "drizzle-orm/d1";
+import { eq, inArray } from "drizzle-orm";
+import { managedSecrets } from "./schema";
+import { decryptSecret, encryptSecret, maskSecret } from "./crypto";
+import { isManagedSecret, MANAGED_SECRETS } from "./registry";
+
+export type SecretStatus = {
+  key: string;
+  /** Whether a usable value exists from any source. */
+  configured: boolean;
+  /** Where the effective value comes from. */
+  source: "env" | "database" | "unset";
+  /**
+   * Masked (or full, for non-sensitive) preview of the effective value.
+   * Never the plaintext of a sensitive secret.
+   */
+  preview: string | null;
+  /** True when a stored row exists but could not be decrypted. */
+  undecryptable: boolean;
+  updatedAt: string | null;
+};
+
+type EnvLike = Record<string, unknown> & { DB: D1Database };
+
+function envValue(env: EnvLike, key: string): string | undefined {
+  const raw = env[key];
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}
+
+/**
+ * Resolve one secret's effective value: env first, then the encrypted row.
+ *
+ * Returns null when unset or undecryptable — callers treat both as "not
+ * configured", which is what makes an unreadable row degrade one
+ * integration instead of throwing on every request.
+ */
+export async function getSecret(
+  env: EnvLike,
+  key: string,
+): Promise<string | null> {
+  const fromEnv = envValue(env, key);
+  if (fromEnv) return fromEnv;
+
+  const masterSecret = envValue(env, "BETTER_AUTH_SECRET");
+  if (!masterSecret) return null;
+
+  const row = await drizzle(env.DB)
+    .select()
+    .from(managedSecrets)
+    .where(eq(managedSecrets.key, key))
+    .limit(1)
+    .get();
+  if (!row) return null;
+
+  return decryptSecret(row.valueEncrypted, masterSecret);
+}
+
+/**
+ * Resolve several secrets in one query.
+ *
+ * Used on the request path (plugin init) where a query per secret would
+ * add avoidable round-trips to every cold start.
+ */
+export async function getSecrets(
+  env: EnvLike,
+  keys: readonly string[],
+): Promise<Record<string, string | null>> {
+  const result: Record<string, string | null> = {};
+  const needed: string[] = [];
+
+  for (const key of keys) {
+    const fromEnv = envValue(env, key);
+    if (fromEnv) result[key] = fromEnv;
+    else {
+      result[key] = null;
+      needed.push(key);
+    }
+  }
+  if (needed.length === 0) return result;
+
+  const masterSecret = envValue(env, "BETTER_AUTH_SECRET");
+  if (!masterSecret) return result;
+
+  const rows = await drizzle(env.DB)
+    .select()
+    .from(managedSecrets)
+    .where(inArray(managedSecrets.key, needed))
+    .all();
+
+  for (const row of rows) {
+    result[row.key] = await decryptSecret(row.valueEncrypted, masterSecret);
+  }
+  return result;
+}
+
+/**
+ * Status of every managed secret, for the admin page.
+ *
+ * Returns previews only — never a plaintext sensitive value. The admin
+ * form is write-only by design: round-tripping a live payment key to the
+ * browser would put it in page source, browser history, extensions, and
+ * any intermediary proxy.
+ */
+export async function listSecretStatus(env: EnvLike): Promise<SecretStatus[]> {
+  const masterSecret = envValue(env, "BETTER_AUTH_SECRET");
+  const rows = await drizzle(env.DB).select().from(managedSecrets).all();
+  const byKey = new Map(rows.map((r) => [r.key, r]));
+
+  const out: SecretStatus[] = [];
+  for (const def of MANAGED_SECRETS) {
+    const fromEnv = envValue(env, def.key);
+    if (fromEnv) {
+      out.push({
+        key: def.key,
+        configured: true,
+        source: "env",
+        preview: def.sensitive ? maskSecret(fromEnv) : fromEnv,
+        undecryptable: false,
+        updatedAt: null,
+      });
+      continue;
+    }
+
+    const row = byKey.get(def.key);
+    if (!row) {
+      out.push({
+        key: def.key,
+        configured: false,
+        source: "unset",
+        preview: null,
+        undecryptable: false,
+        updatedAt: null,
+      });
+      continue;
+    }
+
+    const plaintext = masterSecret
+      ? await decryptSecret(row.valueEncrypted, masterSecret)
+      : null;
+    out.push({
+      key: def.key,
+      configured: plaintext !== null,
+      source: plaintext !== null ? "database" : "unset",
+      preview:
+        plaintext === null
+          ? null
+          : def.sensitive
+            ? maskSecret(plaintext)
+            : plaintext,
+      // A row exists but did not decrypt — almost always a rotated
+      // BETTER_AUTH_SECRET. Surfaced so the admin sees a real explanation
+      // instead of a silently "unset" field they know they configured.
+      undecryptable: plaintext === null,
+      updatedAt: row.updatedAt,
+    });
+  }
+  return out;
+}
+
+/**
+ * Store (or replace) a secret. Encrypts before it touches the database.
+ *
+ * Rejects unknown keys: without that check a crafted POST could write an
+ * arbitrary key, including one shadowing an env var the registry
+ * deliberately refuses to manage.
+ */
+export async function setSecret(
+  env: EnvLike,
+  key: string,
+  plaintext: string,
+  updatedBy: string,
+): Promise<void> {
+  if (!isManagedSecret(key)) {
+    throw new Error(`Refusing to store unmanaged secret key: ${key}`);
+  }
+  const masterSecret = envValue(env, "BETTER_AUTH_SECRET");
+  if (!masterSecret) {
+    throw new Error(
+      "Cannot store secrets: BETTER_AUTH_SECRET is not set on this Worker.",
+    );
+  }
+  const valueEncrypted = await encryptSecret(plaintext, masterSecret);
+  const nowIso = new Date().toISOString();
+
+  // Raw SQL rather than drizzle's `.onConflictDoUpdate()`: D1 does not
+  // expose conflict-clause builders uniformly across drizzle versions on
+  // the sqlite dialect. `discount-service.ts` hit exactly this and uses
+  // raw SQL for the same reason. An upsert that silently degrades to a
+  // failed INSERT here would leave a rotated credential unsaved while the
+  // UI reported success.
+  await env.DB.prepare(
+    `INSERT INTO managed_secrets (key, value_encrypted, updated_at, updated_by)
+       VALUES (?1, ?2, ?3, ?4)
+     ON CONFLICT(key) DO UPDATE SET
+       value_encrypted = excluded.value_encrypted,
+       updated_at      = excluded.updated_at,
+       updated_by      = excluded.updated_by`,
+  )
+    .bind(key, valueEncrypted, nowIso, updatedBy)
+    .run();
+}
+
+/** Remove a stored secret. Any env value keeps applying afterwards. */
+export async function deleteSecret(env: EnvLike, key: string): Promise<void> {
+  if (!isManagedSecret(key)) {
+    throw new Error(`Refusing to delete unmanaged secret key: ${key}`);
+  }
+  await drizzle(env.DB)
+    .delete(managedSecrets)
+    .where(eq(managedSecrets.key, key));
+}

--- a/src/plugins/shop/abandoned-cart-email.ts
+++ b/src/plugins/shop/abandoned-cart-email.ts
@@ -117,11 +117,32 @@ function buildHtml(input: AbandonedCartInput, siteUrl: string): string {
  * Send the recovery email via Resend. Returns true on success, false
  * (with console.warn) on any failure — never throws.
  */
+/**
+ * Resolve the Resend key: env first, then the encrypted secrets table.
+ * Returns undefined without a DB binding, keeping this usable in tests.
+ */
+async function resolveAbandonedResendKey(
+  env: ResendAbandonedEnv & { DB?: D1Database },
+): Promise<string | undefined> {
+  if (env.RESEND_API_KEY) return env.RESEND_API_KEY;
+  if (!env.DB) return undefined;
+  const { getSecret } = await import("$lib/server/secrets/service");
+  return (
+    (await getSecret(
+      env as ResendAbandonedEnv & { DB: D1Database },
+      "RESEND_API_KEY",
+    )) ?? undefined
+  );
+}
+
 export async function sendAbandonedCartEmail(
   env: ResendAbandonedEnv,
   input: AbandonedCartInput,
 ): Promise<boolean> {
-  if (!env.RESEND_API_KEY || !env.RESEND_FROM) return false;
+  // env-first, then the encrypted managed_secrets table so the key can be
+  // set from /admin/settings/secrets. Silent no-op when unset.
+  const apiKey = await resolveAbandonedResendKey(env);
+  if (!apiKey || !env.RESEND_FROM) return false;
   if (input.items.length === 0) return false;
   const siteUrl = env.PUBLIC_SITE_URL ?? "";
   const html = buildHtml(input, siteUrl);
@@ -129,7 +150,7 @@ export async function sendAbandonedCartEmail(
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
-        authorization: `Bearer ${env.RESEND_API_KEY}`,
+        authorization: `Bearer ${apiKey}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({

--- a/src/plugins/shop/beam-config.server.ts
+++ b/src/plugins/shop/beam-config.server.ts
@@ -1,0 +1,84 @@
+/**
+ * Server-only resolution of BeamCheckout credentials.
+ *
+ * ## Why this is a separate `.server.ts` file
+ *
+ * `src/plugins/shop/index.ts` is reachable from the browser bundle:
+ *
+ *   admin/+layout.svelte → Sidebar.svelte → sidebar-nav.ts
+ *     → plugins/registrations.ts → plugins/shop/index.ts
+ *
+ * That chain exists because plugins contribute sidebar entries, which must
+ * render on the client after hydration. Importing the secrets service from
+ * `index.ts` therefore pulls decryption code — and the HKDF derivation from
+ * BETTER_AUTH_SECRET — toward the client bundle. SvelteKit's
+ * `vite-plugin-sveltekit-guard` correctly refuses to build that, and it is
+ * right to: it is exactly the leak this feature must not introduce.
+ *
+ * Keeping resolution here, imported only from server-side request handlers,
+ * means the browser graph never reaches it.
+ *
+ * ## Why resolve per-request rather than once at plugin init
+ *
+ * Secrets are now runtime-editable from /admin/settings/secrets. A provider
+ * constructed once during `onInit` would capture whatever key existed at
+ * boot and keep using it after an admin rotates it — silently charging
+ * against a revoked key until the isolate recycled. Resolving at the point
+ * of use costs one indexed primary-key lookup and is always current.
+ */
+import { getSecrets } from "$lib/server/secrets/service";
+import { BeamPaymentProvider } from "./beam";
+import { getPaymentProvider, type PaymentProvider } from "./payment";
+
+type BeamEnv = Record<string, unknown> & {
+  DB: D1Database;
+  BEAM_BASE_URL?: string;
+};
+
+/**
+ * Build a Beam provider from the currently-effective credentials, or null
+ * when unconfigured.
+ *
+ * Null rather than throw: the shop still serves catalog and cart without
+ * payment credentials, and checkout surfaces a purposeful 503 instead of
+ * every page 500-ing.
+ */
+export async function resolveBeamProvider(
+  env: BeamEnv,
+): Promise<PaymentProvider | null> {
+  const resolved = await getSecrets(env, [
+    "BEAM_API_KEY",
+    "BEAM_WEBHOOK_SECRET",
+  ]);
+  const apiKey = resolved.BEAM_API_KEY;
+  const webhookSecret = resolved.BEAM_WEBHOOK_SECRET;
+  if (!apiKey || !webhookSecret) return null;
+
+  return new BeamPaymentProvider({
+    apiKey,
+    webhookSecret,
+    baseUrl: env.BEAM_BASE_URL,
+  });
+}
+
+/**
+ * Get a payment provider for a request, preferring one registered from env
+ * at plugin init and falling back to DB-stored credentials.
+ *
+ * The two paths exist because env credentials are registered eagerly in
+ * `onInit` (cheap, no DB round-trip) while DB credentials cannot be — see
+ * the module comment above. Callers on the server should use this rather
+ * than `getPaymentProvider` directly, or a site configured purely through
+ * the admin UI would report "no payment provider" despite being set up.
+ */
+export async function resolveProviderForRequest(
+  env: BeamEnv,
+  name: string,
+): Promise<PaymentProvider | null> {
+  const registered = getPaymentProvider(name);
+  if (registered) return registered;
+  // Only Beam has a DB-credential path today. Other providers keep their
+  // existing env-only registration.
+  if (name !== "beam") return null;
+  return resolveBeamProvider(env);
+}

--- a/src/plugins/shop/email.ts
+++ b/src/plugins/shop/email.ts
@@ -88,6 +88,26 @@ function escapeAttr(s: string): string {
 }
 
 /**
+ * Resolve the Resend key: env first, then the encrypted secrets table.
+ *
+ * Falls back to `env.RESEND_API_KEY` alone when there is no DB binding,
+ * so this stays usable in tests and in any context without a database.
+ */
+async function resolveResendKey(
+  env: ResendEnv & { DB?: D1Database },
+): Promise<string | undefined> {
+  if (env.RESEND_API_KEY) return env.RESEND_API_KEY;
+  if (!env.DB) return undefined;
+  const { getSecret } = await import("$lib/server/secrets/service");
+  return (
+    (await getSecret(
+      env as ResendEnv & { DB: D1Database },
+      "RESEND_API_KEY",
+    )) ?? undefined
+  );
+}
+
+/**
  * Send the order receipt via Resend. Returns true on success, false
  * (with console.warn) on any failure — never throws into the caller.
  */
@@ -95,7 +115,11 @@ export async function sendOrderReceipt(
   env: ResendEnv,
   order: OrderWithItems,
 ): Promise<boolean> {
-  if (!env.RESEND_API_KEY || !env.RESEND_FROM) {
+  // Resolves env-first, then the encrypted managed_secrets table, so the
+  // key can be set from /admin/settings/secrets. Still a silent no-op when
+  // unset — a missing email key must never fail a paid order.
+  const apiKey = await resolveResendKey(env);
+  if (!apiKey || !env.RESEND_FROM) {
     return false;
   }
   const siteUrl = env.PUBLIC_SITE_URL ?? "";
@@ -104,7 +128,7 @@ export async function sendOrderReceipt(
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
-        authorization: `Bearer ${env.RESEND_API_KEY}`,
+        authorization: `Bearer ${apiKey}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({

--- a/src/plugins/shop/index.ts
+++ b/src/plugins/shop/index.ts
@@ -80,6 +80,15 @@ export default defineKhaopadPlugin({
     // Skip silently when Beam credentials aren't set — the shop still
     // ships product catalog + cart, checkout will surface a helpful
     // 503 if a payment attempt fires without a configured provider.
+    //
+    // Only ENV credentials are read here. This module is reachable from
+    // the browser bundle (sidebar-nav → registrations → this file), so it
+    // must never import the secrets service — that would pull decryption
+    // and the BETTER_AUTH_SECRET-derived key toward the client.
+    //
+    // DB-stored credentials are resolved per-request instead, in
+    // `beam-config.server.ts`. That also keeps a rotated key effective
+    // immediately, rather than pinning whatever existed at boot.
     const beamKey = ctx.env.BEAM_API_KEY;
     const beamWebhookSecret = ctx.env.BEAM_WEBHOOK_SECRET;
     if (beamKey && beamWebhookSecret) {

--- a/src/routes/(admin)/admin/settings/secrets/+page.server.ts
+++ b/src/routes/(admin)/admin/settings/secrets/+page.server.ts
@@ -1,0 +1,118 @@
+import { error, fail, redirect } from "@sveltejs/kit";
+import { logAudit } from "$lib/server/audit";
+import { canManageSecrets } from "$lib/server/auth/permissions";
+import { secretsByGroup, isManagedSecret } from "$lib/server/secrets/registry";
+import {
+  listSecretStatus,
+  setSecret,
+  deleteSecret,
+} from "$lib/server/secrets/service";
+import type { Actions, PageServerLoad } from "./$types";
+
+/**
+ * Credential management is **super_admin only** — deliberately stricter
+ * than `canManageSettings` (which admits `admin`) used by the general
+ * settings page.
+ *
+ * The values here create charges and issue refunds against a live payment
+ * account. A site title is reversible; a leaked Beam key is not. Where the
+ * two roles differ, credentials belong with the narrower one.
+ */
+function requireSuperAdmin(locals: App.Locals) {
+  if (!locals.user) throw error(401, "Not authenticated");
+  if (!canManageSecrets(locals.user)) {
+    throw error(
+      403,
+      "Only super admins can manage integration credentials. These keys can move money.",
+    );
+  }
+}
+
+export const load: PageServerLoad = async ({ locals, platform }) => {
+  if (!locals.user) throw redirect(302, "/admin/login");
+  requireSuperAdmin(locals);
+
+  const env = platform?.env;
+  if (!env?.DB) {
+    return {
+      groups: [...secretsByGroup()].map(([name, defs]) => ({ name, defs })),
+      statuses: [],
+      platformReady: false,
+      hasMasterSecret: false,
+    };
+  }
+
+  // Status only — never the plaintext of a sensitive value. The form is
+  // write-only by design: round-tripping a live key to the browser would
+  // put it in page source, history, extensions and any proxy in the path.
+  const statuses = await listSecretStatus(env);
+
+  return {
+    groups: [...secretsByGroup()].map(([name, defs]) => ({ name, defs })),
+    statuses,
+    platformReady: true,
+    // Without BETTER_AUTH_SECRET there is no key-derivation root, so
+    // nothing can be encrypted. Surfaced so the page explains itself
+    // rather than failing on submit.
+    hasMasterSecret: Boolean(env.BETTER_AUTH_SECRET),
+  };
+};
+
+export const actions: Actions = {
+  save: async ({ request, locals, platform }) => {
+    requireSuperAdmin(locals);
+    const env = platform?.env;
+    if (!env?.DB) return fail(503, { error: "Database is not available." });
+
+    const form = await request.formData();
+    const key = String(form.get("key") ?? "");
+    const value = String(form.get("value") ?? "");
+
+    if (!isManagedSecret(key)) {
+      return fail(400, { error: `Unknown secret: ${key}` });
+    }
+    // Empty submit is a no-op, not a delete. Deleting is its own explicit
+    // action — otherwise a stray Enter on a blank field silently removes a
+    // live payment credential.
+    if (!value.trim()) {
+      return fail(400, {
+        error: "Value is empty. Use Remove to clear a stored secret.",
+      });
+    }
+
+    try {
+      await setSecret(env, key, value.trim(), locals.user!.id);
+    } catch (err) {
+      return fail(500, {
+        error: err instanceof Error ? err.message : "Failed to store secret.",
+      });
+    }
+
+    // Audit the CHANGE, never the value. An audit log that records
+    // credentials is a second place to leak them.
+    await logAudit(env.DB, locals.user!.id, "settings.secret.update", key, {
+      key,
+    });
+
+    return { success: true, key };
+  },
+
+  remove: async ({ request, locals, platform }) => {
+    requireSuperAdmin(locals);
+    const env = platform?.env;
+    if (!env?.DB) return fail(503, { error: "Database is not available." });
+
+    const form = await request.formData();
+    const key = String(form.get("key") ?? "");
+    if (!isManagedSecret(key)) {
+      return fail(400, { error: `Unknown secret: ${key}` });
+    }
+
+    await deleteSecret(env, key);
+    await logAudit(env.DB, locals.user!.id, "settings.secret.delete", key, {
+      key,
+    });
+
+    return { success: true, key, removed: true };
+  },
+};

--- a/src/routes/(admin)/admin/settings/secrets/+page.svelte
+++ b/src/routes/(admin)/admin/settings/secrets/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { enhance } from "$app/forms";
+  import { resolve } from "$app/paths";
   import type { ActionData, PageData } from "./$types";
 
   let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -11,8 +12,9 @@
 
 <div class="mx-auto max-w-3xl p-6">
   <header class="mb-6">
-    <a href="/admin/settings" class="text-sm text-muted-foreground hover:underline"
-      >← Settings</a
+    <a
+      href={resolve("/(admin)/admin/settings")}
+      class="text-sm text-muted-foreground hover:underline">← Settings</a
     >
     <h1 class="mt-2 text-2xl font-semibold">Integration credentials</h1>
     <p class="mt-1 text-sm text-muted-foreground">

--- a/src/routes/(admin)/admin/settings/secrets/+page.svelte
+++ b/src/routes/(admin)/admin/settings/secrets/+page.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import { enhance } from "$app/forms";
+  import type { ActionData, PageData } from "./$types";
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  const statusFor = (key: string) => data.statuses.find((s) => s.key === key);
+</script>
+
+<svelte:head><title>Integration credentials — Khao Pad</title></svelte:head>
+
+<div class="mx-auto max-w-3xl p-6">
+  <header class="mb-6">
+    <a href="/admin/settings" class="text-sm text-muted-foreground hover:underline"
+      >← Settings</a
+    >
+    <h1 class="mt-2 text-2xl font-semibold">Integration credentials</h1>
+    <p class="mt-1 text-sm text-muted-foreground">
+      API keys for payments and email. Stored encrypted; never shown again after
+      saving.
+    </p>
+  </header>
+
+  {#if !data.platformReady}
+    <div class="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+      Database binding unavailable — credentials cannot be read or stored.
+    </div>
+  {:else}
+    {#if !data.hasMasterSecret}
+      <div
+        class="mb-6 rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-900"
+      >
+        <strong>BETTER_AUTH_SECRET is not set.</strong> It is the key-derivation
+        root for encrypting these values, so nothing can be saved until it exists.
+        Set it as a Cloudflare secret:
+        <code class="mt-2 block font-mono text-xs"
+          >npx wrangler secret put BETTER_AUTH_SECRET</code
+        >
+      </div>
+    {/if}
+
+    {#if form?.error}
+      <div
+        class="mb-4 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900"
+      >
+        {form.error}
+      </div>
+    {:else if form?.success}
+      <div
+        class="mb-4 rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-900"
+      >
+        {form.removed ? "Removed" : "Saved"}
+        {form.key}. Takes effect on the next request.
+      </div>
+    {/if}
+
+    {#each data.groups as group (group.name)}
+      <section class="mb-8">
+        <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide">
+          {group.name}
+        </h2>
+
+        <div class="space-y-4">
+          {#each group.defs as def (def.key)}
+            {@const status = statusFor(def.key)}
+            <div class="rounded-lg border p-4">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <label for={def.key} class="text-sm font-medium">
+                    {def.label}
+                  </label>
+                  <p class="mt-0.5 font-mono text-xs text-muted-foreground">
+                    {def.key}
+                  </p>
+                </div>
+
+                {#if status?.source === "env"}
+                  <span
+                    class="shrink-0 rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-800"
+                    >Set in Cloudflare</span
+                  >
+                {:else if status?.undecryptable}
+                  <span
+                    class="shrink-0 rounded bg-red-100 px-2 py-0.5 text-xs text-red-800"
+                    >Cannot decrypt</span
+                  >
+                {:else if status?.configured}
+                  <span
+                    class="shrink-0 rounded bg-green-100 px-2 py-0.5 text-xs text-green-800"
+                    >Configured</span
+                  >
+                {:else}
+                  <span
+                    class="shrink-0 rounded bg-neutral-100 px-2 py-0.5 text-xs text-neutral-700"
+                    >Not set</span
+                  >
+                {/if}
+              </div>
+
+              <p class="mt-2 text-xs text-muted-foreground">{def.help}</p>
+
+              {#if status?.preview}
+                <p class="mt-2 font-mono text-xs">
+                  Current: <span class="rounded bg-muted px-1.5 py-0.5"
+                    >{status.preview}</span
+                  >
+                </p>
+              {/if}
+
+              {#if status?.undecryptable}
+                <p class="mt-2 text-xs text-red-700">
+                  A value is stored but could not be decrypted — this happens
+                  when BETTER_AUTH_SECRET is rotated. Re-enter the value below.
+                </p>
+              {/if}
+
+              {#if status?.source === "env"}
+                <p class="mt-3 text-xs text-muted-foreground">
+                  This value comes from a Cloudflare environment variable, which
+                  takes precedence over anything stored here. Remove the env var
+                  to manage it from this page.
+                </p>
+              {:else}
+                <form
+                  method="POST"
+                  action="?/save"
+                  use:enhance
+                  class="mt-3 flex gap-2"
+                >
+                  <input type="hidden" name="key" value={def.key} />
+                  <input
+                    id={def.key}
+                    name="value"
+                    type={def.sensitive ? "password" : "text"}
+                    autocomplete="off"
+                    placeholder={status?.configured
+                      ? "Enter a new value to replace"
+                      : "Paste value"}
+                    class="flex-1 rounded-md border px-3 py-1.5 text-sm"
+                    disabled={!data.hasMasterSecret}
+                  />
+                  <button
+                    type="submit"
+                    class="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+                    disabled={!data.hasMasterSecret}
+                  >
+                    Save
+                  </button>
+                </form>
+
+                {#if status?.configured || status?.undecryptable}
+                  <form method="POST" action="?/remove" use:enhance class="mt-2">
+                    <input type="hidden" name="key" value={def.key} />
+                    <button
+                      type="submit"
+                      class="text-xs text-red-700 hover:underline"
+                    >
+                      Remove stored value
+                    </button>
+                  </form>
+                {/if}
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/each}
+
+    <section class="mt-10 rounded-lg border border-dashed p-4">
+      <h2 class="text-sm font-semibold">Managed in Cloudflare only</h2>
+      <p class="mt-2 text-xs text-muted-foreground">
+        <code class="font-mono">BETTER_AUTH_SECRET</code> cannot be moved here.
+        It is read on every request to validate the session — before we know who
+        you are — so storing it behind this page would be circular. It also signs
+        session cookies, meaning anything able to read it could forge a login as
+        any user.
+      </p>
+      <p class="mt-2 text-xs text-muted-foreground">
+        <code class="font-mono">CLOUDFLARE_API_TOKEN</code> and
+        <code class="font-mono">CLOUDFLARE_ACCOUNT_ID</code> are deploy-time
+        credentials used to create the Worker, so they cannot live inside it.
+      </p>
+    </section>
+  {/if}
+</div>

--- a/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
@@ -11,7 +11,7 @@ import { error, fail, redirect } from "@sveltejs/kit";
 import { hasRole } from "$lib/server/auth/permissions";
 import { logAudit } from "$lib/server/audit";
 import { OrderService } from "$plugins/shop/order-service";
-import { getPaymentProvider } from "$plugins/shop/payment";
+import { resolveProviderForRequest } from "$plugins/shop/beam-config.server";
 import { parseBahtToSatang } from "$plugins/shop/money";
 import { track, buildEventContext } from "$lib/server/analytics/track";
 import type { Actions, PageServerLoad } from "./$types";
@@ -97,7 +97,10 @@ export const actions: Actions = {
     }
 
     // Provider refund first — if it fails, don't record the adjustment.
-    const provider = getPaymentProvider(order.providerName ?? "beam");
+    const provider = await resolveProviderForRequest(
+      env,
+      order.providerName ?? "beam",
+    );
     if (!provider) {
       return fail(503, {
         error: `Payment provider '${order.providerName}' is not configured — cannot process refund`,

--- a/src/routes/api/shop/checkout/pay/+server.ts
+++ b/src/routes/api/shop/checkout/pay/+server.ts
@@ -9,7 +9,7 @@
  */
 import { error, json } from "@sveltejs/kit";
 import { OrderService } from "$plugins/shop/order-service";
-import { getPaymentProvider } from "$plugins/shop/payment";
+import { resolveProviderForRequest } from "$plugins/shop/beam-config.server";
 import type { RequestHandler } from "./$types";
 
 export const POST: RequestHandler = async ({ request, platform, url }) => {
@@ -35,7 +35,10 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
     );
   }
 
-  const provider = getPaymentProvider(order.providerName ?? "beam");
+  const provider = await resolveProviderForRequest(
+    env,
+    order.providerName ?? "beam",
+  );
   if (!provider) {
     return json(
       {

--- a/src/routes/api/shop/webhook/beam/+server.ts
+++ b/src/routes/api/shop/webhook/beam/+server.ts
@@ -13,7 +13,7 @@
  * spoofed cancellations that would release inventory.
  */
 import { json } from "@sveltejs/kit";
-import { getPaymentProvider } from "$plugins/shop/payment";
+import { resolveProviderForRequest } from "$plugins/shop/beam-config.server";
 import { OrderService } from "$plugins/shop/order-service";
 import { sendOrderReceipt } from "$plugins/shop/email";
 import { drizzle } from "drizzle-orm/d1";
@@ -26,7 +26,7 @@ export const POST: RequestHandler = async ({ request, platform, url }) => {
   const env = platform?.env;
   if (!env) return json({ ok: false, code: "NO_PLATFORM" }, { status: 503 });
 
-  const provider = getPaymentProvider("beam");
+  const provider = await resolveProviderForRequest(env, "beam");
   if (!provider) {
     return json(
       { ok: false, code: "PROVIDER_NOT_CONFIGURED" },


### PR DESCRIPTION
Beam and Resend keys can now be set from the admin panel instead of requiring `wrangler secret put` and Cloudflare account access. The real win is ownership: `BEAM_API_KEY` currently needs a developer to change it, when the right owner for a payment credential is whoever runs the shop.

## What moved, and what deliberately did not

**Managed here (4):** `BEAM_MERCHANT_ID`, `BEAM_API_KEY`, `BEAM_WEBHOOK_SECRET`, `RESEND_API_KEY` — all read during a request that already has `DB` and a resolved session.

**`BETTER_AUTH_SECRET` stays in Cloudflare**, for two independent reasons:

1. **Circular.** It is read in `authHook` to resolve the session on *every* request — before we know who the user is. Storing it behind a session-gated admin page would require a session to fetch the secret that validates sessions.
2. **Privilege escalation.** It signs session cookies. Anything that can read it can mint a session for any user, including super_admin.

It is also the key-derivation root for encrypting this table, so storing it beside the ciphertext would defeat the encryption. `CLOUDFLARE_API_TOKEN` is excluded on the same principle — it creates the Worker, so it cannot live inside it. The settings page states all of this inline rather than leaving it folklore.

## Encryption

AES-GCM-256, key derived from `BETTER_AUTH_SECRET` via HKDF-SHA256 under a scoped `info` string. Fresh random IV per write — IV reuse under one key breaks GCM's **authentication**, not just confidentiality. Ciphertext carries a `v1:` prefix so a future re-key can recognise and migrate old rows rather than guess.

Decryption failures return `null` rather than throwing: a row left unreadable by a rotated master secret degrades that one integration instead of 500-ing every request. The UI surfaces that state explicitly instead of silently showing "unset" for a field the admin knows they configured.

## Two properties the design turns on

**env always beats the database.** A leaked key can be rotated with `wrangler secret put` and takes effect immediately, without needing a working admin panel — which may be exactly what is compromised. Existing deployments keep working untouched; nothing to migrate.

**The form is write-only.** Only a masked last-4 preview ever reaches the browser. Round-tripping a live payment key would put it in page source, browser history, extensions, and every proxy in the path.

Access is **super_admin only**, via a new `canManageSecrets` — deliberately narrower than `canManageSettings`, which admits `admin`. A site title is reversible; a leaked payment key is not.

## Two bugs found while building this

**1. Client-bundle leak.** Resolving credentials in the shop plugin's `onInit` put the secrets service on the browser import graph:

```
admin/+layout.svelte → Sidebar.svelte → sidebar-nav.ts
  → plugins/registrations.ts → plugins/shop/index.ts
    → $lib/server/secrets/service.ts   ← decryption toward the client
```

SvelteKit's `vite-plugin-sveltekit-guard` refused the build, correctly. Resolution moved to `beam-config.server.ts`, imported only from server handlers. Verified after the fix: the client bundle contains **no** crypto code, no `HKDF`, no `managed_secrets` — only my explanatory UI copy that happens to name the env var.

This also fixed a latent staleness bug. A provider constructed once at `onInit` would keep using whatever key existed at boot, silently charging against a revoked key after an admin rotated it. Credentials now resolve per request.

**2. D1 upsert.** Switched `.onConflictDoUpdate()` to raw `ON CONFLICT DO UPDATE` SQL. `discount-service.ts` already documents that D1 does not expose conflict-clause builders uniformly across drizzle versions on the sqlite dialect — a silently-degraded upsert here would leave a rotated credential unsaved while the UI reported success.

## Tests

**89 total, up from 60.** 29 new: crypto primitives, the registry's exclusions, and the service against **real SQLite with the real migrations applied**.

Guards were mutation-verified — inverted, confirmed failing, reverted:

| Mutation | Result |
|---|---|
| Remove masking | ✅ 2 tests fail |
| Allow unmanaged keys | ✅ 1 test fails |
| Treat key-presence as configured | ✅ 1 test fails |

One honest note: the empty-string env guard **survived** its first mutation. Investigating showed why — `envValue` filters empty strings *and* every caller branches on truthiness, so either alone suffices; the check is redundant defence, not a live guard. The test was asserting behaviour two mechanisms provide. It now asserts through `listSecretStatus` as well and does catch a genuine regression.

## Gate

`pnpm test` 89 passed · `pnpm run check` 0 errors · `pnpm run build` ok · lint warnings unchanged from main (17, all pre-existing).