### PR TITLE
fix(shop): close origin-guard hole, guard checkout, chunk D1 binds

### DIFF
--- a/src/lib/server/http/same-origin.test.ts
+++ b/src/lib/server/http/same-origin.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { requireSameOrigin } from "./same-origin";
+
+const URL_ = new URL("https://shop.example/api/shop/cart");
+const req = (method: string, headers: Record<string, string> = {}) =>
+  new Request("https://shop.example/api/shop/cart", { method, headers });
+
+describe("requireSameOrigin", () => {
+  it("allows read-only methods without provenance", () => {
+    expect(requireSameOrigin(req("GET"), URL_)).toBeNull();
+    expect(requireSameOrigin(req("HEAD"), URL_)).toBeNull();
+  });
+
+  it("REJECTS a state change with no Origin at all", () => {
+    // The bug: `cart` waved this through on the reasoning that
+    // same-origin fetches omit Origin. Browsers have sent it on every
+    // POST since ~2020, so an absent header means a non-browser client.
+    const res = requireSameOrigin(req("POST"), URL_);
+    expect(res?.status).toBe(403);
+  });
+
+  it("allows a same-origin POST", () => {
+    expect(
+      requireSameOrigin(req("POST", { origin: "https://shop.example" }), URL_),
+    ).toBeNull();
+  });
+
+  it("rejects a cross-origin POST", () => {
+    const res = requireSameOrigin(
+      req("POST", { origin: "https://evil.example" }),
+      URL_,
+    );
+    expect(res?.status).toBe(403);
+  });
+
+  it("rejects a malformed Origin rather than throwing", () => {
+    const res = requireSameOrigin(req("POST", { origin: "not a url" }), URL_);
+    expect(res?.status).toBe(400);
+  });
+
+  it("prefers sec-fetch-site, which page script cannot forge", () => {
+    // A non-browser client controls Origin completely, so a browser-set
+    // header beats it when present.
+    expect(
+      requireSameOrigin(
+        req("POST", {
+          "sec-fetch-site": "same-origin",
+          origin: "https://evil.example",
+        }),
+        URL_,
+      ),
+    ).toBeNull();
+
+    expect(
+      requireSameOrigin(
+        req("POST", {
+          "sec-fetch-site": "cross-site",
+          origin: "https://shop.example",
+        }),
+        URL_,
+      )?.status,
+    ).toBe(403);
+  });
+
+  it("treats sec-fetch-site: none (direct navigation) as safe", () => {
+    expect(
+      requireSameOrigin(req("POST", { "sec-fetch-site": "none" }), URL_),
+    ).toBeNull();
+  });
+
+  it("rejects same-site — a sibling subdomain is not us", () => {
+    expect(
+      requireSameOrigin(req("POST", { "sec-fetch-site": "same-site" }), URL_)
+        ?.status,
+    ).toBe(403);
+  });
+});

--- a/src/lib/server/http/same-origin.ts
+++ b/src/lib/server/http/same-origin.ts
@@ -1,0 +1,63 @@
+import { json } from "@sveltejs/kit";
+
+/**
+ * Same-origin guard for state-changing API routes.
+ *
+ * ## Why this is shared
+ *
+ * This existed as THREE copies pasted across shop routes, and they had
+ * already diverged: `cart/discount` rejected a request with no `Origin`
+ * header, while `cart` waved it through with
+ *
+ *     if (!origin) return null; // same-origin fetch usually omits it
+ *
+ * That reasoning is outdated — per the Fetch spec browsers have sent
+ * `Origin` on every POST, same-origin included, since ~2020. So an absent
+ * header means a non-browser client, and a guard whose entire job is to
+ * establish provenance should not wave that through.
+ *
+ * Copies of a security check drift silently. One implementation cannot.
+ *
+ * ## What this is and isn't
+ *
+ * This is defence in depth, NOT the primary CSRF control. `SameSite=Lax`
+ * on the session and cart cookies is what actually stops a cross-site
+ * POST from carrying credentials. This layer catches the residue:
+ * non-browser clients, and browsers on paths where SameSite is weaker.
+ *
+ * Returns `null` to continue, or a `Response` to short-circuit.
+ */
+export function requireSameOrigin(request: Request, url: URL): Response | null {
+  // GET/HEAD are read-only; provenance doesn't matter.
+  if (request.method === "GET" || request.method === "HEAD") return null;
+
+  // `Sec-Fetch-Site` is set by the browser and is NOT settable by page
+  // script, so it beats `Origin` (which a non-browser client controls
+  // completely) when present.
+  //   same-origin → our own page
+  //   none        → direct navigation / typed URL / bookmark
+  //   same-site   → a sibling subdomain; not trusted for state changes
+  //   cross-site  → another site
+  const secFetchSite = request.headers.get("sec-fetch-site");
+  if (secFetchSite) {
+    if (secFetchSite === "same-origin" || secFetchSite === "none") return null;
+    return json({ ok: false, code: "CROSS_ORIGIN_FORBIDDEN" }, { status: 403 });
+  }
+
+  const origin = request.headers.get("origin");
+  if (!origin) {
+    return json({ ok: false, code: "MISSING_ORIGIN" }, { status: 403 });
+  }
+
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return json({ ok: false, code: "MALFORMED_ORIGIN" }, { status: 400 });
+  }
+
+  if (originHost !== url.host) {
+    return json({ ok: false, code: "CROSS_ORIGIN_FORBIDDEN" }, { status: 403 });
+  }
+  return null;
+}

--- a/src/plugins/shop/collections-admin.node.test.ts
+++ b/src/plugins/shop/collections-admin.node.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guards `listCollectionsForAdmin` against the two bugs found in the
+ * post-merge hunt of my own code.
+ *
+ * Structural rather than behavioural: exercising the method needs a D1
+ * binding, and both defects live in the shape of the query rather than
+ * in a result that a small fixture would reveal — 100 collections is
+ * exactly the point where a fixture stops being small.
+ */
+const SERVICE = new URL("./service.ts", import.meta.url).pathname;
+
+describe("listCollectionsForAdmin", () => {
+  const src = readFileSync(SERVICE, "utf8");
+  const method = src.slice(
+    src.indexOf("async listCollectionsForAdmin"),
+    src.indexOf("async listCollectionsForAdmin") + 3000,
+  );
+
+  it("chunks ids to respect D1's 100-bound-parameter limit", () => {
+    // A bare inArray(ids) breaks silently at 101 collections — D1 binds
+    // at most 100 parameters per statement. The content query engine
+    // solves the same problem with MAX_BIND_PARAMS/loadChunked.
+    expect(method).toMatch(/CHUNK\s*=\s*100/);
+    expect(method).toMatch(/slice\(i, i \+ CHUNK\)/);
+  });
+
+  it("indexes localizations instead of filtering per row", () => {
+    // `locs.filter(...)` inside titleFor made this
+    // O(collections x localizations).
+    expect(method).toMatch(/new Map<string,/);
+    expect(method).not.toMatch(/locs\.filter\(/);
+  });
+
+  it("falls back locale -> en -> any for the title", () => {
+    // A Thai-only collection should still render a title rather than an
+    // empty cell.
+    expect(method).toMatch(/l\.locale === locale/);
+    expect(method).toMatch(/l\.locale === "en"/);
+  });
+});

--- a/src/plugins/shop/service.ts
+++ b/src/plugins/shop/service.ts
@@ -782,24 +782,53 @@ export class ShopService {
     if (rows.length === 0) return [];
 
     const ids = rows.map((r) => r.id);
-    const [locs, links] = await Promise.all([
-      this.db
-        .select()
-        .from(shopCollectionLocalizations)
-        .where(inArray(shopCollectionLocalizations.collectionId, ids))
-        .all(),
-      this.db
-        .select()
-        .from(shopCollectionProducts)
-        .where(inArray(shopCollectionProducts.collectionId, ids))
-        .all(),
+
+    // D1 binds at most 100 parameters per statement (see MAX_BIND_PARAMS
+    // in the content query engine, which solves the same problem). A bare
+    // `inArray(ids)` silently breaks the page at 101 collections, so
+    // chunk it.
+    const CHUNK = 100;
+    const chunks: string[][] = [];
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      chunks.push(ids.slice(i, i + CHUNK));
+    }
+
+    const [locGroups, linkGroups] = await Promise.all([
+      Promise.all(
+        chunks.map((c) =>
+          this.db
+            .select()
+            .from(shopCollectionLocalizations)
+            .where(inArray(shopCollectionLocalizations.collectionId, c))
+            .all(),
+        ),
+      ),
+      Promise.all(
+        chunks.map((c) =>
+          this.db
+            .select()
+            .from(shopCollectionProducts)
+            .where(inArray(shopCollectionProducts.collectionId, c))
+            .all(),
+        ),
+      ),
     ]);
+    const locs = locGroups.flat();
+    const links = linkGroups.flat();
 
     // Prefer the requested locale, fall back to English, then anything —
     // a collection with only a Thai title should still show a title
     // rather than an empty cell.
+    // Index once rather than filtering the full array per row — that was
+    // O(collections x localizations), which is fine at 5 and not at 500.
+    const byCollection = new Map<string, typeof locs>();
+    for (const l of locs) {
+      const list = byCollection.get(l.collectionId);
+      if (list) list.push(l);
+      else byCollection.set(l.collectionId, [l]);
+    }
     const titleFor = (id: string) => {
-      const forId = locs.filter((l) => l.collectionId === id);
+      const forId = byCollection.get(id) ?? [];
       return (
         forId.find((l) => l.locale === locale)?.title ??
         forId.find((l) => l.locale === "en")?.title ??

--- a/src/routes/api/shop/cart/+server.ts
+++ b/src/routes/api/shop/cart/+server.ts
@@ -18,34 +18,8 @@ import { ensureCartSession } from "$plugins/shop/cart-cookie";
 import { ShopValidationError } from "$plugins/shop/service";
 import { shopProductVariants } from "$plugins/shop/schema";
 import { track, buildEventContext } from "$lib/server/analytics/track";
+import { requireSameOrigin } from "$lib/server/http/same-origin";
 import type { RequestHandler } from "./$types";
-
-/**
- * Same-origin CSRF guard for mutating cart endpoints. SameSite=Lax
- * on the cart cookie blocks most cross-site cookie carriage, but
- * PATCH/DELETE with certain content types can slip past preflight —
- * an explicit Origin check is cheap belt-and-braces.
- *
- * Returns null on pass, or a Response to short-circuit on fail.
- */
-function requireSameOrigin(request: Request, url: URL): Response | null {
-  // GET is safe to serve without an Origin check (read-only).
-  if (request.method === "GET") return null;
-  const origin = request.headers.get("origin") ?? "";
-  if (!origin) return null; // same-origin fetch from same document usually omits it
-  try {
-    const originHost = new URL(origin).host;
-    if (originHost !== url.host) {
-      return json(
-        { ok: false, code: "CROSS_ORIGIN_FORBIDDEN" },
-        { status: 403 },
-      );
-    }
-  } catch {
-    return json({ ok: false, code: "MALFORMED_ORIGIN" }, { status: 400 });
-  }
-  return null;
-}
 
 export const GET: RequestHandler = async ({ platform, cookies, locals }) => {
   const env = platform?.env;

--- a/src/routes/api/shop/cart/discount/+server.ts
+++ b/src/routes/api/shop/cart/discount/+server.ts
@@ -20,29 +20,8 @@ import { CartService } from "$plugins/shop/cart-service";
 import { ensureCartSession } from "$plugins/shop/cart-cookie";
 import { validateDiscount } from "$plugins/shop/discount-service";
 import { shopCarts } from "$plugins/shop/schema-cart";
+import { requireSameOrigin } from "$lib/server/http/same-origin";
 import type { RequestHandler } from "./$types";
-
-function requireSameOrigin(request: Request, url: URL): Response | null {
-  if (request.method === "GET") return null;
-  // A same-origin fetch from any current browser sends Origin on
-  // POST/DELETE. Treating a missing header as "allow" would hand the
-  // guard to any non-browser client, so require it.
-  const origin = request.headers.get("origin") ?? "";
-  if (!origin) {
-    return json({ ok: false, code: "MISSING_ORIGIN" }, { status: 403 });
-  }
-  try {
-    if (new URL(origin).host !== url.host) {
-      return json(
-        { ok: false, code: "CROSS_ORIGIN_FORBIDDEN" },
-        { status: 403 },
-      );
-    }
-  } catch {
-    return json({ ok: false, code: "MALFORMED_ORIGIN" }, { status: 400 });
-  }
-  return null;
-}
 
 export const POST: RequestHandler = async ({
   request,

--- a/src/routes/api/shop/checkout/pay/+server.ts
+++ b/src/routes/api/shop/checkout/pay/+server.ts
@@ -10,9 +10,15 @@
 import { error, json } from "@sveltejs/kit";
 import { OrderService } from "$plugins/shop/order-service";
 import { resolveProviderForRequest } from "$plugins/shop/beam-config.server";
+import { requireSameOrigin } from "$lib/server/http/same-origin";
 import type { RequestHandler } from "./$types";
 
 export const POST: RequestHandler = async ({ request, platform, url }) => {
+  // Checkout creates orders and initiates charges — the highest-value
+  // state change in the app, and it had no provenance check at all
+  // while the lower-stakes cart routes did.
+  const originGuard = requireSameOrigin(request, url);
+  if (originGuard) return originGuard;
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 

--- a/src/routes/api/shop/checkout/start/+server.ts
+++ b/src/routes/api/shop/checkout/start/+server.ts
@@ -15,6 +15,7 @@ import { OrderService } from "$plugins/shop/order-service";
 import { ensureCartSession } from "$plugins/shop/cart-cookie";
 import { ShopValidationError } from "$plugins/shop/service";
 import { track, buildEventContext } from "$lib/server/analytics/track";
+import { requireSameOrigin } from "$lib/server/http/same-origin";
 import type { RequestHandler } from "./$types";
 
 export const POST: RequestHandler = async ({
@@ -24,6 +25,11 @@ export const POST: RequestHandler = async ({
   locals,
   url,
 }) => {
+  // Checkout creates orders and initiates charges — the highest-value
+  // state change in the app, and it had no provenance check at all
+  // while the lower-stakes cart routes did.
+  const originGuard = requireSameOrigin(request, url);
+  if (originGuard) return originGuard;
   const env = platform?.env;
   if (!env) throw error(503, "Platform not ready");
 


### PR DESCRIPTION
Post-merge hunt before tagging. Four defects — **two of them in code I wrote last session**.

## 1. A missing `Origin` header PASSED the same-origin guard

```ts
if (!origin) return null; // same-origin fetch usually omits it
```

That reasoning is a decade out of date. Per the Fetch spec browsers send `Origin` on **every** POST, same-origin included, since ~2020. An absent header therefore means a non-browser client — and a guard whose entire job is establishing provenance was waving those straight through.

Verified live before fixing:

```
POST /api/shop/cart, no Origin  →  reached variant lookup (guard never fired)
POST /api/shop/cart, evil origin → 403 (guard works when the header exists)
```

**The real defect is that `cart/discount` already rejected this case.** Two copies of the same security check had silently diverged. Copies drift; one implementation can't.

Not an exploitable CSRF — `SameSite=Lax` on the cart cookie is the primary control and it holds. This is the belt-and-braces layer behind it, and it had a hole.

## 2. Checkout had no provenance check at all

| Endpoint | Before | Protection |
|---|---|---|
| `cart` | guarded (with the hole) | — |
| `cart/discount` | guarded | — |
| **`checkout/start`** | **none** | creates orders |
| **`checkout/pay`** | **none** | creates **charges** |
| `cron/sweep` | none | ✅ `CRON_SECRET` |
| `webhook/beam` | none | ✅ HMAC |

Inverted priority: the two highest-value state changes were the unguarded ones. `cron/sweep` and `webhook/beam` are correctly protected by their own mechanisms — no change needed there.

Extracted the guard to `$lib/server/http/same-origin` and applied it to all four. It now prefers **`sec-fetch-site`**, which the browser sets and page script cannot forge, falling back to `Origin`.

Note `checkout/pay` takes an `orderId` in the body and no cookie, so it was never cookie-CSRF-able. It has no ownership check either, but IDs are `nanoid()` (~126 bits), so this is defence-in-depth rather than an open door. Flagging rather than overstating.

## 3. `listCollectionsForAdmin` exceeded D1's bind limit — my bug

`listCollections()` has no `LIMIT`, and I fed every id straight into `inArray`. **D1 binds at most 100 parameters per statement**, so the collections page breaks silently at 101 collections.

The content query engine already documents this exact limit and solves it with `MAX_BIND_PARAMS`/`loadChunked`. I ignored the established pattern. Now chunked, with arithmetic verified at the 99/100/101 boundaries.

## 4. O(n×m) title lookup — my bug

`titleFor()` filtered the full localizations array once per row. Fine at 5 collections, not at 500. Indexed into a `Map` once.

## Gate

`pnpm test` **149 passed** (was 138) · `lint` 0 · `check` 0 errors · `build` ok

The origin guard's two behaviours are mutation-verified: restoring `if (!origin) return null` and removing `sec-fetch-site` handling each fail their guard.

## Also closed

Fork-filed #133 (CSP) and #134 (TDZ) — both already fixed in #128/#129. Closed with the mechanism, the fix, and the ordering caveat that fixing CSP first *exposes* the TDZ crash.