### PR TITLE
fix(admin): 500 on every admin page — TDZ on the nav registry binding

### DIFF
--- a/src/lib/components/admin/sidebar-nav.node.test.ts
+++ b/src/lib/components/admin/sidebar-nav.node.test.ts
@@ -69,4 +69,16 @@ describe("sidebar-nav module initialization", () => {
     // than left as cargo cult.
     expect(source).toMatch(/import ["']\$lib\/plugins\/registrations["']/);
   });
+
+  it("declares the registry with `var`, not `let` — TDZ safety", () => {
+    // `let` sits in the Temporal Dead Zone until its declaration runs.
+    // This module side-effect-imports $lib/plugins/registrations at the
+    // bottom, and the bundler hoisted those plugin calls ABOVE the
+    // declaration in production — every admin page threw
+    // "Cannot access 'pe' before initialization" and rendered 500.
+    // `var` is hoisted and initialized to undefined, so the lazy guard
+    // works no matter the evaluation order.
+    expect(source).toMatch(/var _registry:/);
+    expect(source).not.toMatch(/let _registry:/);
+  });
 });

--- a/src/lib/components/admin/sidebar-nav.ts
+++ b/src/lib/components/admin/sidebar-nav.ts
@@ -74,7 +74,28 @@ type RegistryEntry = { title: () => string; items: NavItem[] };
  * Reading through this accessor makes the order irrelevant: whoever
  * touches the registry first creates it.
  */
-let _registry: Map<string, RegistryEntry> | undefined;
+// `var`, deliberately — NOT `let`. This is the one case where var is
+// correct and let is a bug.
+//
+// `let` is block-scoped and lives in the Temporal Dead Zone until its
+// declaration executes: touching it before then throws
+// `ReferenceError: Cannot access '_registry' before initialization`.
+// `var` is hoisted and initialized to `undefined`, so the guard below
+// simply sees undefined and creates the Map.
+//
+// That matters because this module imports `$lib/plugins/registrations`
+// as a side effect at the bottom of the file, and a bundler is free to
+// hoist those plugin registration calls ABOVE this declaration. It did:
+// production minified the shop plugin's registerPaymentProvider call
+// directly before `let pe;` (this variable), so every admin page threw
+// on hydration and rendered "500 Internal Error".
+//
+// The lazy accessor added after the earlier outage fixed the Map being
+// undefined, but not the TDZ on the binding itself — the accessor cannot
+// run at all if reaching the variable throws. `var` closes that gap.
+//
+// eslint-disable-next-line no-var
+var _registry: Map<string, RegistryEntry> | undefined;
 function registry(): Map<string, RegistryEntry> {
   if (!_registry) _registry = new Map<string, RegistryEntry>();
   return _registry;


### PR DESCRIPTION
**Every admin page rendered "500 Internal Error"** client-side while the server returned 200 — which is why curl looked healthy throughout.

```
ReferenceError: Cannot access 'pe' before initialization
    at xe (/_app/immutable/nodes/2.D44NJupj.js:106:2743)
```

## Cause

`pe` is the minified `_registry` in `sidebar-nav.ts`, declared with `let`. `let` sits in the **Temporal Dead Zone** until its declaration executes.

This module side-effect-imports `$lib/plugins/registrations` at the bottom, and the bundler hoisted those plugin calls **above** the declaration. The minified output is unambiguous — the shop plugin's `registerPaymentProvider` sits directly before `let pe;`:

```js
…registerPaymentProvider:r}},[]);d(new n({merchantId:e,…}))}}});let pe;function xe(){return pe||(pe=new Map),pe}
```

## This is the same bug as the earlier outage — my previous fix was incomplete

The lazy accessor added after that outage fixed the **Map** being undefined. It did not fix the **TDZ on the binding**, and an accessor can't run if merely reaching the variable throws. I treated that fix as complete; it wasn't.

`var` is correct here, and this is the one case where it genuinely beats `let`: it's hoisted and initialized to `undefined`, so the existing guard sees undefined and creates the Map regardless of evaluation order.

## Why it surfaced now

CSP had been blocking SvelteKit's inline bootstrap entirely, so **no JS ran at all** — a JS error was invisible. Fixing hydration exposed a latent break. Three separate bugs stacked:

1. `paths.relative` → nested routes requested `/admin/_app/…` → 404 (#127)
2. CSP `script-src 'self'` with no nonce → bootstrap refused (#128)
3. **this** → hydration finally runs, and immediately throws

Each masked the next.

## Verification

Confirmed `var` in the minified production bundle, not just source. Test asserts the declaration kind.

`pnpm test` **122 passed** · `lint` 0 · `check` 0 errors · `build` ok