### PR TITLE
feat(shop): build the Collections admin page; wire add-to-cart

### DIFF
--- a/src/plugins/shop/service.ts
+++ b/src/plugins/shop/service.ts
@@ -760,6 +760,65 @@ export class ShopService {
       .all();
   }
 
+  /**
+   * Collections with their localized title and product count, for the
+   * admin list view.
+   *
+   * `listCollections` returns bare rows, which are not renderable on
+   * their own — the title lives in `shop_collection_localizations` and
+   * the count in `shop_collection_products`. Both are fetched in ONE
+   * query each and joined in memory rather than per-row, so the page
+   * costs 3 queries regardless of how many collections exist.
+   */
+  async listCollectionsForAdmin(locale = "en"): Promise<
+    Array<
+      ShopCollection & {
+        title: string;
+        productCount: number;
+      }
+    >
+  > {
+    const rows = await this.listCollections();
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((r) => r.id);
+    const [locs, links] = await Promise.all([
+      this.db
+        .select()
+        .from(shopCollectionLocalizations)
+        .where(inArray(shopCollectionLocalizations.collectionId, ids))
+        .all(),
+      this.db
+        .select()
+        .from(shopCollectionProducts)
+        .where(inArray(shopCollectionProducts.collectionId, ids))
+        .all(),
+    ]);
+
+    // Prefer the requested locale, fall back to English, then anything —
+    // a collection with only a Thai title should still show a title
+    // rather than an empty cell.
+    const titleFor = (id: string) => {
+      const forId = locs.filter((l) => l.collectionId === id);
+      return (
+        forId.find((l) => l.locale === locale)?.title ??
+        forId.find((l) => l.locale === "en")?.title ??
+        forId[0]?.title ??
+        ""
+      );
+    };
+    const counts = new Map<string, number>();
+    for (const l of links) {
+      counts.set(l.collectionId, (counts.get(l.collectionId) ?? 0) + 1);
+    }
+
+    return rows.map((r) => ({
+      ...r,
+      title: titleFor(r.id),
+      productCount: counts.get(r.id) ?? 0,
+    }));
+  }
+
   async createCollection(input: {
     slug?: string;
     status?: "draft" | "active" | "archived";

--- a/src/routes/(admin)/admin/shop/collections/+page.server.ts
+++ b/src/routes/(admin)/admin/shop/collections/+page.server.ts
@@ -1,8 +1,10 @@
-import { redirect, error } from "@sveltejs/kit";
+import { redirect, error, fail } from "@sveltejs/kit";
 import { hasRole } from "$lib/server/auth/permissions";
-import type { PageServerLoad } from "./$types";
+import { logAudit } from "$lib/server/audit";
+import { ShopService, ShopValidationError } from "$plugins/shop/service";
+import type { Actions, PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, platform }) => {
   if (!locals.user) throw redirect(302, "/admin/login");
   if (!hasRole(locals.user, "editor")) {
     throw error(
@@ -10,5 +12,83 @@ export const load: PageServerLoad = async ({ locals }) => {
       "Only editors, admins and super admins can access this area.",
     );
   }
-  return {};
+  const env = platform?.env;
+  if (!env) throw error(503, "Platform not ready");
+
+  const svc = new ShopService(env.DB);
+  const locale = locals.locale ?? "en";
+
+  // Products are loaded so a collection can be POPULATED at creation
+  // time. Without them the page could only ever create empty
+  // collections, which is the less useful half of the feature.
+  const [collections, products] = await Promise.all([
+    svc.listCollectionsForAdmin(locale),
+    svc.listProducts({ limit: 200 }),
+  ]);
+
+  return { collections, products };
+};
+
+export const actions: Actions = {
+  create: async ({ request, locals, platform }) => {
+    if (!locals.user) throw error(401, "Not authenticated");
+    if (!hasRole(locals.user, "editor")) {
+      throw error(403, "Only editors and above can create collections.");
+    }
+    const form = await request.formData();
+    const titleEn = String(form.get("titleEn") ?? "").trim();
+    const titleTh = String(form.get("titleTh") ?? "").trim();
+    const slug = String(form.get("slug") ?? "").trim();
+    const status = String(form.get("status") ?? "draft") as
+      | "draft"
+      | "active"
+      | "archived";
+    const productIds = form.getAll("productIds").map(String).filter(Boolean);
+
+    const env = platform?.env;
+    if (!env) {
+      return fail(503, {
+        error: "Platform not ready",
+        values: { titleEn, titleTh, slug, status },
+      });
+    }
+
+    // English is required because the slug derives from it —
+    // `createCollection` rejects a missing `en` localization. Checking
+    // here gives a field-level message instead of a 500.
+    if (!titleEn) {
+      return fail(400, {
+        error: "English title is required — the slug is derived from it.",
+        values: { titleEn, titleTh, slug, status },
+      });
+    }
+
+    const svc = new ShopService(env.DB);
+    let id: string;
+    try {
+      id = await svc.createCollection({
+        slug: slug || undefined,
+        status,
+        localizations: {
+          en: { title: titleEn },
+          ...(titleTh ? { th: { title: titleTh } } : {}),
+        },
+        productIds,
+      });
+    } catch (err) {
+      if (err instanceof ShopValidationError) {
+        return fail(400, {
+          error: err.message,
+          values: { titleEn, titleTh, slug, status },
+        });
+      }
+      throw err;
+    }
+
+    await logAudit(env.DB, locals.user.id, "shop.collection.create", id, {
+      productCount: productIds.length,
+    });
+
+    return { success: true, id };
+  },
 };

--- a/src/routes/(admin)/admin/shop/collections/+page.svelte
+++ b/src/routes/(admin)/admin/shop/collections/+page.svelte
@@ -1,15 +1,168 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
 	import { Boxes } from 'lucide-svelte';
+	import type { ActionData, PageData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let createOpen = $state(false);
+
+	const statusClass = (s: string) =>
+		s === 'active'
+			? 'bg-green-100 text-green-800'
+			: s === 'archived'
+				? 'bg-neutral-100 text-neutral-700'
+				: 'bg-amber-100 text-amber-800';
 </script>
 
-<div class="max-w-2xl space-y-4 p-6">
-	<header class="flex items-center gap-3">
-		<Boxes class="h-6 w-6 text-muted-foreground" />
-		<h1 class="text-2xl font-semibold">Collections</h1>
+<svelte:head><title>Collections — Khao Pad CMS</title></svelte:head>
+
+<div class="space-y-4 p-6">
+	<header class="flex flex-wrap items-center justify-between gap-3">
+		<div class="flex items-center gap-3">
+			<Boxes class="h-6 w-6 text-muted-foreground" />
+			<div>
+				<h1 class="text-2xl font-semibold">Collections</h1>
+				<p class="text-sm text-muted-foreground">Group products for storefront browsing.</p>
+			</div>
+		</div>
+		<button
+			type="button"
+			onclick={() => (createOpen = !createOpen)}
+			class="h-11 rounded-md bg-primary px-4 text-sm text-primary-foreground sm:h-9"
+		>
+			{createOpen ? 'Cancel' : 'New collection'}
+		</button>
 	</header>
-	<div class="rounded-lg border border-dashed border-border p-8 text-center">
-		<p class="text-sm text-muted-foreground">
-			Collections ship alongside the product catalog in v3.1.
-		</p>
-	</div>
+
+	{#if form?.error}
+		<div class="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900">
+			{form.error}
+		</div>
+	{:else if form?.success}
+		<div class="rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-900">
+			Collection created.
+		</div>
+	{/if}
+
+	{#if createOpen}
+		<form
+			method="POST"
+			action="?/create"
+			use:enhance={() => async ({ update }) => {
+				await update();
+				createOpen = false;
+			}}
+			class="space-y-4 rounded-lg border p-4"
+		>
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div>
+					<label for="titleEn" class="text-sm font-medium">Title (English)</label>
+					<input
+						id="titleEn"
+						name="titleEn"
+						required
+						value={form?.values?.titleEn ?? ''}
+						class="mt-1 h-11 w-full rounded-md border px-3 text-base sm:h-9 sm:text-sm"
+					/>
+					<p class="mt-1 text-xs text-muted-foreground">
+						Required — the slug is derived from this.
+					</p>
+				</div>
+				<div>
+					<label for="titleTh" class="text-sm font-medium">Title (Thai)</label>
+					<input
+						id="titleTh"
+						name="titleTh"
+						value={form?.values?.titleTh ?? ''}
+						class="mt-1 h-11 w-full rounded-md border px-3 text-base sm:h-9 sm:text-sm"
+					/>
+				</div>
+				<div>
+					<label for="slug" class="text-sm font-medium">Slug</label>
+					<input
+						id="slug"
+						name="slug"
+						placeholder="auto from English title"
+						value={form?.values?.slug ?? ''}
+						class="mt-1 h-11 w-full rounded-md border px-3 font-mono text-base sm:h-9 sm:text-sm"
+					/>
+				</div>
+				<div>
+					<label for="status" class="text-sm font-medium">Status</label>
+					<select
+						id="status"
+						name="status"
+						class="mt-1 h-11 w-full rounded-md border px-3 text-base sm:h-9 sm:text-sm"
+					>
+						<option value="draft">Draft</option>
+						<option value="active">Active</option>
+					</select>
+				</div>
+			</div>
+
+			{#if data.products.length > 0}
+				<fieldset>
+					<legend class="text-sm font-medium">Products</legend>
+					<p class="mb-2 text-xs text-muted-foreground">
+						Optional — products can be added now or later.
+					</p>
+					<div class="max-h-56 space-y-1 overflow-y-auto rounded-md border p-2">
+						{#each data.products as p (p.id)}
+							<label class="flex items-center gap-2 text-sm">
+								<input type="checkbox" name="productIds" value={p.id} />
+								<span>{p.title || p.slug}</span>
+							</label>
+						{/each}
+					</div>
+				</fieldset>
+			{:else}
+				<p class="text-xs text-muted-foreground">
+					No products yet — create some first to populate a collection.
+				</p>
+			{/if}
+
+			<button
+				type="submit"
+				class="h-11 rounded-md bg-primary px-4 text-sm text-primary-foreground sm:h-9"
+			>
+				Create collection
+			</button>
+		</form>
+	{/if}
+
+	{#if data.collections.length === 0}
+		<div class="rounded-lg border border-dashed border-border p-8 text-center">
+			<p class="text-sm text-muted-foreground">
+				No collections yet. Create one to group products on the storefront.
+			</p>
+		</div>
+	{:else}
+		<div class="overflow-x-auto rounded-lg border border-border">
+			<table class="w-full text-sm">
+				<thead class="bg-muted">
+					<tr>
+						<th class="px-4 py-3 text-left font-medium">Title</th>
+						<th class="px-4 py-3 text-left font-medium">Slug</th>
+						<th class="px-4 py-3 text-left font-medium">Status</th>
+						<th class="px-4 py-3 text-right font-medium">Products</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each data.collections as c (c.id)}
+						<tr class="border-t border-border">
+							<td class="px-4 py-3 font-medium">{c.title || '(untitled)'}</td>
+							<td class="px-4 py-3 font-mono text-xs text-muted-foreground">{c.slug}</td>
+							<td class="px-4 py-3">
+								<span class="rounded px-2 py-0.5 text-xs {statusClass(c.status)}">
+									{c.status}
+								</span>
+							</td>
+							<td class="px-4 py-3 text-right tabular-nums">{c.productCount}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
 </div>

--- a/src/routes/(admin)/admin/shop/collections/collections-page.node.test.ts
+++ b/src/routes/(admin)/admin/shop/collections/collections-page.node.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guards the Collections admin page against regressing to a placeholder.
+ *
+ * This page shipped as a stub reading "Collections ship alongside the
+ * product catalog in v3.1" — and was still saying that at v3.8.1, seven
+ * minor versions later, while the backend (3 tables, service methods and
+ * a live public API) had been complete the whole time.
+ *
+ * A version-numbered "coming soon" string is the specific thing worth
+ * asserting against: it ages silently, and nothing else in the codebase
+ * fails when it does.
+ */
+const PAGE = new URL("./+page.svelte", import.meta.url).pathname;
+const SERVER = new URL("./+page.server.ts", import.meta.url).pathname;
+
+describe("collections admin page", () => {
+  const page = readFileSync(PAGE, "utf8");
+  const server = readFileSync(SERVER, "utf8");
+
+  it("makes no 'ships in vX.Y' promise", () => {
+    // The exact failure mode: a future-tense version claim that nobody
+    // revisits once that version ships.
+    expect(page).not.toMatch(/ship[s]? .{0,30}in v\d/i);
+    expect(page).not.toMatch(/coming soon/i);
+  });
+
+  it("loads real collections rather than returning an empty object", () => {
+    expect(server).toMatch(/listCollectionsForAdmin/);
+    expect(server).not.toMatch(/return \{\};/);
+  });
+
+  it("can create a collection", () => {
+    expect(server).toMatch(/createCollection/);
+    expect(page).toMatch(/action="\?\/create"/);
+  });
+
+  it("loads products so a collection can be populated at creation", () => {
+    // Creating only-empty collections is the less useful half; without
+    // products in the loader the form cannot offer them.
+    expect(server).toMatch(/listProducts/);
+    expect(page).toMatch(/name="productIds"/);
+  });
+
+  it("requires the English title, since the slug derives from it", () => {
+    expect(server).toMatch(/English title is required/);
+  });
+
+  it("keeps the table horizontally scrollable on mobile", () => {
+    // overflow-hidden clips rather than scrolls — the bug fixed across
+    // 13 admin tables in v3.8.0.
+    expect(page).toMatch(/overflow-x-auto/);
+    expect(page).not.toMatch(/border-border overflow-hidden">\s*<table/);
+  });
+});

--- a/src/routes/(www)/[locale]/products/[slug]/+page.svelte
+++ b/src/routes/(www)/[locale]/products/[slug]/+page.svelte
@@ -63,6 +63,46 @@
 			// sessionStorage disabled (private mode etc.) — skip
 		}
 	});
+
+	// ─── Add to cart ────────────────────────────────────────────────
+	// POSTs the selected variant to /api/shop/cart, which is same-origin
+	// guarded and handles session creation. Previously the page had no
+	// way to add anything: cart and checkout existed and worked, but
+	// nothing on the product page was wired to them, and a footer note
+	// still promised the feature for a release that had long since gone
+	// out — so the shop could not take an order at all.
+	let adding = $state(false);
+	let addError = $state<string | null>(null);
+	let added = $state(false);
+
+	async function addToCart() {
+		if (!selectedVariant || adding) return;
+		adding = true;
+		addError = null;
+		added = false;
+		try {
+			const res = await fetch('/api/shop/cart', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ variantId: selectedVariant.id, quantity: 1 })
+			});
+			if (!res.ok) {
+				// Surface the server's reason (out of stock, unknown variant)
+				// rather than a generic failure — the customer can act on it.
+				const body = await res.json().catch(() => null);
+				addError =
+					(body && typeof body === 'object' && 'message' in body
+						? String(body.message)
+						: null) ?? 'Could not add to cart. Please try again.';
+				return;
+			}
+			added = true;
+		} catch {
+			addError = 'Network error. Please try again.';
+		} finally {
+			adding = false;
+		}
+	}
 </script>
 
 <!-- SEO is rendered by the layout via page.data.seo. Only the Product
@@ -141,13 +181,21 @@
 	{/if}
 
 	<footer class="mt-10 border-t border-border pt-6">
-		<p class="text-sm text-muted-foreground">
-			Cart + checkout ship in v3.2 (<a
-				href="https://github.com/codustry/khaopad/issues/57"
-				class="underline"
-				target="_blank"
-				rel="noopener">#57</a
-			>). Currently browse-only.
-		</p>
+		<div class="flex flex-wrap items-center gap-3">
+			<button
+				type="button"
+				onclick={addToCart}
+				disabled={adding || !selectedVariant}
+				class="h-11 rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground disabled:opacity-50 sm:h-10"
+			>
+				{adding ? 'Adding…' : 'Add to cart'}
+			</button>
+			{#if added}
+				<a href="/cart" class="text-sm underline">View cart →</a>
+			{/if}
+		</div>
+		{#if addError}
+			<p class="mt-3 text-sm text-destructive">{addError}</p>
+		{/if}
 	</footer>
 </article>

--- a/src/routes/(www)/[locale]/products/[slug]/add-to-cart.node.test.ts
+++ b/src/routes/(www)/[locale]/products/[slug]/add-to-cart.node.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guards the product page's add-to-cart control.
+ *
+ * The page shipped with a footer reading "Cart + checkout ship in v3.2
+ * … currently browse-only" and was still saying it at v3.8.1. Cart and
+ * checkout had in fact been live for six minor versions — the routes
+ * worked and the API accepted POSTs — but nothing on the product page
+ * was ever wired to them. So the shop could not take an order at all.
+ */
+// decodeURIComponent: SvelteKit route dirs contain [brackets], which
+// URL.pathname percent-encodes — the raw path would not resolve.
+const PAGE = decodeURIComponent(
+  new URL("./+page.svelte", import.meta.url).pathname,
+);
+
+describe("product page add to cart", () => {
+  const page = readFileSync(PAGE, "utf8");
+
+  it("makes no 'ships in vX.Y' promise", () => {
+    expect(page).not.toMatch(/ship .{0,20}in v\d/i);
+    expect(page).not.toMatch(/browse-only/i);
+  });
+
+  it("posts the selected variant to the cart API", () => {
+    expect(page).toMatch(/\/api\/shop\/cart/);
+    expect(page).toMatch(/variantId: selectedVariant\.id/);
+  });
+
+  it("surfaces the server's error rather than a generic message", () => {
+    // Out-of-stock is actionable; "something went wrong" is not.
+    expect(page).toMatch(/addError/);
+  });
+
+  it("disables the button while the request is in flight", () => {
+    // Prevents double-adding on an impatient second click.
+    expect(page).toMatch(/disabled=\{adding/);
+  });
+
+  it("offers a route to the cart after a successful add", () => {
+    expect(page).toMatch(/href="\/cart"/);
+  });
+});


### PR DESCRIPTION
Two placeholders promised features for releases that had **long since shipped**. In both cases the backend was already complete — only the UI was missing.

Spotted by @thunpisit: `/admin/shop/collections` still said *"Collections ship alongside the product catalog in v3.1"* — at **v3.8.1**.

## 1. Collections

Seven minor versions after the promised release, the page was a stub. The backend had been there the whole time: 3 tables (`shop_collections`, `_localizations`, `_products`), `listCollections`/`createCollection` with product assignment, and a live public API returning `{"collections":[]}`.

**Now a real page** — list with localized title, status and product count; create form with EN/TH titles, optional slug, status, and product assignment at creation time.

`listCollectionsForAdmin` fetches localizations and product links in **one query each** and joins in memory, so the page costs 3 queries regardless of collection count. Title falls back locale → `en` → any, so a Thai-only collection still shows a title rather than an empty cell.

## 2. Add to cart — the more serious one

The product page footer read *"Cart + checkout ship in v3.2 … Currently browse-only."*

That was wrong, and customer-facing. `/cart` and `/checkout` both return 200, and `/api/shop/cart` accepts POSTs. **But nothing on the product page was ever wired to them** — so the shop could not take an order at all.

Added the button, posting the selected variant to the existing API. It:

- surfaces the **server's** error (out of stock, unknown variant) instead of a generic failure, so the customer can act on it
- disables while in flight, so an impatient second click can't double-add
- offers a link to the cart on success

## Tests

Guards assert no `ships in vX.Y` / `coming soon` copy on either page, plus the behaviour behind them. That string is exactly what's worth testing — it ages silently and nothing else in the codebase fails when it does.

**133 tests** (was 122). `lint` 0 · `check` 0 errors · `build` ok.

Two things worth flagging from writing this:

- My own explanatory comment quoted the old copy and tripped the guard. Reworded — but I kept the assertion scanning the whole file rather than just markup, because a stale promise in a comment ages the same way.
- `new URL().pathname` percent-encodes SvelteKit's `[slug]` bracket dirs, so the test file needed `decodeURIComponent`. Worth knowing for any future test that reads a route file.

## Not in scope

Collections have no edit or delete yet — `ShopService` only exposes `list` and `create`. The page is honest about what it can do rather than showing controls that don't work. Worth a follow-up issue.