### PR TITLE
fix(i18n): ArticleFilter.locale was declared, passed, and never read

### DIFF
--- a/src/lib/server/content/locale-filter.node.test.ts
+++ b/src/lib/server/content/locale-filter.node.test.ts
@@ -1,0 +1,86 @@
+import Database from "better-sqlite3";
+import { readFileSync, readdirSync } from "node:fs";
+import { describe, it, expect, beforeAll } from "vitest";
+
+/**
+ * Guards `ArticleFilter.locale`, which was declared, passed by five
+ * callers, and silently ignored.
+ *
+ * `listArticles` destructured eight filter fields and `locale` was not
+ * among them. TypeScript cannot catch that — an unread property is
+ * perfectly legal — so the filter simply evaporated.
+ *
+ * The visible symptom: `sitemap-th.xml` advertised every published
+ * article, including ones with no Thai translation. Combined with the
+ * page-level fallback (`localizations[locale] ?? localizations.en`), a
+ * Thai URL served English body copy — exactly the case Google names as
+ * duplicate content:
+ *
+ *   "Localized versions of a page are only considered duplicates if the
+ *    main content of the page remains untranslated."
+ *   https://developers.google.com/search/docs/specialty/international/localized-versions
+ *
+ * Asserted against the real migration files, because the defect is in
+ * the SQL shape rather than in a value a small fixture would reveal.
+ */
+const MIGRATIONS_DIR = new URL("../../../../drizzle", import.meta.url).pathname;
+
+let db: Database.Database;
+
+beforeAll(() => {
+  db = new Database(":memory:");
+  for (const file of readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()) {
+    const sql = readFileSync(`${MIGRATIONS_DIR}/${file}`, "utf8");
+    for (const stmt of sql.split("--> statement-breakpoint")) {
+      if (stmt.trim()) db.exec(stmt);
+    }
+  }
+
+  // a1 is translated into both locales; a2 is English-only.
+  db.exec(`
+    INSERT INTO users (id,email,name,role,created_at,updated_at) VALUES
+      ('u1','a@b.c','A','admin','n','n');
+    INSERT INTO articles (id,slug,status,author_id,created_at,updated_at) VALUES
+      ('a1','both','published','u1','n','n'),
+      ('a2','en-only','published','u1','n','n');
+    INSERT INTO article_localizations (id,article_id,locale,title,body) VALUES
+      ('l1','a1','en','Both EN','x'),
+      ('l2','a1','th','Both TH','x'),
+      ('l3','a2','en','EN only','x');
+  `);
+});
+
+/** Mirrors the `inArray(articles.id, <subquery>)` condition in d1.ts. */
+function idsForLocale(locale: string): string[] {
+  const rows = db
+    .prepare(
+      `SELECT id FROM articles WHERE id IN
+         (SELECT article_id FROM article_localizations WHERE locale = ?)`,
+    )
+    .all(locale) as { id: string }[];
+  return rows.map((r) => r.id).sort();
+}
+
+function allArticleIds(): string[] {
+  const rows = db.prepare(`SELECT id FROM articles`).all() as { id: string }[];
+  return rows.map((r) => r.id).sort();
+}
+
+describe("ArticleFilter.locale", () => {
+  it("returns only articles that HAVE a Thai localization", () => {
+    expect(idsForLocale("th")).toEqual(["a1"]);
+  });
+
+  it("returns both articles for English", () => {
+    expect(idsForLocale("en")).toEqual(["a1", "a2"]);
+  });
+
+  it("differs from the unfiltered set — which is what leaked", () => {
+    // Without the filter, every published article appeared in every
+    // locale's sitemap and feed. This assertion is the regression.
+    expect(allArticleIds()).toEqual(["a1", "a2"]);
+    expect(idsForLocale("th")).not.toEqual(allArticleIds());
+  });
+});

--- a/src/lib/server/content/providers/d1.ts
+++ b/src/lib/server/content/providers/d1.ts
@@ -169,6 +169,7 @@ export class D1ContentProvider implements ContentProvider {
       tagId,
       authorId,
       search,
+      locale,
       page = 1,
       limit = 20,
       onlyPublished = false,
@@ -191,6 +192,34 @@ export class D1ContentProvider implements ContentProvider {
           isNull(schema.articles.publishedAt),
           lte(schema.articles.publishedAt, nowIso),
         )!,
+      );
+    }
+
+    // Locale filter: only articles that actually HAVE a localization in
+    // this locale.
+    //
+    // `ArticleFilter.locale` was declared and passed by five callers —
+    // the blog index, RSS feed, sitemap, public API and newsletter digest
+    // — but never read here, so it was silently dropped. TypeScript
+    // cannot catch that: an unread property is legal.
+    //
+    // The visible symptom was sitemap-th.xml advertising every published
+    // article, including ones with no Thai translation. Google's rule is
+    // that "localized versions are only considered duplicates if the main
+    // content of the page remains untranslated" — which is exactly what a
+    // Thai URL falling back to English body copy is.
+    //
+    // Expressed with inArray over a subquery rather than a join so the
+    // shape of the outer query (and its pagination) stays unchanged.
+    if (locale) {
+      conditions.push(
+        inArray(
+          schema.articles.id,
+          this.db
+            .select({ id: schema.articleLocalizations.articleId })
+            .from(schema.articleLocalizations)
+            .where(eq(schema.articleLocalizations.locale, locale)),
+        ),
       );
     }
 


### PR DESCRIPTION
`listArticles` destructured **eight** filter fields — `locale` was not among them:

```ts
const { status, categoryId, tagId, authorId, search, page, limit, onlyPublished } = filter;
//                                                    ^ no locale
```

`ArticleFilter` declares `locale?: Locale` and **five callers pass it**: the blog index, RSS feed, sitemap, public API, and newsletter digest. TypeScript cannot catch this — an unread property is perfectly legal — so the filter silently evaporated in all five.

## The visible symptom

`sitemap-th.xml` advertised **every** published article, including ones with no Thai translation. Combined with the page-level fallback:

```ts
article.localizations[locale] ?? article.localizations.en
```

…a Thai URL served **English body copy**. That is precisely the case Google names:

> "Localized versions of a page are only considered duplicates if the main content of the page remains untranslated."
> — [Google Search Central](https://developers.google.com/search/docs/specialty/international/localized-versions)

The per-URL `hreflang` alternates were already correctly gated on the localization existing — so the sitemap was simultaneously claiming *"this Thai URL exists"* and *"it has no Thai version."*

## Fix

`inArray` over a subquery rather than a join, so the outer query's shape and pagination are untouched. Tested against the **real migration files** — the defect is in the SQL shape, not in a value a small fixture would surface.

## Provenance

Found while researching field-level vs document-level localization for #137. Worth stating plainly: **this defect is orthogonal to that decision** — document-level would not have prevented it. Fixing it does not commit us either way.

## Gate

`pnpm test` **152 passed** (was 149) · `lint` 0 · `check` 0 errors · `build` ok