### PR TITLE
fix: hydration broken on every nested route — login form silently did nothing

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,6 +11,25 @@ const config = {
         exclude: ["<all>"],
       },
     }),
+    // Absolute asset paths. SvelteKit defaults to `relative: true`, which
+    // emits the hydration bootstrap as a RELATIVE import:
+    //
+    //     import("../_app/immutable/entry/start.<hash>.js")
+    //
+    // From a nested route that resolves against the page URL, so
+    // /admin/login requested /admin/_app/... → 404. Hydration never
+    // started, and every form fell back to a native submit: the login
+    // page cleared its fields and showed no error, because the JS handler
+    // that calls /api/auth/sign-in was never attached.
+    //
+    // Only single-segment routes worked (/en emitted "./_app/..."), which
+    // is why the homepage looked fine while everything below it was inert.
+    //
+    // Relative paths only matter when serving from an unknown base path;
+    // this app is always served from the domain root.
+    paths: {
+      relative: false,
+    },
     alias: {
       $components: "src/lib/components",
       $plugins: "src/plugins",


### PR DESCRIPTION
**The whole app was inert below the first path level.** Reported by @thunpisit ("can't login"), reproduced in a clean browser profile.

## Symptom

Submitting the login form cleared the fields, stayed on the page, and showed **no error**. Network panel showed **no request at all** — `/api/auth/sign-in/email` was never called.

## Cause

SvelteKit's `paths.relative` defaults to `true`, emitting the hydration bootstrap as a relative import:

```js
import("../_app/immutable/entry/start.<hash>.js")
```

That resolves against the page URL, so `/admin/login` requested `/admin/_app/...` — a **404**, since the adapter only emits assets at `/_app/`. Hydration never started, so the submit handler never attached and the browser did a native form submit.

Verified on the deployed demo:

| Route | Emitted import | |
|---|---|---|
| `/en` | `./_app/...` | ✅ works (single segment) |
| `/en/blog` | `../_app/...` | ❌ 404 |
| `/admin/login` | `../_app/...` | ❌ 404 |

```
/admin/_app/immutable/entry/start.De4qpzsE.js  → 404
/_app/immutable/entry/start.De4qpzsE.js        → 200
```

**Every nested route — public and admin — was served as static HTML with no client routing and no working forms.** The homepage being fine is exactly why this went unnoticed.

## Fix

`paths.relative: false`. Relative paths only matter when serving from an unknown base path; this app is always at the domain root.

## Note on diagnosis

I initially told the user to clear cookies. That was wrong — the API, credentials, and the v3.8.0 cookie fix were all working. curl and direct `fetch()` calls succeeded because they bypass the form entirely; only driving the real UI in a clean profile surfaced it.

Two of my own measurements misled me first: `document.cookie` reading `(none)` (the session cookie is **HttpOnly**, so it's never visible to JS — I was logged in the whole time), and a form that wouldn't submit under `form_input` (which sets `.value` without firing the `input` event Svelte's `bind:value` needs).

## Gate

`pnpm test` 121 passed · `lint` 0 · `check` 0 errors · `build` ok

Worth adding a hydration assertion to the smoke test — a page that renders but doesn't hydrate passes every check we currently run.