### PR TITLE
fix(csp): hand-written CSP blocked SvelteKit's inline bootstrap — app was inert

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -334,19 +334,16 @@ const cacheHook: Handle = async ({ event, resolve }) => {
  * the admin session cookie. HttpOnly on the cookie blocks the primary
  * `document.cookie` vector; CSP closes off script injection at the source.
  *
- * We ship separate CSP for public and admin surfaces:
+ * The CSP itself is defined in svelte.config.js (`kit.csp`), NOT here.
+ * SvelteKit must own it so it can nonce its own inline hydration
+ * bootstrap. This file previously set `script-src 'self'` by hand on the
+ * reasoning that "public HTML never legitimately needs inline JS" — but
+ * SvelteKit's bootstrap IS inline JS on every page, so the browser
+ * refused it and the entire app shipped as inert HTML.
  *
- * - Public: strict — script-src 'self', no inline scripts, no eval.
- *   Public HTML never legitimately needs inline JS; a stored-XSS payload
- *   that would `<script>` under a permissive policy just gets refused.
- *   `img-src` and `media-src` include `data:` and `blob:` for markdown-
- *   embedded images/media; `connect-src` allows same-origin fetch for
- *   comment forms + newsletter subscribe.
- *
- * - Admin: relaxed only where the shadcn/svelte-sonner stack needs it
- *   (inline style attributes from bits-ui components). Scripts still
- *   locked to 'self'. Admin is authenticated so external content injection
- *   isn't the same threat class.
+ * `csp.mode: "auto"` keeps the policy strict (nonce per response, hashes
+ * where prerendered) rather than resorting to 'unsafe-inline', which
+ * would reopen the stored-XSS hole this policy exists to close.
  *
  * Same-origin defenses beyond CSP:
  * - `X-Content-Type-Options: nosniff` — kills MIME sniffing attacks
@@ -361,34 +358,6 @@ const SECURITY_HEADERS_STATIC: Record<string, string> = {
   "X-Frame-Options": "DENY",
 };
 
-const CSP_PUBLIC = [
-  "default-src 'self'",
-  "script-src 'self'",
-  "style-src 'self' 'unsafe-inline'", // Tailwind emits some inline styles at build; svelte hydration attaches per-component styles
-  "img-src 'self' data: blob: https:", // https: allows R2 CDN + external cover images
-  "media-src 'self' data: blob: https:",
-  "font-src 'self' data:",
-  "connect-src 'self'",
-  "frame-ancestors 'none'",
-  "form-action 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-].join("; ");
-
-const CSP_ADMIN = [
-  "default-src 'self'",
-  "script-src 'self'",
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: https:",
-  "media-src 'self' data: blob: https:",
-  "font-src 'self' data:",
-  "connect-src 'self'",
-  "frame-ancestors 'none'",
-  "form-action 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-].join("; ");
-
 const securityHeadersHook: Handle = async ({ event, resolve }) => {
   const response = await resolve(event);
 
@@ -396,13 +365,12 @@ const securityHeadersHook: Handle = async ({ event, resolve }) => {
     if (!response.headers.has(name)) response.headers.set(name, value);
   }
 
-  if (!response.headers.has("Content-Security-Policy")) {
-    const isAdmin = event.locals.surface === "admin";
-    response.headers.set(
-      "Content-Security-Policy",
-      isAdmin ? CSP_ADMIN : CSP_PUBLIC,
-    );
-  }
+  // NOTE: the CSP is deliberately NOT set here. SvelteKit generates it
+  // (svelte.config.js `kit.csp`) so it can attach a nonce to its own
+  // inline hydration bootstrap. A hand-written policy here would clobber
+  // that nonce — which is exactly what the previous `script-src 'self'`
+  // did: the browser refused the bootstrap, hydration never ran, and the
+  // whole app was served as inert HTML with non-functioning forms.
 
   return response;
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -30,6 +30,37 @@ const config = {
     paths: {
       relative: false,
     },
+    // Let SvelteKit generate the CSP so it can NONCE its own inline
+    // hydration bootstrap.
+    //
+    // hooks.server.ts previously set `script-src 'self'` by hand, on the
+    // reasoning that "public HTML never legitimately needs inline JS".
+    // But SvelteKit's bootstrap IS inline JS, emitted on every page — so
+    // the browser refused it, hydration never ran, and the entire app was
+    // served as inert HTML. Forms did native submits; the login page
+    // cleared its fields and showed no error.
+    //
+    // `mode: "auto"` emits a nonce for the inline bootstrap (and hashes
+    // for prerendered pages), which keeps the policy strict — strictly
+    // BETTER than 'unsafe-inline', which would have been the tempting fix
+    // and would have re-opened the stored-XSS hole the CSP exists to close.
+    csp: {
+      mode: "auto",
+      directives: {
+        "default-src": ["self"],
+        "script-src": ["self"],
+        // bits-ui / svelte-sonner emit inline style attributes.
+        "style-src": ["self", "unsafe-inline"],
+        "img-src": ["self", "data:", "blob:", "https:"],
+        "media-src": ["self", "data:", "blob:", "https:"],
+        "font-src": ["self", "data:"],
+        "connect-src": ["self"],
+        "frame-ancestors": ["none"],
+        "form-action": ["self"],
+        "base-uri": ["self"],
+        "object-src": ["none"],
+      },
+    },
     alias: {
       $components: "src/lib/components",
       $plugins: "src/plugins",


### PR DESCRIPTION
**The entire app was served as non-interactive HTML.** This is the actual root cause of "can't login" — #127 fixed a real but secondary bug.

## Cause

`hooks.server.ts` set the CSP by hand:

```
script-src 'self'      ← no nonce, no 'unsafe-inline'
```

SvelteKit's hydration bootstrap is an **inline `<script>`** emitted on every page. The browser refused it, `kit.start()` never ran, and nothing hydrated — no client router, no event handlers, no reactive state.

The doc comment justified it as: *"Public HTML never legitimately needs inline JS."* That's false for SvelteKit — its own bootstrap is inline. The policy was written against a threat model that didn't account for the framework it was protecting.

## Symptom

Submitting the login form cleared the fields, stayed on the page, and showed **no error**. Network panel showed **no request** — the handler that POSTs `/api/auth/sign-in` was never attached, so the browser did a native form submit.

## Fix

Move the CSP into `svelte.config.js` `kit.csp` with `mode: "auto"`, so SvelteKit nonces its own bootstrap. **Every directive preserved verbatim.**

Deliberately **not** `'unsafe-inline'` — that was the tempting one-line fix and would have reopened the stored-XSS hole this policy exists to close. A per-response nonce is strictly stronger than what we had, because the old policy wasn't protecting anything: it was breaking the app instead.

Also removed the now-unused `CSP_PUBLIC`/`CSP_ADMIN` constants and corrected the comment, rather than leaving it describing behaviour that no longer exists.

## Relationship to #127

#127 (`paths.relative: false`) was a **genuine second bug** — nested routes emitted `import("../_app/...")`, so `/admin/login` requested `/admin/_app/...` → 404. But fixing it alone left the app broken, because CSP blocked the bootstrap regardless of whether its URL resolved. Both fixes are needed.

## On my diagnosis

I first told the user this was a stale cookie and to clear their browser. That was wrong, and I should have verified before advising. The API, the credentials, and the v3.8.0 cookie fix were all working — which is exactly why `curl` and direct `fetch()` succeeded while the real UI did not.

Two of my own measurements sent me down blind alleys: `document.cookie` reading `(none)` (the session cookie is **HttpOnly** — invisible to JS; I was logged in throughout), and a form that wouldn't submit under `form_input` (which sets `.value` without firing the `input` event Svelte's `bind:value` needs).

## Gate

`pnpm test` 121 passed · `lint` 0 · `check` 0 errors · `build` ok

**A hydration assertion belongs in the smoke test.** Every check we run today passes against a page that renders but doesn't hydrate — which is precisely how this shipped.