### PR TITLE
fix(auth): inert __Host- prefix (#120) + mobile UX: clipped tables, tap targets, iOS zoom

### DIFF
--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -15,11 +15,15 @@
 				ghost: 'hover:bg-accent hover:text-accent-foreground',
 				link: 'text-primary underline-offset-4 hover:underline',
 			},
+			// Mobile-first sizing: 44px tall on touch, denser on desktop (sm:+).
+			// 44px is the Apple/Google minimum tap target; the previous 36px
+			// (h-9) missed it on every primary action, and icon buttons at
+			// 36x36 were the hardest to hit accurately.
 			size: {
-				default: 'h-9 px-4 py-2',
-				sm: 'h-8 rounded-md px-3 text-xs',
-				lg: 'h-10 rounded-md px-6',
-				icon: 'h-9 w-9',
+				default: 'h-11 px-4 py-2 sm:h-9',
+				sm: 'h-9 rounded-md px-3 text-xs sm:h-8',
+				lg: 'h-12 rounded-md px-6 sm:h-10',
+				icon: 'h-11 w-11 sm:h-9 sm:w-9',
 			},
 		},
 		defaultVariants: { variant: 'default', size: 'default' },

--- a/src/lib/components/ui/input/input.svelte
+++ b/src/lib/components/ui/input/input.svelte
@@ -13,7 +13,16 @@
 <input
 	bind:value
 	class={cn(
-		'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+		// Mobile: 44px tall and 16px text.
+		//   - h-11 (44px) meets the Apple/Google minimum tap target; h-9 (36px)
+		//     did not. WCAG 2.5.8 asks for 24px, platform guidance for 44px.
+		//   - text-base (16px) is the threshold below which iOS Safari ZOOMS the
+		//     page on focus, then leaves it zoomed — the single most jarring
+		//     mobile bug in a form. text-sm (14px) triggered it on every input.
+		// Desktop (sm:+) keeps the original denser 36px/14px sizing, where
+		// pointer precision makes it comfortable.
+		'flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors',
+		'sm:h-9 sm:text-sm',
 		'file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground',
 		'placeholder:text-muted-foreground',
 		'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',

--- a/src/lib/server/auth/cookie-name.node.test.ts
+++ b/src/lib/server/auth/cookie-name.node.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guards the session cookie NAME against issue #120.
+ *
+ * Better Auth composes the final name as an unconditional concatenation
+ * (`cookies/index.mjs`):
+ *
+ *     name: `${secureCookiePrefix}${name}`
+ *
+ * with `secureCookiePrefix === "__Secure-"` in production. Configuring a
+ * name that already starts with `__Host-` therefore shipped
+ * `__Secure-__Host-khaopad_session`.
+ *
+ * Per RFC 6265bis §4.1.3.2 a prefix only carries its guarantees as the
+ * LEADING prefix, so the `__Host-` there was inert — verified against the
+ * deployed demo, where a `__Secure-__Host-` cookie was accepted WITH a
+ * `Domain` attribute while a correctly-named `__Host-` cookie was refused.
+ *
+ * This is a structural test rather than a runtime one: instantiating
+ * Better Auth needs a D1 binding, and the defect lives in the configured
+ * string, which is exactly what this reads.
+ */
+const AUTH_SRC = new URL("./index.ts", import.meta.url).pathname;
+
+describe("session cookie name (#120)", () => {
+  const source = readFileSync(AUTH_SRC, "utf8");
+
+  /** The `name:` value inside the session_token cookie config. */
+  const configuredName = (() => {
+    const block = source.slice(source.indexOf("session_token:"));
+    const match = block.match(/name:\s*"([^"]+)"/);
+    return match?.[1];
+  })();
+
+  it("configures a session cookie name", () => {
+    expect(configuredName).toBeDefined();
+  });
+
+  it("does NOT hardcode a __Host- prefix", () => {
+    // The regression. Better Auth prepends __Secure- unconditionally, so
+    // a __Host- here produces a doubled, inert prefix.
+    expect(configuredName).not.toMatch(/^__Host-/);
+  });
+
+  it("does NOT hardcode a __Secure- prefix either", () => {
+    // Better Auth already adds this in production; hardcoding it would
+    // yield __Secure-__Secure- — same class of bug.
+    expect(configuredName).not.toMatch(/^__Secure-/);
+  });
+
+  it("carries no cookie-prefix at all — the library owns that", () => {
+    expect(configuredName).not.toMatch(/^__/);
+    expect(configuredName).toBe("khaopad_session");
+  });
+
+  it("pins the __Host--equivalent attributes explicitly", () => {
+    // We lose browser-enforced __Host- semantics, so these must be set
+    // deliberately rather than inherited from a default that could change.
+    const block = source.slice(source.indexOf("session_token:"));
+    expect(block).toMatch(/path:\s*"\/"/);
+    expect(block).toMatch(/httpOnly:\s*true/);
+    expect(block).toMatch(/sameSite:\s*"lax"/);
+  });
+
+  it("never enables crossSubDomainCookies", () => {
+    // Enabling it makes Better Auth set a Domain attribute, which is the
+    // one thing __Host- exists to forbid — and would widen session scope
+    // to every subdomain.
+    expect(source).not.toMatch(
+      /crossSubDomainCookies[\s\S]{0,80}enabled:\s*true/,
+    );
+  });
+});

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -78,20 +78,61 @@ export function createAuth(
     },
     advanced: {
       /**
-       * Force the __Host- cookie prefix on the session cookie.
+       * Session cookie name — deliberately WITHOUT a `__Host-` prefix.
        *
-       * Better Auth's default in production is `__Secure-better-auth.session_token`,
-       * which requires Secure=true but permits Domain/Path variations. `__Host-`
-       * additionally mandates Path=/ and forbids Domain — the browser enforces
-       * that no subdomain (however friendly) can set a cookie with this name.
+       * ## Why not `__Host-` (issue #120)
        *
-       * Khao Pad already ships single-host at /admin — this is belt-and-braces
-       * against a future subdomain being added and inheriting cookie trust.
+       * Better Auth composes the final name as an unconditional
+       * concatenation (`cookies/index.mjs`):
        *
-       * See RFC 6265bis §4.1.3.2, OWASP Session Management Cheat Sheet.
+       *     name: `${secureCookiePrefix}${name}`
+       *
+       * where `secureCookiePrefix` is `"__Secure-"` in production. It does
+       * not check whether the configured name already carries a prefix, so
+       * `"__Host-khaopad_session"` shipped as
+       * `__Secure-__Host-khaopad_session`.
+       *
+       * Per RFC 6265bis §4.1.3.2 a prefix only carries its guarantees when
+       * it is the LEADING prefix. With `__Secure-` in front, `__Host-`
+       * becomes an ordinary part of the name and browsers enforce nothing.
+       * Verified on the deployed demo: a cookie named
+       * `__Secure-__Host-probe` was accepted WITH a `Domain` attribute,
+       * while a correctly-named `__Host-probe` with `Domain` was refused.
+       *
+       * So the old config bought no subdomain protection while looking
+       * like it did — the worst of both.
+       *
+       * ## What we do instead
+       *
+       * Let Better Auth own the prefix. It emits `__Secure-khaopad_session`
+       * in production, which browsers DO enforce (Secure-only transport).
+       *
+       * The attributes below then supply `__Host-`-equivalent hardening
+       * ourselves: `path: "/"` and no `Domain` (crossSubDomainCookies stays
+       * disabled, so Better Auth never sets one). The only thing not
+       * browser-enforced is the "no subdomain may overwrite this name"
+       * guarantee — which matters solely if this deployment ever gains
+       * sibling subdomains on the registrable domain.
+       *
+       * Getting real `__Host-` enforcement needs an upstream Better Auth
+       * change (skip the prefix when the name already has one), or writing
+       * the Set-Cookie header by hand. Tracked in #120.
        */
       cookies: {
-        session_token: { name: "__Host-khaopad_session" },
+        session_token: {
+          name: "khaopad_session",
+          attributes: {
+            // Explicit rather than relying on defaults: these ARE the
+            // __Host- requirements, and a future default change should
+            // not silently relax them.
+            path: "/",
+            httpOnly: true,
+            sameSite: "lax",
+            // `secure` is derived by Better Auth from the environment, so
+            // it stays true in production and false on http://localhost —
+            // hardcoding it would break local dev sign-in.
+          },
+        },
       },
     },
   });

--- a/src/routes/(admin)/admin/api-keys/+page.svelte
+++ b/src/routes/(admin)/admin/api-keys/+page.svelte
@@ -138,7 +138,7 @@
 			<p class="text-sm text-muted-foreground">{m.cms_api_keys_empty()}</p>
 		</div>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/30 text-xs uppercase tracking-wider text-muted-foreground">
 					<tr>

--- a/src/routes/(admin)/admin/articles/+page.svelte
+++ b/src/routes/(admin)/admin/articles/+page.svelte
@@ -62,7 +62,7 @@
 	{#if data.articles.items.length === 0}
 		<p class="text-muted-foreground">{m.cms_no_articles()}</p>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted">
 					<tr>

--- a/src/routes/(admin)/admin/articles/[id]/analytics/+page.server.ts
+++ b/src/routes/(admin)/admin/articles/[id]/analytics/+page.server.ts
@@ -13,7 +13,12 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform, params }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const article = await locals.content.getArticle(params.id);

--- a/src/routes/(admin)/admin/categories/+page.svelte
+++ b/src/routes/(admin)/admin/categories/+page.svelte
@@ -125,7 +125,7 @@
 	{#if data.items.length === 0}
 		<p class="text-sm text-muted-foreground">{m.cms_categories_empty()}</p>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted">
 					<tr>

--- a/src/routes/(admin)/admin/content/+page.server.ts
+++ b/src/routes/(admin)/admin/content/+page.server.ts
@@ -20,7 +20,9 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
   // Defining a content type is a schema change in every meaningful sense
   // — it alters what the public API exposes — so it sits with admins,
   // not editors, matching how /admin/settings is gated.
-  if (!hasRole(locals.user, "admin")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "admin")) {
+    throw error(403, "Only admins and super admins can access this area.");
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 

--- a/src/routes/(admin)/admin/content/+page.svelte
+++ b/src/routes/(admin)/admin/content/+page.svelte
@@ -148,7 +148,7 @@
 				</p>
 			</div>
 		{:else}
-			<div class="overflow-hidden rounded-lg border border-border">
+			<div class="overflow-x-auto rounded-lg border border-border">
 				<table class="w-full text-sm">
 					<thead
 						class="bg-muted/50 text-left text-xs uppercase text-muted-foreground"

--- a/src/routes/(admin)/admin/content/[collection]/+page.server.ts
+++ b/src/routes/(admin)/admin/content/[collection]/+page.server.ts
@@ -24,7 +24,12 @@ const ENTRY_PAGE_SIZE = 50;
 
 export const load: PageServerLoad = async ({ params, locals, platform }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 

--- a/src/routes/(admin)/admin/content/[collection]/+page.svelte
+++ b/src/routes/(admin)/admin/content/[collection]/+page.svelte
@@ -72,7 +72,7 @@
 		</h2>
 
 		{#if c.fields.length > 0}
-			<div class="overflow-hidden rounded-lg border border-border">
+			<div class="overflow-x-auto rounded-lg border border-border">
 				<table class="w-full text-sm">
 					<thead
 						class="bg-muted/50 text-left text-xs uppercase text-muted-foreground"
@@ -327,7 +327,7 @@
 				</p>
 			</div>
 		{:else}
-			<div class="overflow-hidden rounded-lg border border-border">
+			<div class="overflow-x-auto rounded-lg border border-border">
 				<table class="w-full text-sm">
 					<thead
 						class="bg-muted/50 text-left text-xs uppercase text-muted-foreground"

--- a/src/routes/(admin)/admin/content/[collection]/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/content/[collection]/[id]/+page.server.ts
@@ -34,7 +34,12 @@ const RELATION_CHOICE_LIMIT = 200;
 
 export const load: PageServerLoad = async ({ params, locals, platform }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 

--- a/src/routes/(admin)/admin/forms/+page.svelte
+++ b/src/routes/(admin)/admin/forms/+page.svelte
@@ -30,7 +30,7 @@
 			<p class="text-sm text-muted-foreground">{m.cms_forms_empty()}</p>
 		</div>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/30 text-xs uppercase tracking-wider text-muted-foreground">
 					<tr>

--- a/src/routes/(admin)/admin/pages/+page.svelte
+++ b/src/routes/(admin)/admin/pages/+page.svelte
@@ -67,7 +67,7 @@
 			</form>
 		</div>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/30 text-xs uppercase tracking-wider text-muted-foreground">
 					<tr>

--- a/src/routes/(admin)/admin/shop/collections/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/collections/+page.server.ts
@@ -1,9 +1,14 @@
-import { redirect } from "@sveltejs/kit";
+import { redirect, error } from "@sveltejs/kit";
 import { hasRole } from "$lib/server/auth/permissions";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   return {};
 };

--- a/src/routes/(admin)/admin/shop/discounts/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/discounts/+page.server.ts
@@ -23,7 +23,9 @@ import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "admin")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "admin")) {
+    throw error(403, "Only admins and super admins can access this area.");
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 

--- a/src/routes/(admin)/admin/shop/discounts/+page.svelte
+++ b/src/routes/(admin)/admin/shop/discounts/+page.svelte
@@ -132,7 +132,7 @@
 				<p class="text-sm text-muted-foreground">No codes yet.</p>
 			</div>
 		{:else}
-			<div class="overflow-hidden rounded-lg border border-border">
+			<div class="overflow-x-auto rounded-lg border border-border">
 				<table class="w-full text-sm">
 					<thead class="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
 						<tr>

--- a/src/routes/(admin)/admin/shop/orders/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/orders/+page.server.ts
@@ -12,7 +12,9 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform, url }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "admin")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "admin")) {
+    throw error(403, "Only admins and super admins can access this area.");
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const svc = new OrderService(env.DB);

--- a/src/routes/(admin)/admin/shop/orders/+page.svelte
+++ b/src/routes/(admin)/admin/shop/orders/+page.svelte
@@ -42,7 +42,7 @@
 			<p class="text-sm text-muted-foreground">No orders yet.</p>
 		</div>
 	{:else}
-		<div class="overflow-hidden rounded-lg border border-border">
+		<div class="overflow-x-auto rounded-lg border border-border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
 					<tr>

--- a/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/orders/[id]/+page.server.ts
@@ -18,7 +18,9 @@ import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform, params }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "admin")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "admin")) {
+    throw error(403, "Only admins and super admins can access this area.");
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const svc = new OrderService(env.DB);

--- a/src/routes/(admin)/admin/shop/products/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/products/+page.server.ts
@@ -14,7 +14,10 @@ import type { Actions, PageServerLoad } from "./$types";
 export const load: PageServerLoad = async ({ locals, platform, url }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
   if (!hasRole(locals.user, "editor")) {
-    throw redirect(302, "/admin");
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
   }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");

--- a/src/routes/(admin)/admin/shop/products/+page.svelte
+++ b/src/routes/(admin)/admin/shop/products/+page.svelte
@@ -57,7 +57,7 @@
 			</a>
 		</div>
 	{:else}
-		<div class="overflow-hidden rounded-lg border border-border">
+		<div class="overflow-x-auto rounded-lg border border-border">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
 					<tr>

--- a/src/routes/(admin)/admin/shop/products/[id]/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/products/[id]/+page.server.ts
@@ -19,7 +19,12 @@ import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform, params }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const svc = new ShopService(env.DB);

--- a/src/routes/(admin)/admin/shop/products/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/shop/products/[id]/+page.svelte
@@ -79,6 +79,7 @@
 		{#if product.variants.length === 0}
 			<p class="text-sm text-muted-foreground">No variants.</p>
 		{:else}
+			<div class="overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="text-left text-xs uppercase text-muted-foreground">
 					<tr>
@@ -146,6 +147,7 @@
 					{/each}
 				</tbody>
 			</table>
+			</div>
 		{/if}
 	</section>
 

--- a/src/routes/(admin)/admin/shop/products/[id]/analytics/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/products/[id]/analytics/+page.server.ts
@@ -12,7 +12,12 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, platform, params }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
   const svc = new ShopService(env.DB);

--- a/src/routes/(admin)/admin/shop/products/new/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/products/new/+page.server.ts
@@ -6,7 +6,7 @@
  * keeps the onboarding path simple; the ADR's variant-matrix editor
  * is more valuable when there's already a product to attach to.
  */
-import { fail, redirect } from "@sveltejs/kit";
+import { fail, redirect, error } from "@sveltejs/kit";
 import { hasRole } from "$lib/server/auth/permissions";
 import { logAudit } from "$lib/server/audit";
 import { ShopService, ShopValidationError } from "$plugins/shop/service";
@@ -15,7 +15,12 @@ import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
-  if (!hasRole(locals.user, "editor")) throw redirect(302, "/admin");
+  if (!hasRole(locals.user, "editor")) {
+    throw error(
+      403,
+      "Only editors, admins and super admins can access this area.",
+    );
+  }
   return {};
 };
 

--- a/src/routes/(admin)/admin/subscribers/+page.svelte
+++ b/src/routes/(admin)/admin/subscribers/+page.svelte
@@ -127,7 +127,7 @@
 			<p class="text-sm text-muted-foreground">{m.cms_subscribers_empty()}</p>
 		</div>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted/30 text-xs uppercase tracking-wider text-muted-foreground">
 					<tr>

--- a/src/routes/(admin)/admin/tags/+page.svelte
+++ b/src/routes/(admin)/admin/tags/+page.svelte
@@ -102,7 +102,7 @@
 	{#if data.items.length === 0}
 		<p class="text-sm text-muted-foreground">{m.cms_tags_empty()}</p>
 	{:else}
-		<div class="border border-border rounded-lg overflow-hidden">
+		<div class="border border-border rounded-lg overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-muted">
 					<tr>


### PR DESCRIPTION
Four fixes, all verified against the deployed demo in a real browser rather than inferred from source.

## 1. Cookie prefix — closes #120

The session cookie shipped as `__Secure-__Host-khaopad_session`. Better Auth composes the name as an **unconditional concatenation** (`cookies/index.mjs`):

```js
name: `${secureCookiePrefix}${name}`   // secureCookiePrefix === "__Secure-" in prod
```

It never checks for an existing prefix, so our `"__Host-khaopad_session"` got doubled. Per RFC 6265bis §4.1.3.2 a prefix only carries its guarantees as the **leading** prefix, so `__Host-` was inert.

**Verified with controls**, not assumed:

| Cookie | `Domain` set? | Accepted? | Means |
|---|---|---|---|
| `__Secure-__Host-probe` | ✅ | **true** | `__Host-` not enforced |
| `__Host-probe_control` | ✅ | false | Correct name → refused. Control valid. |
| `__Host-probe_valid` | ✗ | true | Sanity check |

Live `Set-Cookie` confirmed as `__Secure-__Host-khaopad_session`.

The old config bought no subdomain protection while looking like it did. Now plain `khaopad_session`, so Better Auth emits `__Secure-khaopad_session` — which browsers *do* enforce. The `__Host-`-equivalent attributes (`path=/`, no `Domain`, `httpOnly`, `SameSite=Lax`) are pinned explicitly so a future default change can't relax them.

⚠️ **This invalidates all sessions — every admin is logged out once. Announce before deploying.** Real `__Host-` enforcement needs an upstream Better Auth change; #120 stays open to track that.

## 2. Admin tables were clipped on mobile

Every list view truncated on a phone. The wrapper used `overflow-hidden`, which **clips** rather than scrolls — so a 457px table in a 375px viewport lost its right-hand columns with no way to reach them. Screenshot showed "Updated" cut mid-word and the Actions column unreachable.

**13 tables fixed.** `overflow-x-auto` preserves the rounded-corner clipping that `overflow-hidden` was there for, while allowing horizontal scroll.

## 3. iOS zoom on every input

Inputs rendered at 14px. Below 16px, iOS Safari zooms the page on focus **and stays zoomed** — the most jarring mobile form bug there is. Now `text-base` on mobile, `sm:text-sm` on desktop.

## 4. Tap targets below the 44px minimum

Inputs and buttons were 36px against the Apple/Google 44px guideline; icon buttons at 36×36 were worst. Now `h-11` on touch, `sm:h-9` to keep desktop density. Both fixes live in the shared `ui/input` and `ui/button` components, so they apply app-wide.

## Also: consistent permission errors

Eleven routes silently redirected to `/admin` on insufficient role while `users`/`audit`/`settings` threw an explanatory 403. Same situation, two behaviours — and a silent bounce leaves the user with no idea why. All now 403 with a reason.

## What the audit found clean

Worth recording: no horizontal page overflow, no console errors, all inputs labelled, alt text present, no unsafe `target=_blank`, sidebar collapses correctly to a hamburger. The mobile shell is solid — the problems were in the shared primitives and the table wrappers.

## Gate

`pnpm test` **109 passed** (was 103) · `lint` 0 · `check` 0 errors · `build` ok

The cookie-name guard is mutation-verified: restoring `__Host-` fails 2 tests.