### PR TITLE
chore: delete macOS duplicate artifacts before typechecking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check": "./scripts/clean-duplicates.sh && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",

--- a/scripts/clean-duplicates.sh
+++ b/scripts/clean-duplicates.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Remove macOS/iCloud duplicate artifacts ("beam-config.server 2.ts").
+#
+# These are created by Finder/iCloud when a file is written while syncing.
+# They are gitignored, so CI never sees them — but they DO reach the local
+# typechecker, where a STALE copy of a since-changed file reports errors
+# against code nobody is editing. Worse, a duplicated migration silently
+# re-runs CREATE TABLE and blocks the whole chain, which has left schema
+# tests passing against stale schema more than once.
+#
+# tsconfig `exclude` does not help: svelte-check walks the filesystem
+# rather than only tsconfig's include set. Deleting is the honest fix —
+# the file is never wanted.
+set -euo pipefail
+found=$(find . \
+  -name '* [0-9].ts' -o -name '* [0-9].sql' -o -name '* [0-9].svelte' \
+  -o -name '* [0-9].json' -o -name '* [0-9].js' \
+  | grep -v node_modules | grep -v '\.git/' || true)
+if [ -n "$found" ]; then
+  echo "Removing macOS duplicate artifacts:"
+  echo "$found" | sed 's/^/  /'
+  echo "$found" | while IFS= read -r f; do rm -f "$f"; done
+fi


### PR DESCRIPTION
The `foo 2.ts` duplicates macOS/iCloud creates have cost time in **four sessions** now.

`.gitignore` keeps them out of CI, but they still reach the **local** typechecker — where a stale copy of a since-changed file reports errors against code nobody is editing. This turn it was `beam-config.server 2.ts`, still carrying the pre-fix `BeamConfig`, failing `check` in an otherwise clean tree.

## What didn't work

I first tried a tsconfig `exclude`. **It does not work** — svelte-check walks the filesystem rather than only tsconfig's include set, and a planted duplicate still failed the run. Reverted rather than ship a guard that looks right and isn't.

## What does

Deleting, since the file is never wanted. Wired into `check` so it runs before every typecheck.

Verified by planting a deliberately broken duplicate:

```
Removing macOS duplicate artifacts:
  ./src/plugins/shop/beam 2.ts
COMPLETED 5325 FILES 0 ERRORS
```

Running it once surfaced **15** existing duplicates, including `scripts/fixtures/registry-demo 2.json` — a duplicate seed fixture nobody had noticed.

Also relevant: a duplicated *migration* silently re-runs `CREATE TABLE` and blocks the chain, which has previously left schema tests passing against stale schema. The integration test catches that, but only after a wasted round trip.