### PR TITLE
chore: v3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khaopad",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Khao Pad (ข้าวผัด) — Modular CMS for Cloudflare",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for the Beam auth fix in #118.

v3.7.0 shipped with an adapter that could not authenticate against Beam's real API — bearer auth instead of HTTP Basic, no merchant ID, wrong base path, and a hex webhook digest where Beam sends base64. Anyone who took v3.7.0 needs this.