### PR TITLE
chore: v3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "khaopad",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "Khao Pad (ข้าวผัด) — Modular CMS for Cloudflare",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for the v3.9.0 release.

**Minor, not patch** — two reasons:

- Collections admin and add-to-cart are new user-facing features (#131)
- The same-origin guard now **rejects** requests it previously allowed. Any non-browser client posting to `/api/shop/cart` or the checkout endpoints without an `Origin` header will start getting 403s (#135). That is intended, but it is a behavioural change.