### PR TITLE
fix(beam): HTTP Basic auth with merchant ID — the adapter never authenticated

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -59,6 +59,7 @@ declare global {
         // ─── @khaopad/plugin-shop (optional) ───────────────
         // Present when the shop plugin's payment adapter is configured.
         // Absent when the shop is running in browse-only mode (no checkout).
+        BEAM_MERCHANT_ID?: string;
         BEAM_API_KEY?: string;
         BEAM_WEBHOOK_SECRET?: string;
         BEAM_BASE_URL?: string;

--- a/src/lib/server/secrets/registry.test.ts
+++ b/src/lib/server/secrets/registry.test.ts
@@ -28,27 +28,31 @@ describe("managed secret registry", () => {
     expect(isManagedSecret("beam_api_key")).toBe(false); // case-sensitive
   });
 
-  it("accepts exactly the three intended keys", () => {
+  it("accepts exactly the four intended keys", () => {
     const keys = MANAGED_SECRETS.map((s) => s.key).sort();
     expect(keys).toEqual([
       "BEAM_API_KEY",
+      "BEAM_MERCHANT_ID",
       "BEAM_WEBHOOK_SECRET",
       "RESEND_API_KEY",
     ]);
   });
 
-  it("only lists keys the application actually reads", () => {
-    // BEAM_MERCHANT_ID was offered in the first cut but nothing consumed
-    // it — BeamConfig takes only apiKey/webhookSecret/baseUrl. Offering an
-    // inert field invites an admin to "configure" something that does
-    // nothing, which is worse than omitting it.
-    expect(isManagedSecret("BEAM_MERCHANT_ID")).toBe(false);
+  it("includes BEAM_MERCHANT_ID — Beam requires it to authenticate", () => {
+    // Beam uses HTTP Basic as base64(merchantId:apiKey), so the merchant
+    // id is the username and a hard requirement, not decoration. I briefly
+    // removed it after concluding from the code that nothing read it;
+    // the code was wrong, not the requirement.
+    expect(isManagedSecret("BEAM_MERCHANT_ID")).toBe(true);
   });
 
-  it("marks every managed credential sensitive", () => {
-    // A wrong value here means a live key renders in full on the page.
+  it("marks credentials sensitive but the merchant identifier public", () => {
+    // A wrong flag means a live key renders in full on the page. The
+    // merchant id is a public identifier — masking it would only make a
+    // typo harder to spot against the Lighthouse dashboard.
     for (const def of MANAGED_SECRETS) {
-      expect(def.sensitive, `${def.key}.sensitive`).toBe(true);
+      const expected = def.key !== "BEAM_MERCHANT_ID";
+      expect(def.sensitive, `${def.key}.sensitive`).toBe(expected);
     }
   });
 

--- a/src/lib/server/secrets/registry.ts
+++ b/src/lib/server/secrets/registry.ts
@@ -48,6 +48,16 @@ export type SecretDef = {
 
 export const MANAGED_SECRETS: readonly SecretDef[] = [
   {
+    key: "BEAM_MERCHANT_ID",
+    label: "Beam merchant ID",
+    help: "REQUIRED. Beam authenticates with HTTP Basic auth as base64(merchantId:apiKey) — the merchant ID is the username, a separate credential from the API key. Without it every Beam request is rejected. Lighthouse dashboard → Developers.",
+    // A public identifier, not a credential — shown in full so an admin
+    // can verify it against the Lighthouse dashboard. Masking it would
+    // only make a typo harder to spot.
+    sensitive: false,
+    group: "Payments — BeamCheckout",
+  },
+  {
     key: "BEAM_API_KEY",
     label: "Beam secret key",
     help: "Server-side API key used to create charges and issue refunds. Beam dashboard → Developers → API keys.",

--- a/src/lib/server/secrets/service.integration.node.test.ts
+++ b/src/lib/server/secrets/service.integration.node.test.ts
@@ -237,19 +237,18 @@ describe("status listing (what the admin page receives)", () => {
     expect(beam.preview).toBe("••••••••8765");
   });
 
-  it("masks every managed secret, since all are sensitive today", async () => {
-    // The `sensitive: false` branch is retained for future non-secret
-    // entries, but nothing currently uses it — assert that, so a new
-    // entry marked non-sensitive is a deliberate decision, not a typo.
-    await setSecret(env, "BEAM_WEBHOOK_SECRET", "whsec_abcdef123456", "u");
+  it("shows the non-sensitive merchant id in full", async () => {
+    // Masking a public identifier just makes it unverifiable against the
+    // Beam dashboard.
+    await setSecret(env, "BEAM_MERCHANT_ID", "codustry-ova1t0", "u");
     const statuses = await listSecretStatus(env);
-    const hook = statuses.find((s) => s.key === "BEAM_WEBHOOK_SECRET")!;
-    expect(hook.preview).toBe("••••••••3456");
+    const merchant = statuses.find((s) => s.key === "BEAM_MERCHANT_ID")!;
+    expect(merchant.preview).toBe("codustry-ova1t0");
   });
 
   it("reports every registry key, including unset ones", async () => {
     const statuses = await listSecretStatus(env);
-    expect(statuses.length).toBe(3);
+    expect(statuses.length).toBe(4);
     for (const s of statuses) {
       expect(s.configured).toBe(false);
       expect(s.source).toBe("unset");

--- a/src/plugins/shop/beam-config.server.ts
+++ b/src/plugins/shop/beam-config.server.ts
@@ -47,14 +47,19 @@ export async function resolveBeamProvider(
   env: BeamEnv,
 ): Promise<PaymentProvider | null> {
   const resolved = await getSecrets(env, [
+    "BEAM_MERCHANT_ID",
     "BEAM_API_KEY",
     "BEAM_WEBHOOK_SECRET",
   ]);
+  const merchantId = resolved.BEAM_MERCHANT_ID;
   const apiKey = resolved.BEAM_API_KEY;
   const webhookSecret = resolved.BEAM_WEBHOOK_SECRET;
-  if (!apiKey || !webhookSecret) return null;
+  // All three are required: merchantId is the HTTP Basic username, so a
+  // provider built without it would 401 on every call.
+  if (!merchantId || !apiKey || !webhookSecret) return null;
 
   return new BeamPaymentProvider({
+    merchantId,
     apiKey,
     webhookSecret,
     baseUrl: env.BEAM_BASE_URL,

--- a/src/plugins/shop/beam.test.ts
+++ b/src/plugins/shop/beam.test.ts
@@ -21,6 +21,16 @@ const CONFIG = {
   webhookSecret: btoa("webhook-key-bytes"), // Beam stores this base64
 };
 
+/** Matches ChargeInput in payment.ts — kept in one place so a shape change breaks once. */
+const CHARGE = {
+  orderId: "ord_1",
+  description: "test charge",
+  amount: 10000,
+  currency: "THB",
+  customerEmail: "buyer@example.com",
+  returnUrl: "https://example.com/return",
+};
+
 afterEach(() => vi.restoreAllMocks());
 
 function mockFetch(body: unknown, ok = true) {
@@ -38,13 +48,7 @@ describe("Beam authentication", () => {
   it("uses HTTP Basic with base64(merchantId:apiKey), NOT bearer", async () => {
     const fetchSpy = mockFetch({ id: "chg_1", status: "pending" });
     const provider = new BeamPaymentProvider(CONFIG);
-    await provider.createCharge({
-      amount: 10000,
-      currency: "THB",
-      description: "test",
-      referenceId: "ref-1",
-      returnUrl: "https://example.com/return",
-    } as Parameters<typeof provider.createCharge>[0]);
+    await provider.createCharge(CHARGE);
 
     const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
     const expected = `Basic ${btoa("codustry-ova1t0:sk_test_abc123")}`;
@@ -56,13 +60,7 @@ describe("Beam authentication", () => {
     // The version belongs in the path, not the base URL. With `/v1` in
     // the base the request went to /v1/charges and 404'd.
     const fetchSpy = mockFetch({ id: "chg_1", status: "pending" });
-    await new BeamPaymentProvider(CONFIG).createCharge({
-      amount: 10000,
-      currency: "THB",
-      description: "t",
-      referenceId: "r",
-      returnUrl: "https://example.com",
-    } as never);
+    await new BeamPaymentProvider(CONFIG).createCharge(CHARGE);
     expect(fetchSpy.mock.calls[0][0]).toBe(
       "https://api.beamcheckout.com/api/v1/charges",
     );
@@ -73,13 +71,7 @@ describe("Beam authentication", () => {
     await new BeamPaymentProvider({
       ...CONFIG,
       baseUrl: "https://playground.api.beamcheckout.com",
-    }).createCharge({
-      amount: 1,
-      currency: "THB",
-      description: "t",
-      referenceId: "r",
-      returnUrl: "https://example.com",
-    } as never);
+    }).createCharge(CHARGE);
     expect(fetchSpy.mock.calls[0][0]).toBe(
       "https://playground.api.beamcheckout.com/api/v1/charges",
     );

--- a/src/plugins/shop/beam.test.ts
+++ b/src/plugins/shop/beam.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { BeamPaymentProvider } from "./beam";
+
+/**
+ * Contract tests against BeamCheckout's documented API.
+ *
+ * These exist because the adapter was originally written on the
+ * assumption that Beam is "roughly Stripe-shaped". It is not, and four
+ * things were wrong as a result — bearer auth instead of HTTP Basic, a
+ * missing merchant ID, `/v1` in the base URL instead of `/api/v1` in the
+ * path, and a hex webhook digest instead of base64.
+ *
+ * None of it was caught by a test, because nothing asserted the wire
+ * format. These tests pin the format itself, per
+ * https://docs.beamcheckout.com/get-started/authentication
+ */
+
+const CONFIG = {
+  merchantId: "codustry-ova1t0",
+  apiKey: "sk_test_abc123",
+  webhookSecret: btoa("webhook-key-bytes"), // Beam stores this base64
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+function mockFetch(body: unknown, ok = true) {
+  const spy = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 400,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+describe("Beam authentication", () => {
+  it("uses HTTP Basic with base64(merchantId:apiKey), NOT bearer", async () => {
+    const fetchSpy = mockFetch({ id: "chg_1", status: "pending" });
+    const provider = new BeamPaymentProvider(CONFIG);
+    await provider.createCharge({
+      amount: 10000,
+      currency: "THB",
+      description: "test",
+      referenceId: "ref-1",
+      returnUrl: "https://example.com/return",
+    } as Parameters<typeof provider.createCharge>[0]);
+
+    const headers = fetchSpy.mock.calls[0][1].headers as Record<string, string>;
+    const expected = `Basic ${btoa("codustry-ova1t0:sk_test_abc123")}`;
+    expect(headers.authorization).toBe(expected);
+    expect(headers.authorization).not.toMatch(/^Bearer/);
+  });
+
+  it("posts to /api/v1/charges on the bare host", async () => {
+    // The version belongs in the path, not the base URL. With `/v1` in
+    // the base the request went to /v1/charges and 404'd.
+    const fetchSpy = mockFetch({ id: "chg_1", status: "pending" });
+    await new BeamPaymentProvider(CONFIG).createCharge({
+      amount: 10000,
+      currency: "THB",
+      description: "t",
+      referenceId: "r",
+      returnUrl: "https://example.com",
+    } as never);
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://api.beamcheckout.com/api/v1/charges",
+    );
+  });
+
+  it("honours a sandbox base URL override", async () => {
+    const fetchSpy = mockFetch({ id: "chg_1", status: "pending" });
+    await new BeamPaymentProvider({
+      ...CONFIG,
+      baseUrl: "https://playground.api.beamcheckout.com",
+    }).createCharge({
+      amount: 1,
+      currency: "THB",
+      description: "t",
+      referenceId: "r",
+      returnUrl: "https://example.com",
+    } as never);
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://playground.api.beamcheckout.com/api/v1/charges",
+    );
+  });
+
+  it("refuses to construct without a merchant ID", () => {
+    // Failing loudly at construction beats 401-ing on every charge with
+    // an error the customer sees at checkout.
+    expect(
+      () => new BeamPaymentProvider({ ...CONFIG, merchantId: "" }),
+    ).toThrow(/merchantId is required/);
+  });
+
+  it("refuses to construct without an api key or webhook secret", () => {
+    expect(() => new BeamPaymentProvider({ ...CONFIG, apiKey: "" })).toThrow(
+      /apiKey is required/,
+    );
+    expect(
+      () => new BeamPaymentProvider({ ...CONFIG, webhookSecret: "" }),
+    ).toThrow(/webhookSecret is required/);
+  });
+
+  it("encodes non-ASCII credentials as UTF-8 before base64", () => {
+    // btoa is byte-oriented and throws on code points > 255. Encoding
+    // first means an unusual merchant id degrades to a wrong header
+    // rather than an exception inside checkout.
+    expect(
+      () => new BeamPaymentProvider({ ...CONFIG, merchantId: "ร้าน-ทดสอบ" }),
+    ).not.toThrow();
+  });
+});
+
+describe("Beam webhook verification", () => {
+  const provider = new BeamPaymentProvider(CONFIG);
+
+  /** Reference implementation of Beam's documented scheme. */
+  async function sign(body: string, base64Key: string): Promise<string> {
+    const keyBytes = Uint8Array.from(atob(base64Key), (c) => c.charCodeAt(0));
+    const key = await crypto.subtle.importKey(
+      "raw",
+      keyBytes,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const sig = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      new TextEncoder().encode(body),
+    );
+    return btoa(
+      Array.from(new Uint8Array(sig), (b) => String.fromCharCode(b)).join(""),
+    );
+  }
+
+  const body = JSON.stringify({ data: { status: "succeeded", id: "chg_1" } });
+
+  it("accepts a correctly base64-signed payload", async () => {
+    const result = await provider.verifyWebhook(
+      body,
+      await sign(body, CONFIG.webhookSecret),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a hex digest", async () => {
+    // The previous implementation produced hex. Beam sends base64, so
+    // every real webhook would have been rejected — orders paid but
+    // never confirmed.
+    const keyBytes = Uint8Array.from(atob(CONFIG.webhookSecret), (c) =>
+      c.charCodeAt(0),
+    );
+    const key = await crypto.subtle.importKey(
+      "raw",
+      keyBytes,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const sig = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      new TextEncoder().encode(body),
+    );
+    const hex = Array.from(new Uint8Array(sig), (b) =>
+      b.toString(16).padStart(2, "0"),
+    ).join("");
+
+    const result = await provider.verifyWebhook(body, hex);
+    expect(result.ok).toBe(false);
+  });
+
+  it("decodes the base64 HMAC key before signing", async () => {
+    // Using the base64 STRING as key material (rather than its decoded
+    // bytes) yields a digest that never matches.
+    const wrong = await (async () => {
+      const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(CONFIG.webhookSecret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const sig = await crypto.subtle.sign(
+        "HMAC",
+        key,
+        new TextEncoder().encode(body),
+      );
+      return btoa(
+        Array.from(new Uint8Array(sig), (b) => String.fromCharCode(b)).join(""),
+      );
+    })();
+
+    expect((await provider.verifyWebhook(body, wrong)).ok).toBe(false);
+  });
+
+  it("rejects a tampered body", async () => {
+    const sig = await sign(body, CONFIG.webhookSecret);
+    const tampered = JSON.stringify({
+      data: { status: "succeeded", id: "chg_ATTACKER" },
+    });
+    expect((await provider.verifyWebhook(tampered, sig)).ok).toBe(false);
+  });
+
+  it("rejects a missing signature", async () => {
+    const result = await provider.verifyWebhook(body, "");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("MISSING_SIGNATURE");
+  });
+
+  it("does not lowercase the signature", async () => {
+    // base64 is case-sensitive; lowercasing guarantees a mismatch. The
+    // old implementation did exactly that.
+    const sig = await sign(body, CONFIG.webhookSecret);
+    expect(sig).not.toBe(sig.toLowerCase()); // fixture has mixed case
+    expect((await provider.verifyWebhook(body, sig)).ok).toBe(true);
+  });
+
+  it("tolerates a sha256= prefix", async () => {
+    const sig = await sign(body, CONFIG.webhookSecret);
+    expect((await provider.verifyWebhook(body, `sha256=${sig}`)).ok).toBe(true);
+  });
+});

--- a/src/plugins/shop/beam.ts
+++ b/src/plugins/shop/beam.ts
@@ -66,12 +66,18 @@ async function hmacSha256Base64(
   body: string,
 ): Promise<string> {
   const enc = new TextEncoder();
-  let keyBytes: Uint8Array;
+  let decoded: Uint8Array;
   try {
-    keyBytes = Uint8Array.from(atob(base64Secret), (c) => c.charCodeAt(0));
+    decoded = Uint8Array.from(atob(base64Secret), (c) => c.charCodeAt(0));
   } catch {
-    keyBytes = enc.encode(base64Secret);
+    decoded = enc.encode(base64Secret);
   }
+  // Copy into a freshly-allocated ArrayBuffer. Both branches above are
+  // `Uint8Array<ArrayBufferLike>`, and importKey's BufferSource requires
+  // the narrower `ArrayBuffer` backing (a SharedArrayBuffer would not be
+  // valid key material).
+  const keyBytes = new Uint8Array(decoded.length);
+  keyBytes.set(decoded);
   const keyMaterial = await crypto.subtle.importKey(
     "raw",
     keyBytes,

--- a/src/plugins/shop/beam.ts
+++ b/src/plugins/shop/beam.ts
@@ -3,16 +3,23 @@
  * Thailand-first payment methods: PromptPay QR, credit/debit card,
  * LINE Pay, TrueMoney.
  *
- * Beam is Thailand's answer to Stripe/Adyen — API surface is roughly
- * Stripe-shaped (Charge object, webhooks with HMAC signatures) but
- * with Thai payment method affinity built in. Reference implementation
- * lives at codustry/bactrack-website; this adapter lifts the client
- * shape but restructures for the plugin runtime.
+ * Beam serves Thai payment methods, but its API is NOT Stripe-shaped —
+ * an earlier version of this adapter assumed it was and got four things
+ * wrong (bearer auth, base path, and the webhook digest encoding). Per
+ * https://docs.beamcheckout.com/get-started/authentication it uses
+ * HTTP Basic auth:
  *
- * Configuration is via env vars (validated at construction time):
- *   BEAM_API_KEY — secret key from beamcheckout.com dashboard
- *   BEAM_WEBHOOK_SECRET — for HMAC signature verification
- *   BEAM_BASE_URL — defaults to https://api.beamcheckout.com/v1
+ *     Authorization: Basic base64(merchantId + ":" + apiKey)
+ *
+ * The merchant ID is a SEPARATE credential from the API key — it is the
+ * Basic username, not something embedded in the key. Without it every
+ * request is rejected, so it is required, not optional.
+ *
+ * Configuration (validated at construction time):
+ *   BEAM_MERCHANT_ID — merchant identifier; the Basic-auth username
+ *   BEAM_API_KEY — secret key from the Lighthouse dashboard
+ *   BEAM_WEBHOOK_SECRET — base64 HMAC key for webhook verification
+ *   BEAM_BASE_URL — defaults to https://api.beamcheckout.com
  *
  * Not shipped:
  *   - Recurring payments / subscriptions (Beam doesn't support natively)
@@ -27,32 +34,54 @@ import type {
   WebhookVerifyResult,
 } from "./payment";
 
-const DEFAULT_BEAM_BASE_URL = "https://api.beamcheckout.com/v1";
+// Host only — the version lives in the documented path (/api/v1/charges),
+// not in the base URL. Sandbox: https://playground.api.beamcheckout.com
+const DEFAULT_BEAM_BASE_URL = "https://api.beamcheckout.com";
 
 export type BeamConfig = {
+  /** Basic-auth username. Required — Beam rejects requests without it. */
+  merchantId: string;
   apiKey: string;
   webhookSecret: string;
   baseUrl?: string;
 };
 
 /**
- * Compute HMAC-SHA256 hex signature — used both to sign outbound
- * requests (Beam auth) and to verify inbound webhook signatures.
- * Uses Web Crypto (available in Cloudflare Workers).
+ * Compute the webhook HMAC-SHA256 digest, BASE64-encoded.
+ *
+ * Two details Beam specifies that a Stripe-shaped implementation gets
+ * wrong (and this adapter previously did):
+ *
+ *  - The digest is **base64**, not hex. `X-Beam-Signature` carries base64.
+ *  - The configured HMAC key is itself **base64-encoded** and must be
+ *    DECODED to bytes before use. Using the base64 string as raw key
+ *    material produces a digest that never matches.
+ *
+ * Falls back to raw-string key material when the secret is not valid
+ * base64, so a misconfigured key fails signature comparison (rejecting
+ * the webhook) rather than throwing inside the handler.
  */
-async function hmacSha256Hex(secret: string, body: string): Promise<string> {
+async function hmacSha256Base64(
+  base64Secret: string,
+  body: string,
+): Promise<string> {
   const enc = new TextEncoder();
+  let keyBytes: Uint8Array;
+  try {
+    keyBytes = Uint8Array.from(atob(base64Secret), (c) => c.charCodeAt(0));
+  } catch {
+    keyBytes = enc.encode(base64Secret);
+  }
   const keyMaterial = await crypto.subtle.importKey(
     "raw",
-    enc.encode(secret),
+    keyBytes,
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"],
   );
   const sig = await crypto.subtle.sign("HMAC", keyMaterial, enc.encode(body));
-  return Array.from(new Uint8Array(sig))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  const digest = new Uint8Array(sig);
+  return btoa(Array.from(digest, (b) => String.fromCharCode(b)).join(""));
 }
 
 /**
@@ -97,6 +126,11 @@ export class BeamPaymentProvider implements PaymentProvider {
   private readonly baseUrl: string;
 
   constructor(private readonly config: BeamConfig) {
+    if (!config.merchantId) {
+      throw new Error(
+        "BeamPaymentProvider: merchantId is required — it is the HTTP Basic username",
+      );
+    }
     if (!config.apiKey) {
       throw new Error("BeamPaymentProvider: apiKey is required");
     }
@@ -106,13 +140,29 @@ export class BeamPaymentProvider implements PaymentProvider {
     this.baseUrl = config.baseUrl ?? DEFAULT_BEAM_BASE_URL;
   }
 
+  /**
+   * HTTP Basic auth: base64(merchantId:apiKey).
+   *
+   * Beam does NOT use bearer tokens. Computed per call rather than cached
+   * so a credential rotated through /admin/settings/secrets takes effect
+   * on the next request.
+   */
+  private authHeader(): string {
+    const raw = `${this.config.merchantId}:${this.config.apiKey}`;
+    // btoa is byte-oriented; encode UTF-8 first so a non-ASCII id or key
+    // does not silently produce a wrong header.
+    const bytes = new TextEncoder().encode(raw);
+    const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+    return `Basic ${btoa(binary)}`;
+  }
+
   async createCharge(input: ChargeInput): Promise<ChargeResult> {
     try {
-      const res = await fetch(`${this.baseUrl}/charges`, {
+      const res = await fetch(`${this.baseUrl}/api/v1/charges`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${this.config.apiKey}`,
+          authorization: this.authHeader(),
         },
         body: JSON.stringify({
           amount: input.amount,
@@ -152,11 +202,11 @@ export class BeamPaymentProvider implements PaymentProvider {
 
   async refund(input: RefundInput): Promise<RefundResult> {
     try {
-      const res = await fetch(`${this.baseUrl}/refunds`, {
+      const res = await fetch(`${this.baseUrl}/api/v1/refunds`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          authorization: `Bearer ${this.config.apiKey}`,
+          authorization: this.authHeader(),
         },
         body: JSON.stringify({
           charge_id: input.providerChargeId,
@@ -199,11 +249,12 @@ export class BeamPaymentProvider implements PaymentProvider {
         message: "X-Beam-Signature header absent",
       };
     }
-    // Strip optional `sha256=` scheme prefix (Stripe convention that
-    // Beam MAY adopt) so we compare hex-to-hex regardless of format.
-    const providedHex = signature.toLowerCase().replace(/^sha256=/, "");
-    const expected = await hmacSha256Hex(this.config.webhookSecret, rawBody);
-    if (!timingSafeEqual(expected, providedHex)) {
+    // Beam sends a bare base64 digest. Strip a `sha256=` prefix defensively
+    // (some gateways add one) but do NOT lowercase — base64 is
+    // case-sensitive, and lowercasing it guarantees a mismatch.
+    const provided = signature.replace(/^sha256=/, "").trim();
+    const expected = await hmacSha256Base64(this.config.webhookSecret, rawBody);
+    if (!timingSafeEqual(expected, provided)) {
       return { ok: false, code: "INVALID_SIGNATURE", message: "HMAC mismatch" };
     }
     let parsed: BeamWebhookEnvelope;

--- a/src/plugins/shop/index.ts
+++ b/src/plugins/shop/index.ts
@@ -89,13 +89,15 @@ export default defineKhaopadPlugin({
     // DB-stored credentials are resolved per-request instead, in
     // `beam-config.server.ts`. That also keeps a rotated key effective
     // immediately, rather than pinning whatever existed at boot.
+    const beamMerchantId = ctx.env.BEAM_MERCHANT_ID;
     const beamKey = ctx.env.BEAM_API_KEY;
     const beamWebhookSecret = ctx.env.BEAM_WEBHOOK_SECRET;
-    if (beamKey && beamWebhookSecret) {
+    if (beamMerchantId && beamKey && beamWebhookSecret) {
       const { BeamPaymentProvider } = await import("./beam");
       const { registerPaymentProvider } = await import("./payment");
       registerPaymentProvider(
         new BeamPaymentProvider({
+          merchantId: beamMerchantId,
           apiKey: beamKey,
           webhookSecret: beamWebhookSecret,
           baseUrl: ctx.env.BEAM_BASE_URL,


### PR DESCRIPTION
**The Beam integration could not have worked against the real API.** Four defects, all from one root assumption in the adapter's own header comment — that Beam is *"roughly Stripe-shaped"*. It isn't.

Per [Beam's authentication docs](https://docs.beamcheckout.com/get-started/authentication):

```
Authorization: Basic base64(merchantId + ":" + apiKey)
```

## The four defects

| # | What we did | What Beam requires | Impact |
|---|---|---|---|
| 1 | `Authorization: Bearer <apiKey>` | HTTP Basic | **Every charge and refund rejected** |
| 2 | No merchant ID in `BeamConfig` | Merchant ID is the Basic **username** | Cannot authenticate at all |
| 3 | `/v1` in base URL → `/v1/charges` | `/api/v1/charges` on the bare host | 404 |
| 4 | Hex digest, lowercased signature | **base64**, case-sensitive, key decoded from base64 first | **Real webhooks rejected — customers charged, orders stuck pending** |

Defect 4 is the nastiest: the customer pays, Beam sends the confirmation, we reject the signature, and the order sits in `pending` forever while the money is gone.

## On the merchant ID — I got this wrong

In #117 I removed `BEAM_MERCHANT_ID` from the credentials portal, having grepped the codebase and found nothing reading it. That was the wrong conclusion drawn from the wrong evidence: **our code** never read it, because our code was broken. The requirement was always real. @thunpisit caught it.

It is now required at construction, so a missing value throws at boot rather than 401-ing at checkout in front of a customer. It stays marked non-sensitive — it is a public identifier, and masking it would only make a typo harder to verify against the Lighthouse dashboard.

## Tests — the actual gap

Nothing asserted the wire format, which is why four defects were invisible for the whole life of the adapter. Added **13 contract tests** pinning headers, endpoint paths, and digest encoding against the documented scheme.

Mutation-verified they catch the originals:

| Reverted to | Result |
|---|---|
| Bearer auth | ✅ 1 test fails |
| Hex digest | ✅ 4 tests fail |

**103 tests total** (was 90). `lint` 0 · `check` 0 errors · `build` ok.

## Follow-up worth doing

These tests pin the format against *documentation*, not a live sandbox. A smoke test against `playground.api.beamcheckout.com` with real sandbox credentials would be stronger — worth adding once someone has sandbox keys to hand.

Note also that `docs.beamcheckout.com/webhook/webhook` 404'd on direct fetch during research; the base64/HMAC-SHA256 scheme was corroborated across two independent sources and matches the API's general style, but **verify the exact byte handling against a real sandbox webhook before trusting production traffic to it**.