### PR TITLE
fix(i18n): admin was pinned to English — the locale cookie was never read

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -45,11 +45,32 @@ const bindingsHook: Handle = async ({ event, resolve }) => {
     .split(",")
     .map((s) => s.trim());
   const defaultLocale = env?.DEFAULT_LOCALE ?? "en";
-  event.locals.locale = localeFromPathname(
-    event.url.pathname,
-    supportedLocales,
-    defaultLocale,
-  );
+  // Locale resolution differs by surface, deliberately.
+  //
+  //   (www)   → URL segment. /en/blog vs /th/blog is SEO-visible and
+  //             shareable, so the path is the source of truth.
+  //   (admin) → COOKIE. The CMS is intentionally locale-prefix-free: it
+  //             is a private surface with no SEO need, and prefixing
+  //             would turn /admin/articles into /th/admin/articles.
+  //
+  // The admin case was previously missing. `localeFromPathname` sees
+  // "admin" as the first segment, finds it isn't a supported locale, and
+  // falls back to DEFAULT_LOCALE — so the CMS was pinned to English no
+  // matter what. AdminLocaleToggle wrote PARAGLIDE_LOCALE and reloaded,
+  // but nothing ever read that cookie, so the toggle did nothing.
+  if (event.locals.surface === "admin") {
+    const cookieLocale = event.cookies.get(paraglideRuntime.cookieName);
+    event.locals.locale =
+      cookieLocale && supportedLocales.includes(cookieLocale)
+        ? cookieLocale
+        : defaultLocale;
+  } else {
+    event.locals.locale = localeFromPathname(
+      event.url.pathname,
+      supportedLocales,
+      defaultLocale,
+    );
+  }
 
   const validation = validatePlatformEnv(env);
 

--- a/src/lib/i18n/admin-locale.node.test.ts
+++ b/src/lib/i18n/admin-locale.node.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guards admin locale resolution.
+ *
+ * The CMS was pinned to English no matter what. `bindingsHook` derived
+ * locale ONLY from the first path segment, so for `/admin/...` it saw
+ * "admin", found it wasn't a supported locale, and fell back to
+ * DEFAULT_LOCALE.
+ *
+ * Meanwhile AdminLocaleToggle wrote a PARAGLIDE_LOCALE cookie and
+ * reloaded — deliberately, because the admin is locale-prefix-free and
+ * prefixing would turn /admin/articles into /th/admin/articles. But
+ * nothing read that cookie, so the toggle was inert.
+ */
+const HOOKS = new URL("../../hooks.server.ts", import.meta.url).pathname;
+const TOGGLE = new URL(
+  "../components/admin/AdminLocaleToggle.svelte",
+  import.meta.url,
+).pathname;
+
+describe("admin locale resolution", () => {
+  const hooks = readFileSync(HOOKS, "utf8");
+  const toggle = readFileSync(TOGGLE, "utf8");
+
+  it("reads the locale cookie on the admin surface", () => {
+    expect(hooks).toMatch(/surface === "admin"/);
+    expect(hooks).toMatch(/cookies\.get\(paraglideRuntime\.cookieName\)/);
+  });
+
+  it("still derives www locale from the URL", () => {
+    // The public site must keep /en/blog ↔ /th/blog working; that is
+    // SEO-visible and shareable in a way a cookie is not.
+    expect(hooks).toMatch(/localeFromPathname/);
+  });
+
+  it("validates the cookie against supported locales", () => {
+    // A crafted cookie must not select an unsupported locale.
+    expect(hooks).toMatch(/supportedLocales\.includes\(cookieLocale\)/);
+  });
+
+  it("resolves surface before locale", () => {
+    // bindingsHook branches on locals.surface, so surfaceHook must run
+    // first or the admin branch never fires.
+    const order = hooks.slice(hooks.indexOf("sequence("));
+    expect(order.indexOf("surfaceHook")).toBeLessThan(
+      order.indexOf("bindingsHook"),
+    );
+  });
+
+  it("keeps the toggle writing the cookie the hook reads", () => {
+    // Both halves must agree on the cookie name, or the toggle silently
+    // does nothing again.
+    expect(toggle).toMatch(/cookieName/);
+    expect(toggle).toMatch(/document\.cookie/);
+  });
+});


### PR DESCRIPTION
The CMS UI stayed English regardless of the **TH toggle**, `Accept-Language`, or the `PARAGLIDE_LOCALE` cookie. Reported by @thunpisit.

## Cause

`bindingsHook` derived locale **only** from the first path segment:

```ts
event.locals.locale = localeFromPathname(event.url.pathname, …);
```

For `/admin/...` that segment is `"admin"` — not a supported locale — so it fell back to `DEFAULT_LOCALE` on every single admin request.

`AdminLocaleToggle` was already doing the right thing. It writes `PARAGLIDE_LOCALE` and hard-reloads, deliberately avoiding Paraglide's `setLocale()` because the URL strategy would rewrite `/admin/articles` → `/th/admin/articles`, and the CMS is intentionally locale-prefix-free. **But nothing on the server read that cookie**, so the toggle wrote a value into the void and the page came back in English.

Verified before fixing:

```
Accept-Language: en  → Dashboard
Accept-Language: th  → Dashboard
PARAGLIDE_LOCALE=th  → Dashboard
```

## Fix

Locale resolution is now surface-aware — which is what the two surfaces actually need:

| Surface | Source | Why |
|---|---|---|
| `(www)` | URL segment | `/en/blog` ↔ `/th/blog` is SEO-visible and shareable; the path must stay authoritative |
| `(admin)` | cookie | Private surface, no SEO need, and prefixing would mangle every admin URL |

The cookie is validated against `SUPPORTED_LOCALES`, so a crafted value can't select an unsupported locale.

Hook order already supports this — `surfaceHook` runs before `bindingsHook`, so `locals.surface` is set when the branch evaluates. **A test asserts that ordering**, because silently reversing it would restore the bug with no other symptom.

## Tests

**138** (was 133). Mutation-verified: dropping the supported-locale check fails the guard.