### PR TITLE
fix(secrets): drop unused BEAM_MERCHANT_ID; guard duplicate files; bump to v3.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ vite.config.js.timestamp-*.mjs
 
 # Local graphify knowledge-graph output
 graphify-out/
+
+# macOS/iCloud duplicate-file artifacts ("foo 2.sql", "foo 3.ts").
+# A duplicated migration silently re-runs CREATE TABLE and blocks the
+# whole chain — and once blocked, schema tests pass against STALE schema.
+# That has bitten this repo more than once; never let one be committed.
+* [0-9].sql
+* [0-9].ts
+* [0-9].json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khaopad",
-  "version": "0.1.0",
+  "version": "3.7.0",
   "description": "Khao Pad (ข้าวผัด) — Modular CMS for Cloudflare",
   "private": true,
   "type": "module",

--- a/src/lib/server/secrets/registry.test.ts
+++ b/src/lib/server/secrets/registry.test.ts
@@ -28,21 +28,27 @@ describe("managed secret registry", () => {
     expect(isManagedSecret("beam_api_key")).toBe(false); // case-sensitive
   });
 
-  it("accepts exactly the four intended keys", () => {
+  it("accepts exactly the three intended keys", () => {
     const keys = MANAGED_SECRETS.map((s) => s.key).sort();
     expect(keys).toEqual([
       "BEAM_API_KEY",
-      "BEAM_MERCHANT_ID",
       "BEAM_WEBHOOK_SECRET",
       "RESEND_API_KEY",
     ]);
   });
 
-  it("marks every credential sensitive except the merchant identifier", () => {
+  it("only lists keys the application actually reads", () => {
+    // BEAM_MERCHANT_ID was offered in the first cut but nothing consumed
+    // it — BeamConfig takes only apiKey/webhookSecret/baseUrl. Offering an
+    // inert field invites an admin to "configure" something that does
+    // nothing, which is worse than omitting it.
+    expect(isManagedSecret("BEAM_MERCHANT_ID")).toBe(false);
+  });
+
+  it("marks every managed credential sensitive", () => {
     // A wrong value here means a live key renders in full on the page.
     for (const def of MANAGED_SECRETS) {
-      const expected = def.key !== "BEAM_MERCHANT_ID";
-      expect(def.sensitive, `${def.key}.sensitive`).toBe(expected);
+      expect(def.sensitive, `${def.key}.sensitive`).toBe(true);
     }
   });
 

--- a/src/lib/server/secrets/registry.ts
+++ b/src/lib/server/secrets/registry.ts
@@ -48,13 +48,6 @@ export type SecretDef = {
 
 export const MANAGED_SECRETS: readonly SecretDef[] = [
   {
-    key: "BEAM_MERCHANT_ID",
-    label: "Beam merchant ID",
-    help: "Your BeamCheckout merchant identifier, e.g. codustry-xxxxxx. An identifier, not a credential — shown in full so you can confirm it.",
-    sensitive: false,
-    group: "Payments — BeamCheckout",
-  },
-  {
     key: "BEAM_API_KEY",
     label: "Beam secret key",
     help: "Server-side API key used to create charges and issue refunds. Beam dashboard → Developers → API keys.",

--- a/src/lib/server/secrets/service.integration.node.test.ts
+++ b/src/lib/server/secrets/service.integration.node.test.ts
@@ -237,17 +237,19 @@ describe("status listing (what the admin page receives)", () => {
     expect(beam.preview).toBe("••••••••8765");
   });
 
-  it("shows the non-sensitive merchant id in full", async () => {
-    // Masking a public identifier just makes it unverifiable.
-    await setSecret(env, "BEAM_MERCHANT_ID", "codustry-ova1t0", "u");
+  it("masks every managed secret, since all are sensitive today", async () => {
+    // The `sensitive: false` branch is retained for future non-secret
+    // entries, but nothing currently uses it — assert that, so a new
+    // entry marked non-sensitive is a deliberate decision, not a typo.
+    await setSecret(env, "BEAM_WEBHOOK_SECRET", "whsec_abcdef123456", "u");
     const statuses = await listSecretStatus(env);
-    const merchant = statuses.find((s) => s.key === "BEAM_MERCHANT_ID")!;
-    expect(merchant.preview).toBe("codustry-ova1t0");
+    const hook = statuses.find((s) => s.key === "BEAM_WEBHOOK_SECRET")!;
+    expect(hook.preview).toBe("••••••••3456");
   });
 
   it("reports every registry key, including unset ones", async () => {
     const statuses = await listSecretStatus(env);
-    expect(statuses.length).toBe(4);
+    expect(statuses.length).toBe(3);
     for (const s of statuses) {
       expect(s.configured).toBe(false);
       expect(s.source).toBe("unset");


### PR DESCRIPTION
Three fixes found while writing the v3.7.0 release notes.

## 1. `BEAM_MERCHANT_ID` was inert

The credentials portal offered it, but **nothing reads it**. `BeamConfig` takes only `apiKey` / `webhookSecret` / `baseUrl`, and grepping the source matched nothing outside the registry entry itself.

An inert field is worse than a missing one — it invites an admin to "configure" something that does nothing, then wonder why checkout still fails. Removed, with a test asserting it stays out.

The `sensitive: false` branch is kept for future non-secret entries, and a test now asserts every *current* entry is sensitive, so adding a non-sensitive one has to be deliberate rather than a typo.

## 2. macOS duplicate-file guard

`.gitignore` now excludes `foo 2.sql`-style duplicates.

A duplicated migration silently re-runs `CREATE TABLE`, blocks the rest of the chain, and — the dangerous part — leaves schema tests **passing against stale schema**. This has now cost time in three separate sessions, including twice in the last day.

Verified the pattern catches `0022_managed_secrets 2.sql` and leaves real migration files tracked.

## 3. Version bump

`package.json` 0.1.0 → **3.7.0**, matching the milestone scheme the README and issue tracker already use:

- shipped through **v3.5** (per README)
- **v3.6** = registry + spec layer (#91, #94, #96 are tagged `v3.6-phase*`)
- **v3.7** = credentials portal (#115)

This will be the **first tagged release** — there were no prior tags or GitHub releases.

## Gate

`pnpm test` **90 passed** · `lint` 0 · `check` 0 errors · `build` ok