### PR TITLE
chore: v3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khaopad",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "description": "Khao Pad (ข้าวผัด) — Modular CMS for Cloudflare",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for #121 (cookie prefix #120 + mobile UX).

Minor rather than patch: the cookie name change **invalidates every existing session**, so forks must announce a forced logout before deploying. That is a behavioural change for users, not just a bug fix.